### PR TITLE
Include bot in interaction context

### DIFF
--- a/discord/app/context.py
+++ b/discord/app/context.py
@@ -22,6 +22,11 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import discord
+
 from ..interactions import Interaction
 from ..utils import cached_property
 
@@ -35,7 +40,8 @@ class InteractionContext:
     .. versionadded:: 2.0
     """
 
-    def __init__(self, interaction: Interaction):
+    def __init__(self, bot: "discord.Bot", interaction: Interaction):
+        self.bot = bot
         self.interaction = interaction
 
     @cached_property

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -38,6 +38,7 @@ from .app import (
     MessageCommand,
     UserCommand,
     ApplicationCommand,
+    InteractionContext,
 )
 from .errors import Forbidden
 from .interactions import Interaction
@@ -245,7 +246,8 @@ class ApplicationCommandMixin:
         except KeyError:
             self.dispatch("unknown_command", interaction)
         else:
-            await command.invoke(interaction)
+            context = await self.get_application_context(interaction)
+            await command.invoke(context)
 
     def slash_command(self, **kwargs) -> SlashCommand:
         """A shortcut decorator that invokes :func:`.ApplicationCommandMixin.command` and adds it to
@@ -335,6 +337,30 @@ class ApplicationCommandMixin:
         group = SubCommandGroup(name, description, guild_ids)
         self.add_application_command(group)
         return group
+
+    async def get_application_context(
+        self, interaction: Interaction, cls=None
+    ) -> InteractionContext:
+        r"""|coro|
+
+        Returns the invocation context from the interaction.
+
+        This is a more low-level counter-part for :meth:`.handle_interaction`
+        to allow users more fine grained control over the processing.
+
+        Parameters
+        -----------
+        interaction: :class:`discord.Interaction`
+            The interaction to get the invocation context from.
+
+        Returns
+        --------
+        :class:`.InteractionContext`
+            The invocation context.
+        """
+        if cls == None:
+            cls = InteractionContext
+        return cls(self, interaction)
 
 
 class BotBase(ApplicationCommandMixin):  # To Insert: CogMixin


### PR DESCRIPTION
## Summary

Currently incoming application commands have no direct reference to the
bot instance. This change includes the bot instance in our interaction
context, much like how we do it in the commands extension.

Having a reference to the bot is pretty handy, and fits well with the
existing design of the library.

A reference to the bot will also allow us to more easily reference a
potential before_invoke or after_invoke hook from within
discord.app.commands.

Finally, by exposing a public get_context method, we open up the ability
to define a custom context, a feature currently supported by the
commands extension.

## Caveats

I have not tested this with user or message commands (not entirely sure how to setup). I can revisit this area once I get a better idea if this is a direction we'd like to pursue.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
