### PR TITLE
add support for passing options in SlashCommand.__init__

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -390,7 +390,7 @@ class SlashCommand(ApplicationCommand):
         self.cog = None
 
         params = self._get_signature_parameters()
-        self.options: List[Option] = self._parse_options(params)
+        self.options: List[Option] = kwargs.get('options') or self._parse_options(params)
 
         try:
             checks = func.__commands_checks__


### PR DESCRIPTION
## Summary

Adds support for passing `options` in `SlashCommand.__init__`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
