### PR TITLE
Added START_EMBEDDED_ACTIVITIES permission #198

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -550,6 +550,14 @@ class Permissions(BaseFlags):
         .. versionadded:: 2.0
         """
         return 1 << 38
+   
+    @flag_value
+    def start_embedded_activities(self) -> int:
+        """:class:`bool`: Returns ``True`` if a user can launch an activity flagged 'EMBEDDED' in a voice channel.
+
+        .. versionadded:: 2.0
+        """
+        return 1 << 39
 
 PO = TypeVar('PO', bound='PermissionOverwrite')
 
@@ -664,6 +672,7 @@ class PermissionOverwrite:
         send_messages_in_threads: Optional[bool]
         external_stickers: Optional[bool]
         use_external_stickers: Optional[bool]
+        start_embedded_activities: Optional[bool]
 
     def __init__(self, **kwargs: Optional[bool]):
         self._values: Dict[str, Optional[bool]] = {}


### PR DESCRIPTION
## Summary

Adds the newly added start_embedded_activities permission into pycord as asked in #198

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

Let me know if there's anything else to add!