### PR TITLE
Fix Issue 363 and Implement Thread Query on WebhookMessage Classes

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -37,6 +37,7 @@ from contextvars import ContextVar
 import aiohttp
 
 from .. import utils
+from ..object import Object
 from ..errors import InvalidArgument, HTTPException, Forbidden, NotFound, DiscordServerError
 from ..message import Message
 from ..enums import try_enum, WebhookType
@@ -45,6 +46,7 @@ from ..asset import Asset
 from ..http import Route
 from ..mixins import Hashable
 from ..channel import PartialMessageable
+from ..threads import Thread
 
 __all__ = (
     'Webhook',
@@ -744,6 +746,12 @@ class WebhookMessage(Message):
         :class:`WebhookMessage`
             The newly edited message.
         """
+        thread = MISSING
+        if hasattr(self, '_thread_id'):
+            thread = Object(self._thread_id)
+        elif isinstance(self.channel, Thread):
+            thread = Object(self.channel.id)
+
         return await self._state._webhook.edit_message(
             self.id,
             content=content,
@@ -753,6 +761,7 @@ class WebhookMessage(Message):
             files=files,
             view=view,
             allowed_mentions=allowed_mentions,
+            thread=thread
         )
 
     async def delete(self, *, delay: Optional[float] = None) -> None:
@@ -775,19 +784,24 @@ class WebhookMessage(Message):
         HTTPException
             Deleting the message failed.
         """
+        thread_id: Optional[int] = None
+        if hasattr(self, '_thread_id'):
+            thread_id = self._thread_id
+        elif isinstance(self.channel, Thread):
+            thread_id = self.channel.id
 
         if delay is not None:
 
             async def inner_call(delay: float = delay):
                 await asyncio.sleep(delay)
                 try:
-                    await self._state._webhook.delete_message(self.id)
+                    await self._state._webhook.delete_message(self.id, thread_id=thread_id)
                 except HTTPException:
                     pass
 
             asyncio.create_task(inner_call())
         else:
-            await self._state._webhook.delete_message(self.id)
+            await self._state._webhook.delete_message(self.id, thread_id=thread_id)
 
 
 class BaseWebhook(Hashable):
@@ -1494,7 +1508,11 @@ class Webhook(BaseWebhook):
             session=self.session,
             thread_id=thread_id,
         )
-        return self._create_message(data)
+        msg = self._create_message(data)
+        if isinstance(msg.channel, PartialMessageable):
+            msg._thread_id = thread_id
+        
+        return msg
 
     async def edit_message(
         self,

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1595,7 +1595,7 @@ class Webhook(BaseWebhook):
         )
 
         thread_id: Optional[int] = None
-        if thread_id is not MISSING:
+        if thread is not MISSING:
             thread_id = thread.id
 
         adapter = async_context.get()

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -812,6 +812,7 @@ class SyncWebhook(BaseWebhook):
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
+        thread: Snowflake = MISSING,
         wait: Literal[True],
     ) -> SyncWebhookMessage:
         ...
@@ -829,6 +830,7 @@ class SyncWebhook(BaseWebhook):
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
+        thread: Snowflake = MISSING,
         wait: Literal[False] = ...,
     ) -> None:
         ...


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Closes #363. I used the minimal reproducible code to determine if the issue's fixed and have what the OP fancied.

I also added thread query on webhook message classes so that editing/deleting webhook messages that are on threads finally work on `WebhookMessage` instances.

(I injected the `thread_id` argument of the `fetch_message` func to the `WebhookMessage` class since I didn't have another way of checking if the PartialMessage channel is a thread or not if that's alright with y'all)
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
