### PR TITLE
Raise error in utils.get_or_fetch if a default value is not passed

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -456,10 +456,10 @@ async def get_or_fetch(obj, attr: str, id: int, *, default: Any = MISSING):
         try:
             getter = await getattr(obj, f'fetch_{attr}')(id)
         except HTTPException:
-            if raise_exc:
-                raise
-            else:
+            if default is not MISSING:
                 return default
+            else:
+                raise
     return getter
 
 def _unique(iterable: Iterable[T]) -> List[T]:


### PR DESCRIPTION
## Summary
Adds a raise_exc kwarg to utils.get_or_fetch. If True, it raises instead of returning the default value.
Moved from #338

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
