### PR TITLE
Allow option decor to infer type from the typehint

### DIFF
--- a/discord/app/commands.py
+++ b/discord/app/commands.py
@@ -501,9 +501,11 @@ class OptionChoice:
     def to_dict(self) -> Dict[str, Union[str, int, float]]:
         return {"name": self.name, "value": self.value}
 
-def option(name, type, **kwargs):
+def option(name, type=None, **kwargs):
     """A decorator that can be used instead of typehinting Option"""
     def decor(func):
+        nonlocal type
+        type = type or func.__annotations__.get(name, str)
         func.__annotations__[name] = Option(type, **kwargs)
         return func
     return decor


### PR DESCRIPTION
## Summary

This allows the option decorator to infer the type from the typehint.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
