### PR TITLE
Add __call__ too all Application Commands

### DIFF
--- a/discord/app/commands.py
+++ b/discord/app/commands.py
@@ -80,6 +80,9 @@ class SlashCommand(ApplicationCommand):
 
         params = OrderedDict(inspect.signature(self.callback).parameters)
         self.options = self.parse_options(params)
+    
+    def __call__(self, ctx, *args, **kwargs):
+        return self.callback(ctx, *args, **kwargs)
 
     def parse_options(self, params: OrderedDict) -> List[Option]:
         final_options = []
@@ -286,6 +289,9 @@ class UserCommand(ApplicationCommand):
 
     def to_dict(self) -> Dict[str, Union[str, int]]:
         return {"name": self.name, "description": self.description, "type": self.type}
+    
+    def __call__(self, ctx, member):
+        return self.callback(ctx, member)
 
     async def invoke(self, ctx: InteractionContext) -> None:
         if "members" not in ctx.interaction.data["resolved"]:
@@ -335,6 +341,9 @@ class MessageCommand(ApplicationCommand):
 
     def to_dict(self):
         return {"name": self.name, "description": self.description, "type": self.type}
+    
+    def __call__(self, ctx, message):
+        return self.callback(ctx, message)
 
     async def invoke(self, ctx: InteractionContext):
         _data = ctx.interaction.data["resolved"]["messages"]


### PR DESCRIPTION
## Summary

This PR makes you able to call any type of Application Command, it functions mostly like [`discord.ext.commands.Command.__call__`](https://discordpy.readthedocs.io/en/master/ext/commands/api.html#discord.ext.commands.Command.__call__) in the fact that it does not respect any cooldowns or converters meaning that the arguments that you give it must be of the correct type. 

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
