### PR TITLE
fix: call bulk_upsert_guild_commands only if there are commands to up…

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -81,7 +81,7 @@ class ApplicationCommandMixin:
         registered_commands = await self.http.get_global_commands(self.user.id)
         for command in [cmd for cmd in self.to_register if cmd.guild_ids is None]:
             as_dict = command.to_dict()
-            if not len(registered_commands) == 0:
+            if len(registered_commands) > 0:
                 matches = [x for x in registered_commands if x["name"] == command.name and x['type'] == command.type]
                 # TODO: rewrite this, it seems inefficient
                 if len(matches) > 0:
@@ -98,10 +98,11 @@ class ApplicationCommandMixin:
                 update_guild_commands[guild_id] = to_update + [as_dict]
 
         for guild_id in update_guild_commands:
-            cmds = await self.http.bulk_upsert_guild_commands(self.user.id, guild_id, update_guild_commands[guild_id])
-            for i in cmds:
-                cmd = get(self.to_register, name=i["name"], description=i["description"], type=i['type'])
-                self.app_commands[i["id"]] = cmd
+            if update_guild_commands[guild_id]:
+                cmds = await self.http.bulk_upsert_guild_commands(self.user.id, guild_id, update_guild_commands[guild_id])
+                for i in cmds:
+                    cmd = get(self.to_register, name=i["name"], description=i["description"], type=i['type'])
+                    self.app_commands[i["id"]] = cmd
 
         cmds = await self.http.bulk_upsert_global_commands(self.user.id, commands)
 


### PR DESCRIPTION

## Summary

Fixes issue with pycord trying to register commands for all guilds the bot is in

## Checklist


- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
