### PR TITLE
Add official Discord Developers server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,4 +110,5 @@ Links
 
 - `Documentation <https://pycord.readthedocs.io/en/latest/index.html>`_
 - `Official Discord Server <https://discord.gg/dK2qkEJ37N>`_
+- `Discord Developers <https://discord.gg/discord-developers>`_
 - `Discord API <https://discord.gg/discord-api>`_


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull requests adds the official Discord Developers server to the links section on the readme. I thought it should go there since the Discord API server isn't an official server and if you have questions about the Discord API you should probably ask in Discord Developers.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
