### PR TITLE
Remove type hinting of slash_command, user_command, message_command

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -247,7 +247,7 @@ class ApplicationCommandMixin:
             context = await self.get_application_context(interaction)
             await command.invoke(context)
 
-    def slash_command(self, **kwargs) -> SlashCommand:
+    def slash_command(self, **kwargs):
         """A shortcut decorator that invokes :func:`.ApplicationCommandMixin.command` and adds it to
         the internal command list via :meth:`~.ApplicationCommandMixin.add_application_command`.
         This shortcut is made specifically for :class:`.SlashCommand`.
@@ -262,7 +262,7 @@ class ApplicationCommandMixin:
         """
         return self.application_command(cls=SlashCommand, **kwargs)
 
-    def user_command(self, **kwargs) -> UserCommand:
+    def user_command(self, **kwargs):
         """A shortcut decorator that invokes :func:`.ApplicationCommandMixin.command` and adds it to
         the internal command list via :meth:`~.ApplicationCommandMixin.add_application_command`.
         This shortcut is made specifically for :class:`.UserCommand`.
@@ -277,7 +277,7 @@ class ApplicationCommandMixin:
         """
         return self.application_command(cls=UserCommand, **kwargs)
 
-    def message_command(self, **kwargs) -> MessageCommand:
+    def message_command(self, **kwargs):
         """A shortcut decorator that invokes :func:`.ApplicationCommandMixin.command` and adds it to
         the internal command list via :meth:`~.ApplicationCommandMixin.add_application_command`.
         This shortcut is made specifically for :class:`.MessageCommand`.


### PR DESCRIPTION
## Summary

This pull request fixes the issue mentioned in #91, specifically slash_command, user_command, message_command decorators caused a "'SlashCommand' object is not callable " warning to appear when being used. This warning is caused due to the return type hinting of the slash_command, user_command and message_command decorators. This pull request removes those return type hinting of the mentioned decorators, fixing issue #91 . 

The return type hinting of the mentioned decorators was also redundant, as the docstring attached to them provide an explanation of the return value already.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
