### PR TITLE
Fix help commands

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -247,7 +247,7 @@ class Cog(metaclass=CogMeta):
 
                 This does not include subcommands.
         """
-        return [c for c in self.__cog_commands__ if c.parent is None]
+        return [c for c in self.__cog_commands__ if hasattr(c,"parent") and c.parent is None]
 
     @property
     def qualified_name(self) -> str:


### PR DESCRIPTION
Context menu commands don't have `parent` attributes, and this breaks help commands. This change fixes that.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes an issue with help commands where they error.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. N/A
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
