### PR TITLE
Return Interaction object in send_message

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -475,7 +475,7 @@ class InteractionResponse:
         file: File = None,
         files: List[File] = None,
         delete_after: float = None
-    ) -> None:
+    ) -> Interaction:
         """|coro|
 
         Responds to this interaction by sending a message.
@@ -600,7 +600,7 @@ class InteractionResponse:
                 await asyncio.sleep(delete_after)
                 await self._parent.delete_original_message()
             asyncio.ensure_future(delete(), loop=self._parent._state.loop)
-
+        return self._parent
 
     async def edit_message(
         self,


### PR DESCRIPTION
## Summary

Closes #350 

This PR returns the Interaction object when `InteractionResponse.send_message()` is called, which allows users to use `Interaction.edit_original_message` to edit the contents of a message sent with `ctx.respond()`.

Example usage:

```py
    @commands.slash_command(name="say", guild_ids=settings.guild_ids)
    async def say(
        self,
        ctx,
        content: Option(str, "What should the bot say?", required=True)
    ):
        """Makes the bot say the specified content."""
        interaction = await ctx.respond(content)
        await interaction.edit_original_message(content=f"MORE {content}?")
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
      - I'm not sure if this change gets picked up automatically or not
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
