### PR TITLE
Remove useless if statement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,6 @@ with open('discord/__init__.py') as f:
     else:
         raise RuntimeError("Could not grab version string")
 
-if not version:
-    raise RuntimeError('version is not set')
-
 if version.endswith(('a', 'b', 'rc')):
     # append version identifier based on commit count
     try:


### PR DESCRIPTION
## Summary
I made this pull-request to remove a useless if statements from the `setup.py`

Since these checks are already here
```py
if search is not None:
        version = search.group(1)

    else:
        raise RuntimeError("Could not grab version string")
```

```py
if not version: # This is unnecessary.
  raise RuntimeError("version is not set")
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
