### PR TITLE
Set the default timeout to `None`

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -152,7 +152,7 @@ class View:
 
         cls.__view_children_items__ = children
 
-    def __init__(self, *, timeout: Optional[float] = 180.0):
+    def __init__(self, *, timeout: Optional[float] = None):
         self.timeout = timeout
         self.children: List[Item] = []
         for func in self.__view_children_items__:


### PR DESCRIPTION
This pull request just sets the default timeout in discord.ui.View to None.

 - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
