### PR TITLE
Add utils.basic_autocomplete

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1042,7 +1042,7 @@ def basic_autocomplete(values: Union[Iterable[str],
 
     Parameters
     -----------
-    values: Union[Iterable[:class:`str`], Callable[[:class:`Interaction`], Union[Iterable[:class:`str`], Coroutine[Iterable[str]]]], Coroutine[Iterable[str]]]
+    values: Union[Iterable[:class:`str`], Callable[[:class:`Interaction`], Union[Iterable[:class:`str`], Coroutine[Iterable[:class:`str`]]]], Coroutine[Iterable[:class:`str`]]]
         Possible values for the option. Accepts an iterable of :class:`str`, a callable (sync or async) that takes a
         single argument of :class:`Interaction`, or a coroutine. Must resolve to an iterable of :class:`str`.
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1076,6 +1076,6 @@ def basic_autocomplete(values: Union[Iterable[str],
             _values = _values(interaction)
         if asyncio.iscoroutine(_values):
             _values = await _values
-        return [x for x in _values if x.lower().startswith(value.lower())]
+        return ([x for x in _values if x.lower().startswith(value.lower())])[:25]
 
     return autocomplete_callback

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -31,6 +31,7 @@ from typing import (
     Any,
     AsyncIterator,
     Callable,
+    Coroutine,
     Dict,
     ForwardRef,
     Generic,
@@ -128,6 +129,7 @@ if TYPE_CHECKING:
     from .abc import Snowflake
     from .invite import Invite
     from .template import Template
+    from .interactions import Interaction
 
     class _RequestLike(Protocol):
         headers: Mapping[str, Any]
@@ -1029,7 +1031,7 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     return f'<t:{int(dt.timestamp())}:{style}>'
 
 
-def basic_autocomplete(*values):
+def basic_autocomplete(*values: str) -> Callable[[Interaction, str], Coroutine[List[str]]]:
     """A helper function to make a basic autocomplete for slash commands. This is a pretty standard autocomplete and
     will return any options that start with the value from the user, case insensitive.
 
@@ -1038,8 +1040,14 @@ def basic_autocomplete(*values):
     Parameters
     -----------
     values: `str`
-        Possible values for the option."""
-    async def autocomplete_callback(interaction, value):
+        Possible values for the option.
+
+    Returns
+    --------
+    Callable[[:class:`Interaction`, :class:`str`], Coroutine[List[:class:`str`]]]
+        A wrapped callback for the autocomplete.
+    """
+    async def autocomplete_callback(interaction: Interaction, value: str) -> List[str]:
         return [x for x in values if x.lower().startswith(value.lower())]
 
     return autocomplete_callback

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1038,6 +1038,23 @@ def basic_autocomplete(values: Union[Iterable[str],
     will return any options that start with the value from the user, case insensitive. If :param:`values` is callable,
     it will be called with the interaction.
 
+    This is meant to be passed into the :attr:`discord.Option.autocomplete` attribute.
+
+    Example
+    --------
+
+    .. code-block:: python3
+
+        Option(str, "color", autocomplete=basic_autocomplete(("red", "green", "blue")))
+
+        # or
+
+        async def autocomplete(interaction):
+            return ("foo", "bar", "baz", interaction.user.name)
+
+        Option(str, "name", autocomplete=basic_autocomplete(autocomplete))
+
+
     .. versionadded:: 2.0
 
     Parameters

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1027,3 +1027,19 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     if style is None:
         return f'<t:{int(dt.timestamp())}>'
     return f'<t:{int(dt.timestamp())}:{style}>'
+
+
+def basic_autocomplete(*values):
+    """A helper function to make a basic autocomplete for slash commands. This is a pretty standard autocomplete and
+    will return any options that start with the value from the user, case insensitive.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    -----------
+    values: `str`
+        Possible values for the option."""
+    async def autocomplete_callback(interaction, value):
+        return [x for x in values if x.lower().startswith(value.lower())]
+
+    return autocomplete_callback


### PR DESCRIPTION
## Summary
Adds a basic autocomplete function to utils. Usage:
```py
import discord
from discord import option
from discord.utils import basic_autocomplete

bot = discord.Bot()

@bot.slash_command()
@option("color", autocomplete=basic_autocomplete(["red", "orange", "yellow", "green", "blue", "purple", "red-orange"]))
async def test_color(ctx, color):
    await ctx.respond(f"Your choice: {color}")
    
async def autocomplete(interaction):
    return [str(num) for num in range(1, len(interaction.user.display_name))]

@bot.slash_command()
@option("number", autocomplete=basic_autocomplete(autocomplete))
async def test_number(ctx, number):
    await ctx.respond(f"Your choice: {number}")
```
![Screen Shot 2021-10-29 at 11 53 47 AM](https://user-images.githubusercontent.com/71356958/139473734-c9b246f1-fa88-4ec8-87e0-5d30e8d1fd67.png)
![Screen Shot 2021-10-29 at 11 54 01 AM](https://user-images.githubusercontent.com/71356958/139473741-a4d1da86-11a8-481a-b3c6-dcf15ed5754c.png)
![Screen Shot 2021-10-29 at 11 54 15 AM](https://user-images.githubusercontent.com/71356958/139473743-b05bcd0a-c5b7-47cf-b8ac-a100208d90a7.png)




## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
