### PR TITLE
Ignore non dispatchable items when refreshing a view

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -394,12 +394,15 @@ class View:
             if item.is_dispatchable()
         }
         # fmt: on
-        children: List[Item] = []
+        children: List[Item] = [item for item in self.children if not item.is_dispatchable()]
         for component in _walk_all_components(components):
             try:
                 older = old_state[(component.type.value, component.custom_id)]  # type: ignore
             except (KeyError, AttributeError):
-                children.append(_component_to_item(component))
+                item = _component_to_item(component)
+                if not item.is_dispatchable():
+                    continue
+                children.append(component)
             else:
                 older.refresh_component(component)
                 children.append(older)


### PR DESCRIPTION
## Summary

The pull request fixes #41 by ignoring non-dispatchable items when refreshing a view.

## Context

When `view.refresh()` is called it can't find the component in https://github.com/Dorukyum/pycord/blob/master/discord/ui/view.py#L400
This causes the re-creation of that item with no row assigned. This causes the item to get moved in row 0.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
