### PR TITLE
Convert raw image URL into bytecode in `client.user.edit`

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -390,7 +390,7 @@ class ClientUser(BaseUser):
             payload['username'] = username
 
         if avatar is not MISSING:
-            if type(avatar) is not bytes:
+            if not isinstance(avatar, bytes):
                 async with aiohttp.ClientSession() as s:
                     async with s.get(str(avatar)) as response:
                         avatar = await response.read()

--- a/discord/user.py
+++ b/discord/user.py
@@ -390,7 +390,7 @@ class ClientUser(BaseUser):
             payload['username'] = username
 
         if avatar is not MISSING:
-            if "http" in str(avatar):
+            if str(avatar).startswith("http"):
                 async with aiohttp.ClientSession() as s:
                     async with s.get(str(avatar)) as response:
                         avatar = await response.read()

--- a/discord/user.py
+++ b/discord/user.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Type, TypeVar, TYPE_CHECKING
 
 import discord.abc
+import aiohttp
 from .asset import Asset
 from .colour import Colour
 from .enums import DefaultAvatar
@@ -389,6 +390,10 @@ class ClientUser(BaseUser):
             payload['username'] = username
 
         if avatar is not MISSING:
+            if "http" in str(avatar):
+                async with aiohttp.ClientSession() as s:
+                    async with s.get(str(avatar)) as response:
+                        avatar = await response.read()
             payload['avatar'] = _bytes_to_base64_data(avatar)
 
         data: UserPayload = await self._state.http.edit_profile(payload)

--- a/discord/user.py
+++ b/discord/user.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Type, TypeVar, TYPE_CHECKING
 
 import discord.abc
-import aiohttp
+
 from .asset import Asset
 from .colour import Colour
 from .enums import DefaultAvatar
@@ -391,9 +391,7 @@ class ClientUser(BaseUser):
 
         if avatar is not MISSING:
             if not isinstance(avatar, bytes):
-                async with aiohttp.ClientSession() as s:
-                    async with s.get(str(avatar)) as response:
-                        avatar = await response.read()
+                avatar = await self._state.http.get_from_cdn(avatar)
             payload['avatar'] = _bytes_to_base64_data(avatar)
 
         data: UserPayload = await self._state.http.edit_profile(payload)

--- a/discord/user.py
+++ b/discord/user.py
@@ -390,7 +390,7 @@ class ClientUser(BaseUser):
             payload['username'] = username
 
         if avatar is not MISSING:
-            if str(avatar).startswith("http"):
+            if type(avatar) is not bytes:
                 async with aiohttp.ClientSession() as s:
                     async with s.get(str(avatar)) as response:
                         avatar = await response.read()


### PR DESCRIPTION
## Summary

This pull request is to fix the issue I was having with the function `client.user.edit` where `avatar` would only take bytecode. It now converts a URL into bytecode using `aiohttp`. If bytecode is already used, the `if` statement added will not run.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    ^^^ I am not aware of where this is found in the repository, but I found the documentation link [here](https://docs.pycord.dev/en/master/api.html?highlight=client%20user%20edit#discord.ClientUser.edit).
- [ ] If `type: ignore` comments were used, a comment is also left explaining why (N/A)
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
