### PR TITLE
Add `can_send` method to Messageable

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1564,7 +1564,7 @@ class Messageable:
                     if obj.guild_id == channel.guild.id:
                         continue
 
-            except KeyError:
+            except (KeyError, AttributeError):
                 raise TypeError(f'The object {obj} is of an invalid type.')
 
             if not getattr(channel.permissions_for(channel.guild.me), permission):

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1531,7 +1531,18 @@ class Messageable:
         return [state.create_message(channel=channel, data=m) for m in data]
     
     def can_send(self, *objects) -> bool:
-        """Returns a :class:`bool` indicating whether you have the permissions to send the object(s)."""
+        """Returns a :class:`bool` indicating whether you have the permissions to send the object(s).
+
+        Raises
+        ------
+        TypeError
+            An invalid type has been passed.
+
+        Returns
+        --------
+        :class:`bool`
+            Indicates whether you have the permissions to send the object(s).
+        """
         mapping = {
             'Message': 'send_messages',
             'Embed': 'embed_links',

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1549,7 +1549,7 @@ class Messageable:
             else:
                 permission = mapping.get(type(obj).__name__) or mapping[obj.__name__]
         except KeyError:
-            raise InvalidArgument('The object is of an invalid type.')
+            raise TypeError('The object is of an invalid type.')
 
         return getattr(channel.permissions_for(channel.guild.me), permission)
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1542,7 +1542,7 @@ class Messageable:
         # Can't use channel = await self._get_channel() since its async
         if hasattr(self, 'permissions_for'):
             channel = self
-        elif hasattr(self, 'channel'):
+        elif not type(self.channel).__name__ in ('DMChannel', 'GroupChannel')
             channel = self.channel
         else:
             return True # Permissions don't exist for User DMs

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1533,7 +1533,7 @@ class Messageable:
     async def can_send(self, obj=None) -> bool:
         """|coro|
         
-        Returns a :class:`bool` indicating whether you the permissions to send the object.
+        Returns a :class:`bool` indicating whether you have the permissions to send the object.
         """
 
         mapping = {

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1529,6 +1529,29 @@ class Messageable:
         state = self._state
         data = await state.http.pins_from(channel.id)
         return [state.create_message(channel=channel, data=m) for m in data]
+    
+    async def can_send(self, obj=None) -> bool:
+        """|coro|
+        
+        Returns a :class:`bool` indicating whether you the permissions to send the object.
+        """
+
+        mapping = {
+            'Message': 'send_messages',
+            'Embed': 'embed_links',
+            'File': 'attach_files'
+        }
+        channel = await self._get_channel()
+
+        try:
+            if obj is None:
+                permission = mapping['Message']
+            else:
+                permission = mapping.get(type(obj).__name__) or mapping[obj.__name__]
+        except KeyError:
+            raise InvalidArgument('The object is of an invalid type.')
+
+        return getattr(channel.permissions_for(channel.guild.me), permission)
 
     def history(
         self,

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1535,7 +1535,9 @@ class Messageable:
         mapping = {
             'Message': 'send_messages',
             'Embed': 'embed_links',
-            'File': 'attach_files'
+            'File': 'attach_files',
+            'Emoji': 'use_external_emojis',
+            'GuildSticker': 'use_external_stickers',
         }
         # Can't use channel = await self._get_channel() since its async
         if hasattr(self, 'permissions_for'):
@@ -1554,8 +1556,16 @@ class Messageable:
                     permission = mapping['Message']
                 else:
                     permission = mapping.get(type(obj).__name__) or mapping[obj.__name__]
+                
+                if type(obj).__name__ == 'Emoji':
+                    if obj._to_partial().is_unicode_emoji or obj.guild_id == channel.guild.id:
+                        continue
+                elif type(obj).__name__ == 'GuildSticker':
+                    if obj.guild_id == channel.guild.id:
+                        continue
+
             except KeyError:
-                raise TypeError('The object is of an invalid type.')
+                raise TypeError(f'The object {obj} is of an invalid type.')
 
             if not getattr(channel.permissions_for(channel.guild.me), permission):
                 return False

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1530,18 +1530,21 @@ class Messageable:
         data = await state.http.pins_from(channel.id)
         return [state.create_message(channel=channel, data=m) for m in data]
     
-    async def can_send(self, obj=None) -> bool:
-        """|coro|
-        
-        Returns a :class:`bool` indicating whether you have the permissions to send the object.
-        """
+    def can_send(self, obj=None) -> bool:
+        """Returns a :class:`bool` indicating whether you have the permissions to send the object."""
 
         mapping = {
             'Message': 'send_messages',
             'Embed': 'embed_links',
             'File': 'attach_files'
         }
-        channel = await self._get_channel()
+        # Can't use channel = await self._get_channel() since its async
+        if hasattr(self, 'permissions_for'):
+            channel = self
+        elif hasattr(self, 'channel'):
+            channel = self.channel
+        else:
+            return True # Permissions don't exist for User DMs
 
         try:
             if obj is None:

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1542,7 +1542,7 @@ class Messageable:
         # Can't use channel = await self._get_channel() since its async
         if hasattr(self, 'permissions_for'):
             channel = self
-        elif not type(self.channel).__name__ in ('DMChannel', 'GroupChannel')
+        elif hasattr(self, 'channel') and not type(self.channel).__name__ in ('DMChannel', 'GroupChannel')
             channel = self.channel
         else:
             return True # Permissions don't exist for User DMs


### PR DESCRIPTION
## Summary

This PR adds a `can_send` method to abc.Messageable

### Usage
```py
embed = discord.Embed(title='Hi')
if ctx.can_send(embed):
  await ctx.send(embed=embed)
else:
  await ctx.send("Can't send embeds :(")
 ```
Works with Message, Embed, File.
P.S. The documentation can be improved I guess.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
