### PR TITLE
Fix circular import

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -25,11 +25,10 @@ DEALINGS IN THE SOFTWARE.
 import asyncio
 import inspect
 
-from .ext.commands._types import _BaseCommand
 from .client import *
 
 
-class ApplicationCommand(_BaseCommand):
+class ApplicationCommand:
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
 


### PR DESCRIPTION
## Summary

This PR fixes a circular import issue that came from importing `_BaseCommand` from the `_types.py` file.

For reference, this is what used to happen:
```python-repl
Python 3.9.6 (default, Aug 23 2021, 19:43:03) 
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import discord.bot
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/esmecat/pycord/discord/__init__.py", line 62, in <module>
    from .bot import *
  File "/home/esmecat/pycord/discord/bot.py", line 28, in <module>
    from .ext.commands._types import _BaseCommand
  File "/home/esmecat/pycord/discord/ext/commands/__init__.py", line 11, in <module>
    from .bot import *
  File "/home/esmecat/pycord/discord/ext/commands/bot.py", line 1036, in <module>
    class Bot(BotBase, discord.Bot):
AttributeError: partially initialized module 'discord' has no attribute 'Bot' (most likely due to a circular import)
```

I am not sure why this import was here in the first place (so I could be wrong in removing it) so please point this out to me if I am incorrect.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
