### PR TITLE
Add reason support in welcome screen edits.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3038,6 +3038,6 @@ class Guild(Hashable):
         options['welcome_channels'] = welcome_channels_data
 
         if options:
-            new = await self._state.http.edit_welcome_screen(self.id, options)
+            new = await self._state.http.edit_welcome_screen(self.id, options, reason=options.get('reason'))
             return WelcomeScreen(data=new, guild=self)
         

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3008,7 +3008,9 @@ class Guild(Hashable):
             The welcome channels. The order of the channels would be same as the passed list order.
         enabled: Optional[:class:`bool`]
             Whether the welcome screen should be displayed.
-        
+        reason: Optional[:class:`str`]
+            The reason that shows up on audit log.
+
         Raises
         -------
         

--- a/discord/http.py
+++ b/discord/http.py
@@ -1496,7 +1496,7 @@ class HTTPClient:
     def get_welcome_screen(self, guild_id: Snowflake) -> Response[welcome_screen.WelcomeScreen]:
         return self.request(Route('GET', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id))
 
-    def edit_welcome_screen(self, guild_id: Snowflake, payload: Any) -> Response[welcome_screen.WelcomeScreen]:
+    def edit_welcome_screen(self, guild_id: Snowflake, payload: Any, *, reason: Optional[str] = None) -> Response[welcome_screen.WelcomeScreen]:
         keys = (
             'description',
             'welcome_channels',
@@ -1505,7 +1505,7 @@ class HTTPClient:
         payload = {
             key: val for key, val in payload.items() if key in keys
         }
-        return self.request(Route('PATCH', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id), json=payload)
+        return self.request(Route('PATCH', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id), json=payload, reason=reason)
 
     # Voice management
 

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -149,6 +149,7 @@ class WelcomeScreen:
         description: Optional[str] = ...,
         welcome_channels: Optional[List[WelcomeChannel]] = ...,
         enabled: Optional[bool] = ...,
+        reason: Optional[str] = ...,
     ) -> None:
         ...
 
@@ -188,7 +189,9 @@ class WelcomeScreen:
             The welcome channels. The order of the channels would be same as the passed list order.
         enabled: Optional[:class:`bool`]
             Whether the welcome screen should be displayed.
-        
+        reason: Optional[:class:`str`]
+            The reason that shows up on Audit log.
+
         Raises
         -------
         
@@ -213,7 +216,7 @@ class WelcomeScreen:
         options['welcome_channels'] = welcome_channels_data
 
         if options:
-            new = await self._guild._state.http.edit_welcome_screen(self._guild.id, options)
+            new = await self._guild._state.http.edit_welcome_screen(self._guild.id, options, reason=options.get('reason'))
             self._update(new)
         
         return self


### PR DESCRIPTION
## Summary

I unknowingly missed the reason support in the welcome screen PR. This PR adds it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
