### PR TITLE
Fix Components getting added to children instead of Items

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -402,7 +402,7 @@ class View:
                 item = _component_to_item(component)
                 if not item.is_dispatchable():
                     continue
-                children.append(component)
+                children.append(item)
             else:
                 older.refresh_component(component)
                 children.append(older)


### PR DESCRIPTION
## Summary

With #50 a new issue got introduced. A small typo that no one noticed had crept in with Components, instead of Items in View.children were inserted.
This also fixes #117 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
