### PR TITLE
Change `ctx.send` to `ctx.respond` in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,11 +77,11 @@ Quick Example
     @bot.slash_command()
     async def hello(ctx, name: str = None):
         name = name or ctx.author.name
-        await ctx.send(f"Hello {name}!")
+        await ctx.respond(f"Hello {name}!")
         
     @bot.user_command(name="Say Hello")
     async def hi(ctx, user):
-        await ctx.send(f"{ctx.author.mention} says hello to {user.name}!")
+        await ctx.respond(f"{ctx.author.mention} says hello to {user.name}!")
         
     bot.run("token")
 


### PR DESCRIPTION
## Summary

This changes `ctx.send` to `ctx.respond` in the README, as this should be used instead of `ctx.send`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
