### PR TITLE
Fix cmd returning None in register_commands due to API change/bug

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -186,6 +186,10 @@ class ApplicationCommandMixin:
         cmds = await self.http.bulk_upsert_global_commands(self.user.id, commands)
 
         for i in cmds:
+            # Discord seems to now return None instead of an empty string...
+            if i["description"] is None:
+                i['description'] = ""
+
             cmd = get(
                 self.pending_application_commands,
                 name=i["name"],
@@ -225,6 +229,10 @@ class ApplicationCommandMixin:
                 raise
             else:
                 for i in cmds:
+                    # Discord seems to now return None instead of an empty string...
+                    if i["description"] is None:
+                        i['description'] = ""
+
                     cmd = get(
                         self.pending_application_commands,
                         name=i["name"],

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -45,7 +45,7 @@ import sys
 
 from .client import Client
 from .shard import AutoShardedClient
-from .utils import MISSING, get, async_all
+from .utils import MISSING, get, find, async_all
 from .commands import (
     SlashCommand,
     SlashCommandGroup,
@@ -186,14 +186,10 @@ class ApplicationCommandMixin:
         cmds = await self.http.bulk_upsert_global_commands(self.user.id, commands)
 
         for i in cmds:
-            # Discord seems to now return None instead of an empty string...
-            if i["description"] is None:
-                i['description'] = ""
-
             cmd = get(
                 self.pending_application_commands,
                 name=i["name"],
-                description=i["description"],
+                guild_ids=None,
                 type=i["type"],
             )
             self.application_commands[i["id"]] = cmd
@@ -229,16 +225,7 @@ class ApplicationCommandMixin:
                 raise
             else:
                 for i in cmds:
-                    # Discord seems to now return None instead of an empty string...
-                    if i["description"] is None:
-                        i['description'] = ""
-
-                    cmd = get(
-                        self.pending_application_commands,
-                        name=i["name"],
-                        description=i["description"],
-                        type=i["type"],
-                    )
+                    cmd = find(lambda cmd: cmd.name == i["name"] and cmd.type == i["type"] and int(i["guild_id"]) in cmd.guild_ids, self.pending_application_commands)
                     self.application_commands[i["id"]] = cmd
 
                     # Permissions


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Discord states that a Context Menu command's description will be returned as an Empty string when fetched here:
https://discord.com/developers/docs/interactions/application-commands#user-commands

But at the moment, they seem to be returning null, and since the commands are registered with an empty string in pycord, "cmd = get" will not find the command and return None, and this causes an error when getting cmd.permissions.

This pull request temporarily fixes it by changing None into an empty string in register_commands before get.
Another way to fix this would be to set ContextMenuCommand's description to None on init.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
