### PR TITLE
Make ext.commands.help filter only prefixed commands.

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -559,7 +559,9 @@ class HelpCommand:
         if sort and key is None:
             key = lambda c: c.name
 
-        iterator = commands if self.show_hidden else filter(lambda c: not c.hidden, commands)
+        # Ignore Application Commands cause they dont have hidden/docs
+        prefix_commands = [command for command in commands if not isinstance(command, discord.commands.ApplicationCommand)]
+        iterator = prefix_commands if self.show_hidden else filter(lambda c: not c.hidden, prefix_commands)
 
         if self.verify_checks is False:
             # if we do not need to verify the checks then we can just


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Currently the help command for commands.Bot errors out if the bot uses Application Commands.
Usually happens when checking help for a specific cog "$help Music" would give such an error:

`<class 'discord.ext.commands.errors.CommandInvokeError'>
Command raised an exception: AttributeError: 'SlashCommand' object has no attribute 'hidden'`

This pull request fixes that by excluding app commands in filter_commands.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
