### PR TITLE
Support responding with deferred_channel_message to component interactions.

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -396,18 +396,18 @@ class InteractionResponse:
 
     async def defer(self, *, ephemeral: bool = False) -> None:
         """|coro|
-        
+
         Defers the interaction response.
-        
+
         This is typically used when the interaction is acknowledged
         and a secondary action will be done later.
-        
+
         Parameters
         -----------
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
             If ``True`` for interactions of type :attr:`InteractionType.component`, this will send an ephemeral 'bot is thinking' message in the channel.
-            
+
         Raises
         -------
         HTTPException

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -415,7 +415,7 @@ class InteractionResponse:
             raise discord.InteractionResponded(self._parent)
 
         defer_type: int = 0
-        data = None
+        data: Optional[Dict[str, Any]] = None
         parent = self._parent
         if parent.type is discord.InteractionType.component:
             if ephemeral:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -396,14 +396,18 @@ class InteractionResponse:
 
     async def defer(self, *, ephemeral: bool = False) -> None:
         """|coro|
+        
         Defers the interaction response.
+        
         This is typically used when the interaction is acknowledged
         and a secondary action will be done later.
+        
         Parameters
         -----------
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
             If ``True`` for interactions of type :attr:`InteractionType.component`, this will send an ephemeral 'bot is thinking' message in the channel.
+            
         Raises
         -------
         HTTPException

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -406,7 +406,7 @@ class InteractionResponse:
         -----------
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
-            If ``True`` for interactions of type :attr:`InteractionType.component`, this will send an ephemeral 'bot is thinking' message in the channel.
+            If ``True`` for interactions of type :attr:`InteractionType.component`, this will defer ephemerally.
 
         Raises
         -------

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -412,24 +412,24 @@ class InteractionResponse:
             This interaction has already been responded to before.
         """
         if self._responded:
-            raise discord.InteractionResponded(self._parent)
+            raise InteractionResponded(self._parent)
 
         defer_type: int = 0
         data: Optional[Dict[str, Any]] = None
         parent = self._parent
-        if parent.type is discord.InteractionType.component:
+        if parent.type is InteractionType.component:
             if ephemeral:
                 data = {'flags': 64}
-                defer_type = discord.InteractionResponseType.deferred_channel_message.value
+                defer_type = InteractionResponseType.deferred_channel_message.value
             else:
-                defer_type = discord.InteractionResponseType.deferred_message_update.value
-        elif parent.type is discord.InteractionType.application_command:
-            defer_type = discord.InteractionResponseType.deferred_channel_message.value
+                defer_type = InteractionResponseType.deferred_message_update.value
+        elif parent.type is InteractionResponseType.application_command:
+            defer_type = InteractionResponseType.deferred_channel_message.value
             if ephemeral:
                 data = {'flags': 64}
 
         if defer_type:
-            adapter = discord.webhook.async_.async_context.get()
+            adapter = async_context.get()
             await adapter.create_interaction_response(
                 parent.id, parent.token, session=parent._session, type=defer_type, data=data
             )


### PR DESCRIPTION
## Summary

Allows users to choose between `deferred_channel_message` and `deferred_message_update` when responding to a component interaction.

![image](https://user-images.githubusercontent.com/49261529/138578440-3d06f172-8b74-4d9f-976d-c7268dc8a69d.png)

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
