### PR TITLE
Add Color.nitro_pink branding color

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -325,5 +325,13 @@ class Colour:
         """
         return cls(0xFEE75C)
 
+    @classmethod
+    def nitro_pink(cls, Type: [CT]) -> CT:
+        """A factory method that returns a :class:`Color` with a value of ``0xf47fff`.
+
+        .. versionadded:: 2.0
+        """
+        return cls(0xf47fff)
+
 
 Color = Colour


### PR DESCRIPTION
## Summary

One of the branding color that is missing in Color class is nitro pink. This PR adds it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
