### PR TITLE
Fixes `discord.Bot.on_application_command_error`

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -569,18 +569,16 @@ class BotBase(ApplicationCommandMixin, CogMixin):
 
         This only fires if you do not specify any listeners for command error.
         """
-        # TODO
-        # if self.extra_events.get('on_application_command_error', None):
-        #     return
+        if self.extra_events.get('on_application_command_error', None):
+            return
 
         command = context.command
         if command and command.has_error_handler():
             return
 
-        # TODO
-        # cog = context.cog
-        # if cog and cog.has_error_handler():
-        #     return
+        cog = context.cog
+        if cog and cog.has_error_handler():
+            return
 
         print(f"Ignoring exception in command {context.command}:", file=sys.stderr)
         traceback.print_exception(

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -22,6 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -30,6 +31,9 @@ import discord.abc
 if TYPE_CHECKING:
     import discord
     from discord.state import ConnectionState
+
+    from .commands import ApplicationCommand
+    from ..cog import Cog
 
 from ..guild import Guild
 from ..interactions import Interaction, InteractionResponse
@@ -63,7 +67,7 @@ class ApplicationContext(discord.abc.Messageable):
     def __init__(self, bot: "discord.Bot", interaction: Interaction):
         self.bot = bot
         self.interaction = interaction
-        self.command = None
+        self.command: ApplicationCommand = None  # type: ignore
         self._state: ConnectionState = self.interaction._state
 
     async def _get_channel(self) -> discord.abc.Messageable:
@@ -130,3 +134,11 @@ class ApplicationContext(discord.abc.Messageable):
     @property
     def edit(self):
         return self.interaction.edit_original_message
+
+    @property
+    def cog(self) -> Optional[Cog]:
+        """Optional[:class:`.Cog`]: Returns the cog associated with this context's command. None if it does not exist."""
+        if self.command is None:
+            return None
+       
+        return self.command.cog


### PR DESCRIPTION
## Summary
Fixes #326 
Fixes #279 

This PR un-comments the commented out section in `discord.Bot.on_application_command_error`. To implement this, `ApplicationContext.cog` was added.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
