### PR TITLE
Bugfix for task.loop

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -565,11 +565,13 @@ class Loop(Generic[LF]):
 
         if self._current_loop == 0:
             self._time_index += 1
-            return datetime.datetime.combine(datetime.datetime.now(datetime.timezone.utc), next_time)
+            if next_time > datetime.datetime.now(datetime.timezone.utc).timetz():
+                return datetime.datetime.combine(datetime.datetime.now(datetime.timezone.utc), next_time)
+            else:
+                return datetime.datetime.combine(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1), next_time)
 
-        next_date = self._last_iteration
-        if self._time_index == 0:
-            # we can assume that the earliest time should be scheduled for "tomorrow"
+        next_date = cast(datetime.datetime, self._last_iteration)
+        if next_time < next_date.timetz():
             next_date += datetime.timedelta(days=1)
 
         self._time_index += 1


### PR DESCRIPTION
Makes task.loop check if the time must be on this day or the next

## Summary

See https://github.com/nextcord/nextcord/pull/201

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
