### PR TITLE
Change `ctx.send` to `ctx.respond` in the examples

### DIFF
--- a/examples/app_commands/slash_basic.py
+++ b/examples/app_commands/slash_basic.py
@@ -13,14 +13,14 @@ bot = discord.Bot()
 @bot.slash_command(guild_ids=[...])  # create a slash command for the supplied guilds
 async def hello(ctx):
     """Say hello to the bot"""  # the command description can be supplied as the docstring
-    await ctx.send(f"Hello {ctx.author}!")
+    await ctx.respond(f"Hello {ctx.author}!")
 
 
 @bot.slash_command(
     name="hi"
 )  # Not passing in guild_ids creates a global slash command (might take an hour to register)
 async def global_command(ctx, num: int):  # Takes one integer parameter
-    await ctx.send(f"This is a global command, {num}!")
+    await ctx.respond(f"This is a global command, {num}!")
 
 
 @bot.slash_command(guild_ids=[...])
@@ -28,8 +28,8 @@ async def joined(
     ctx, member: discord.Member = None
 ):  # Passing a default value makes the argument optional
     user = member or ctx.author
-    await ctx.send(f"{user.name} joined at {discord.utils.format_dt(user.joined_at)}")
+    await ctx.respond(f"{user.name} joined at {discord.utils.format_dt(user.joined_at)}")
 
 
-# To learn how to add descriptions, choices to options check slash_options.py
+# To learn how to add descriptions and choices to options, check slash_options.py
 bot.run("TOKEN")

--- a/examples/app_commands/slash_options.py
+++ b/examples/app_commands/slash_options.py
@@ -14,6 +14,6 @@ async def hello(
     gender: Option(str, "Choose your gender", choices=["Male", "Female", "Other"]),
     age: Option(int, "Enter your age", required=False, default=18),
 ):
-    await ctx.send(f"Hello {name}")
+    await ctx.respond(f"Hello {name}")
 
 bot.run('TOKEN')


### PR DESCRIPTION
## Summary

This PR changes `ctx.send` to `ctx.respond` in the examples as this should be used instead.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
