### PR TITLE
[Commands] Remove redundant type declaration of input_type in Options() class

### DIFF
--- a/discord/app/commands.py
+++ b/discord/app/commands.py
@@ -169,7 +169,7 @@ class SlashCommand(ApplicationCommand):
 
 class Option:
     def __init__(
-        self, input_type: SlashCommandOptionType, /, description: str, **kwargs
+        self, input_type, /, description: str, **kwargs
     ) -> None:
         self.name: Optional[str] = kwargs.pop("name", None)
         self.description = description


### PR DESCRIPTION
## Summary

This pull request fixes issue #120 . The class Option() has input_type's type declared as SlashCommandOptionType. This creates an issue when trying to use built in types such as 'str' when using the Option in a command, saying it's an unexpected type. This pull request removes the type declaration from input_type argument. This doesn't affect the functionality of the class as the init method checks if input_type is an instance of SlashCommandOptionType, and if it's not, it sets it to be one.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
