### PR TITLE
created delete_after parameter for ctx.respond

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -384,6 +384,7 @@ class InteractionResponse:
         An interaction can only be responded to once.
         """
         return self._responded
+        
 
     async def defer(self, *, ephemeral: bool = False) -> None:
         """|coro|
@@ -460,7 +461,8 @@ class InteractionResponse:
         view: View = MISSING,
         tts: bool = False,
         ephemeral: bool = False,
-        allowed_mentions: AllowedMentions = None
+        allowed_mentions: AllowedMentions = None,
+        delete_after: float = None
     ) -> None:
         """|coro|
 
@@ -487,6 +489,9 @@ class InteractionResponse:
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
+        delete_after: :class:`float`
+            If provided, the number of seconds to wait in the background
+            before deleting the message we just sent.
             
         Raises
         -------
@@ -546,6 +551,10 @@ class InteractionResponse:
             self._parent._state.store_view(view)
 
         self._responded = True
+        if delete_after != None:
+            await asyncio.sleep(delete_after)
+            await self._parent.delete_original_message()
+
 
     async def edit_message(
         self,


### PR DESCRIPTION
## Summary
Created the delete_after parameter for ctx.resopnd
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
