### PR TITLE
Change `commands.check` to allow `ApplicationCommand`

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1723,7 +1723,7 @@ def check(predicate: Check) -> Callable[[T], T]:
     """
 
     def decorator(func: Union[Command, CoroFunc]) -> Union[Command, CoroFunc]:
-        if isinstance(func, Command):
+        if isinstance(func, _BaseCommand):
             func.checks.append(predicate)
         else:
             if not hasattr(func, '__commands_checks__'):


### PR DESCRIPTION
## Summary
This PR fixes an issue that wouldn't allow `commands.check` to add the check callback to `ApplicationCommand.checks`.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
