### PR TITLE
Add Raw thread delete event

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Set, List
 
+from .enums import ChannelType, try_enum
+
 if TYPE_CHECKING:
     from .types.raw_models import (
         MessageDeleteEvent,
@@ -293,7 +295,7 @@ class RawThreadDeleteEvent(_RawReprMixin):
         The ID of the guild the deleted thread belonged to.
     parent_id: :class:`int`
         The ID of the channel the thread belonged to.
-    thread: :class:`Optional[discord.Thread]`
+    thread: Optional[:class:`discord.Thread`]
         The thread that was deleted. This may be ``None`` if deleted thread is not found in internal cache.
     """
     # TODO: Typehint data as RawThreadDeleteEvent when added to types.raw_models
@@ -302,6 +304,6 @@ class RawThreadDeleteEvent(_RawReprMixin):
         self.thread_type: ChannelType = try_enum(ChannelType, data.get('type'))
         self.guild_id: int = data.get('guild_id')
         self.parent_id: int = data.get('parent_id')
-        self.thread: Thread = None
+        self.thread: Optional[Thread] = None
 
    

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -36,7 +36,8 @@ if TYPE_CHECKING:
         MessageUpdateEvent,
         ReactionClearEvent,
         ReactionClearEmojiEvent,
-        IntegrationDeleteEvent
+        IntegrationDeleteEvent,
+        ThreadDeleteEvent,
     )
     from .message import Message
     from .partial_emoji import PartialEmoji
@@ -51,6 +52,7 @@ __all__ = (
     'RawReactionClearEvent',
     'RawReactionClearEmojiEvent',
     'RawIntegrationDeleteEvent',
+    'RawThreadDeleteEvent',
 )
 
 
@@ -298,12 +300,12 @@ class RawThreadDeleteEvent(_RawReprMixin):
     thread: Optional[:class:`discord.Thread`]
         The thread that was deleted. This may be ``None`` if deleted thread is not found in internal cache.
     """
-    # TODO: Typehint data as RawThreadDeleteEvent when added to types.raw_models
-    def __init__(self, data) -> None:
-        self.thread_id: int = data.get('id')
-        self.thread_type: ChannelType = try_enum(ChannelType, data.get('type'))
-        self.guild_id: int = data.get('guild_id')
-        self.parent_id: int = data.get('parent_id')
+    
+    def __init__(self, data: ThreadDeleteEvent) -> None:
+        self.thread_id: int = data['id']
+        self.thread_type: ChannelType = try_enum(ChannelType, data['type'])
+        self.guild_id: int = data['guild_id']
+        self.parent_id: int = data['parent_id']
         self.thread: Optional[Thread] = None
 
    

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -300,12 +300,13 @@ class RawThreadDeleteEvent(_RawReprMixin):
     thread: Optional[:class:`discord.Thread`]
         The thread that was deleted. This may be ``None`` if deleted thread is not found in internal cache.
     """
-    
+    __slots__ = ('thread_id', 'thread_type', 'guild_id', 'parent_id', 'thread')
+
     def __init__(self, data: ThreadDeleteEvent) -> None:
-        self.thread_id: int = data['id']
-        self.thread_type: ChannelType = try_enum(ChannelType, data['type'])
-        self.guild_id: int = data['guild_id']
-        self.parent_id: int = data['parent_id']
+        self.thread_id: int = int(data['id'])
+        self.thread_type: ChannelType = try_enum(ChannelType, int(data['type']))
+        self.guild_id: int = int(data['guild_id'])
+        self.parent_id: int = int(data['parent_id'])
         self.thread: Optional[Thread] = None
 
    

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -276,3 +276,32 @@ class RawIntegrationDeleteEvent(_RawReprMixin):
             self.application_id: Optional[int] = int(data['application_id'])
         except KeyError:
             self.application_id: Optional[int] = None
+
+class RawThreadDeleteEvent(_RawReprMixin):
+    """Represents the payload for :func:`on_raw_thread_delete` event.
+
+    .. versionadded:: 2.0
+    
+    Attributes
+    ----------
+
+    thread_id: :class:`int`
+        The ID of the thread that was deleted.
+    thread_type: :class:`discord.ChannelType`
+        The channel type of the deleted thread.
+    guild_id: :class:`int`
+        The ID of the guild the deleted thread belonged to.
+    parent_id: :class:`int`
+        The ID of the channel the thread belonged to.
+    thread: :class:`Optional[discord.Thread]`
+        The thread that was deleted. This may be ``None`` if deleted thread is not found in internal cache.
+    """
+    # TODO: Typehint data as RawThreadDeleteEvent when added to types.raw_models
+    def __init__(self, data) -> None:
+        self.thread_id: int = data.get('id')
+        self.thread_type: ChannelType = try_enum(ChannelType, data.get('type'))
+        self.guild_id: int = data.get('guild_id')
+        self.parent_id: int = data.get('parent_id')
+        self.thread: Thread = None
+
+   

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
     from .message import Message
     from .partial_emoji import PartialEmoji
     from .member import Member
+    from .threads import Thread
+
 
 
 __all__ = (

--- a/discord/state.py
+++ b/discord/state.py
@@ -850,12 +850,18 @@ class ConnectionState:
     def parse_thread_delete(self, data) -> None:
         guild_id = int(data['guild_id'])
         guild = self._get_guild(guild_id)
+
         if guild is None:
             _log.debug('THREAD_DELETE referencing an unknown guild ID: %s. Discarding', guild_id)
             return
 
-        thread_id = int(data['id'])
-        thread = guild.get_thread(thread_id)
+        raw = RawThreadDeleteEvent(data)
+        thread = guild.get_thread(raw.thread_id)
+        raw.thread = thread
+
+        self.dispatch('raw_thread_delete', raw)
+
+
         if thread is not None:
             guild._remove_thread(thread)  # type: ignore
             self.dispatch('thread_delete', thread)

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -85,3 +85,10 @@ class _IntegrationDeleteEventOptional(TypedDict, total=False):
 class IntegrationDeleteEvent(_IntegrationDeleteEventOptional):
     id: Snowflake
     guild_id: Snowflake
+
+class ThreadDeleteEvent(TypedDict, total=False):
+    thread_id: Snowflake
+    thread_type: int
+    guild_id: Snowflake
+    parent_id: Snowflake
+

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -760,7 +760,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_thread_delete(thread)
 
     Called whenever a thread is deleted.  If the deleted thread isn't found in internal cache 
-    then this will not be called. Consider using :func:`on_raw_thread_delete`
+    then this will not be called. Archived threads are not in the cache. Consider using :func:`on_raw_thread_delete`
 
 
     Note that you can get the guild from :attr:`Thread.guild`.
@@ -3951,6 +3951,14 @@ RawIntegrationDeleteEvent
 .. attributetable:: RawIntegrationDeleteEvent
 
 .. autoclass:: RawIntegrationDeleteEvent()
+    :members:
+
+RawThreadDeleteEvent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: RawThreadDeleteEvent
+
+.. autoclass:: RawThreadDeleteEvent()
     :members:
 
 PartialWebhookGuild

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -759,7 +759,9 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_thread_delete(thread)
 
-    Called whenever a thread is deleted.
+    Called whenever a thread is deleted.  If the deleted thread isn't found in internal cache 
+    then this will not be called. Consider using :func:`on_raw_thread_delete`
+
 
     Note that you can get the guild from :attr:`Thread.guild`.
 
@@ -769,6 +771,14 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     :param thread: The thread that got deleted.
     :type thread: :class:`Thread`
+
+.. function:: on_raw_thread_delete(payload)
+    
+    Called whenever a thread is deleted. Unlike :func:`on_thread_delete` this is called
+    regardless of the state of the internal cache.
+
+    :param payload: The raw event payload data.
+    :type payload: :class:`RawThreadDeleteEvent`
 
 .. function:: on_thread_member_join(member)
               on_thread_member_remove(member)


### PR DESCRIPTION
## Summary

This PR implements the raw thread delete event. The reason for this is because the archived threads aren't in the cache so `on_thread_delete` event is not dispatched when an archived thread is deleted.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
