### PR TITLE
Options having different names than parameter name

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -421,6 +421,7 @@ class SlashCommand(ApplicationCommand):
 
             if option.name is None:
                 option.name = p_name
+            option._parameter_name = p_name
 
             final_options.append(option)
 
@@ -479,11 +480,11 @@ class SlashCommand(ApplicationCommand):
             elif op.input_type == SlashCommandOptionType.string and op._converter is not None:
                 arg = await op._converter.convert(ctx, arg)
 
-            kwargs[op.name] = arg
+            kwargs[op._parameter_name] = arg
 
         for o in self.options:
-            if o.name not in kwargs:
-                kwargs[o.name] = o.default
+            if o._parameter_name not in kwargs:
+                kwargs[o._parameter_name] = o.default
         
         if self.cog is not None:
             await self.callback(self.cog, ctx, **kwargs)


### PR DESCRIPTION
## Summary
Fixes #106.
Tested with one different named option and one normal option in a slash command.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, ...)
