### PR TITLE
Implement options

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -42,7 +42,7 @@ class Option:
         User: 6,
         abc.GuildChannel: 7,
         Role: 8,
-        Union[Role, User]: 9
+        Union[Role, User]: 9,
         float: 10
     }
 


### PR DESCRIPTION
## Summary

This PR implements providing Options for slash commands, at the moment, registering a slash command like so:
```py
@bot.slash()
async def command(a, b: int, c: str):
     ''' description '''
``` 
will result in the following when calling `command.to_dict()`:
```json 
{
    "name": "command",
    "description": "description",
    "options": [
        {
            "type": 4,
            "name": "b",
            "description": "b",
            "required": true
        },
        {
            "type": 3,
            "name": "c",
            "description": "c",
            "required": true
        }
    ]
}
```

You can also typehint to `bool`, `discord.User`, `abc.GuildChannel`, `discord.Role`, `typing.Union[discord.Role, discord.User]` and `float` which represent the option types 5, 6, 7, 8, 9 and 10 respectively.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
