### PR TITLE
Add `command.id` & Make `bot.application_commands` a list

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -193,6 +193,7 @@ class ApplicationCommandMixin:
                 type=i["type"],
             )
             self.application_commands[i["id"]] = cmd
+            cmd.id = i["id"]
 
             # Permissions (Roles will be converted to IDs just before Upsert for Global Commands)
             global_permissions.append({"id": i["id"], "permissions": cmd.permissions})
@@ -227,6 +228,7 @@ class ApplicationCommandMixin:
                 for i in cmds:
                     cmd = find(lambda cmd: cmd.name == i["name"] and cmd.type == i["type"] and int(i["guild_id"]) in cmd.guild_ids, self.pending_application_commands)
                     self.application_commands[i["id"]] = cmd
+                    cmd.id = i["id"]
 
                     # Permissions
                     permissions = [

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -100,7 +100,7 @@ class ApplicationCommand(_BaseCommand):
     cog = None
     
     def __repr__(self):
-        return f"<discord.commands.{self.__class__.__name__} name={self.name}>"
+        return f"<discord.commands.{self.__class__.__name__} name={self.name} id={self.id}>"
 
     def __eq__(self, other):
         return isinstance(other, self.__class__)


### PR DESCRIPTION
## Summary
This adds an `id` attribute to application commands.
Also makes `bot.application_commands` a list.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
