### PR TITLE
Simplify custom context usage & support custom autocomplete context

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -378,8 +378,7 @@ class ApplicationCommandMixin:
         application_context_cls
             The factory class that will be used to create the context.
             By default, this is :class:`.ApplicationContext`. Should a custom
-            class be provided, it must be similar enough to
-            :class:`.ApplicationContext`\'s interface.
+            class be provided, it must be a subclass of :class:`.ApplicationContext`.
         autocomplete_context_cls
             The factory class that will be used to create the context.
             By default, this is :class:`.AutocompleteContext`. Should a custom

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -382,8 +382,7 @@ class ApplicationCommandMixin:
         autocomplete_context_cls
             The factory class that will be used to create the context.
             By default, this is :class:`.AutocompleteContext`. Should a custom
-            class be provided, it must be similar enough to
-            :class:`.AutocompleteContext`\'s interface.
+            class be provided, it must be a subclass of :class:`.AutocompleteContext`.
         """
         if interaction.type not in (
             InteractionType.application_command, 


### PR DESCRIPTION
## Summary

This pr simplifies custom context usage and adds custom autocomplete context support.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
