### PR TITLE
add ctx.voice_client and ctx.typing shortcuts for InteractionContext

### DIFF
--- a/discord/app/context.py
+++ b/discord/app/context.py
@@ -33,6 +33,7 @@ from ..member import Member
 from ..message import Message
 from ..user import User
 from ..utils import cached_property
+from ..context_managers import Typing
 
 
 class InteractionContext:
@@ -81,6 +82,13 @@ class InteractionContext:
     @cached_property
     def user(self) -> Optional[Union[Member, User]]:
         return self.interaction.user
+
+    @property
+    def voice_client(self):
+        return self.guild.voice_client
+
+    def typing(self):
+        return Typing(self.channel)
 
     @cached_property
     def response(self) -> InteractionResponse:


### PR DESCRIPTION
## Summary

This PR adds a voice_client property and typing method to discord.app.context.InteractionContext. The voice_client property is a shortcut to `self.interaction.guild.voice_client` and the typing method is a shortcut for `discord.context_managers.Typing(self.interaction.channel)`. 

This mimics `discord.ext.commands.Context`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
