### PR TITLE
Add autocomplete example

### DIFF
--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -1,0 +1,34 @@
+import discord
+from discord.commands import slash_command, Option
+bot = discord.Bot()
+
+COLORS = ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
+
+
+async def get_colors(ctx: discord.AutocompleteContext):
+    return [color for color in COLORS if color.startswith(ctx.value.lower())]
+
+
+async def get_animals(ctx: discord.AutocompleteContext):
+    picked_color = ctx.options["color"]
+    if picked_color == "red":
+        return ["cardinal", "ladybug"]
+    elif picked_color == "orange":
+        return ["clownfish", "tiger"]
+    elif picked_color == "yellow":
+        return ["goldfinch", "banana slug"]
+    elif picked_color == "green":
+        return ["tree frog", "python"]
+    elif picked_color == "blue":
+        return ["blue jay", "blue whale"]
+    elif picked_color == "indigo":
+        return ["eastern indigo snake"]  # needs to return an iterable even if only one item
+    elif picked_color == "violet":
+        return ["purple emperor butterfly", "orchid dottyback"]
+    else:
+        return ["rainbowfish"]
+
+
+@slash_command(name="ac_colors")
+async def autocomplete_basic_example(ctx: discord.ApplicationContext, color: Option(str, "Pick a color!", autocomplete=get_colors), animal: Option(str, "Pick an animal!", autocomplete=get_animals)):
+    await ctx.respond(f"You picked {color} for the color, which allowed you to choose {animal} for the animal.")

--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -4,6 +4,94 @@ bot = discord.Bot()
 
 COLORS = ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
 
+LOTS_OF_COLORS = [
+    "aliceblue",
+    "antiquewhite",
+    "aqua",
+    "aquamarine",
+    "azure",
+    "beige",
+    "bisque",
+    "blueviolet",
+    "brown",
+    "burlywood",
+    "cadetblue",
+    "cornflowerblue",
+    "cornsilk",
+    "crimson",
+    "cyan",
+    "darkblue",
+    "deepskyblue",
+    "dimgray",
+    "dimgrey",
+    "dodgerblue",
+    "firebrick",
+    "floralwhite",
+    "forestgreen",
+    "fuchsia",
+    "gainsboro",
+    "ghostwhite",
+    "gold",
+    "goldenrod",
+    "gray",
+    "green",
+    "greenyellow",
+    "grey",
+    "honeydew",
+    "hotpink",
+    "indianred",
+    "indigo",
+    "ivory",
+    "khaki",
+    "lavender",
+    "lavenderblush",
+    "lawngreen",
+    "lightcoral",
+    "maroon",
+    "mediumaquamarine",
+    "mediumblue",
+    "mediumorchid",
+    "midnightblue",
+    "navajowhite",
+    "navy",
+    "oldlace",
+    "olive",
+    "olivedrab",
+    "orange",
+    "orangered",
+    "orchid",
+    "palegoldenrod",
+    "palegreen",
+    "plum",
+    "powderblue",
+    "purple",
+    "red",
+    "rosybrown",
+    "royalblue",
+    "saddlebrown",
+    "sienna",
+    "springgreen",
+    "steelblue",
+    "tan",
+    "teal",
+    "thistle",
+    "tomato",
+    "turquoise",
+    "violet",
+    "wheat",
+    "white",
+    "whitesmoke",
+    "yellow",
+    "yellowgreen",
+]
+
+BASIC_ALLOWED = [123, 444, 55782]  # this would be a list of discord user IDs
+
+
+# Simple example of using logic in a basic_autocomplete callback. In this case, we're only returning any results if the user's ID exists in the BASIC_ALLOWED list
+async def color_searcher(ctx: discord.AutocompleteContext):
+    return [color for color in LOTS_OF_COLORS if ctx.interaction.user.id in BASIC_ALLOWED]
+
 
 async def get_colors(ctx: discord.AutocompleteContext):
     return [color for color in COLORS if color.startswith(ctx.value.lower())]
@@ -29,6 +117,21 @@ async def get_animals(ctx: discord.AutocompleteContext):
         return ["rainbowfish"]
 
 
-@slash_command(name="ac_colors")
-async def autocomplete_example(ctx: discord.ApplicationContext, color: Option(str, "Pick a color!", autocomplete=get_colors), animal: Option(str, "Pick an animal!", autocomplete=get_animals)):
+@slash_command(name="ac_example", guild_ids=[...])
+async def autocomplete_example(
+    ctx: discord.ApplicationContext,
+    color: Option(str, "Pick a color!", autocomplete=get_colors),
+    animal: Option(str, "Pick an animal!", autocomplete=get_animals),
+):
     await ctx.respond(f"You picked {color} for the color, which allowed you to choose {animal} for the animal.")
+
+
+@slash_command(name="ac_basic_example", guild_ids=[...])
+async def autocomplete_basic_example(
+    ctx: discord.ApplicationContext,
+    color: Option(str, "Pick a color from this big list", autocomplete=discord.utils.basic_autocomplete(color_searcher)),
+    animal: Option(str, "Pick an animal from this small list", autocomplete=discord.utils.basic_autocomplete(["snail", "python", "cricket", "orca"])),
+):
+    await ctx.respond(f"You picked {color} as your color, and {animal} as your animal!")
+
+bot.run("TOKEN")

--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -85,19 +85,24 @@ LOTS_OF_COLORS = [
     "yellowgreen",
 ]
 
-BASIC_ALLOWED = [123, 444, 55782]  # this would be a list of discord user IDs
+BASIC_ALLOWED = [...]  # this would normally be a list of discord user IDs for the purpose of this example
 
 
-# Simple example of using logic in a basic_autocomplete callback. In this case, we're only returning any results if the user's ID exists in the BASIC_ALLOWED list
 async def color_searcher(ctx: discord.AutocompleteContext):
+    """Returns a list of matching colors from the LOTS_OF_COLORS list
+    In this example, we've added logic to only display any results in the returned list if the user's ID exists in the BASIC_ALLOWED list.
+    This is to demonstrate passing a callback in the discord.utils.basic_autocomplete function.
+    """
     return [color for color in LOTS_OF_COLORS if ctx.interaction.user.id in BASIC_ALLOWED]
 
 
 async def get_colors(ctx: discord.AutocompleteContext):
+    """Returns a list of colors that begin with the characters entered so far."""
     return [color for color in COLORS if color.startswith(ctx.value.lower())]
 
 
 async def get_animals(ctx: discord.AutocompleteContext):
+    """Returns an animal that is (mostly) the color selected for the "color" option."""
     picked_color = ctx.options["color"]
     if picked_color == "red":
         return ["cardinal", "ladybug"]
@@ -123,15 +128,21 @@ async def autocomplete_example(
     color: Option(str, "Pick a color!", autocomplete=get_colors),
     animal: Option(str, "Pick an animal!", autocomplete=get_animals),
 ):
+    """This demonstrates using the ctx.options parameter to to create slash command options that are dependent on the values entered for other options."""
     await ctx.respond(f"You picked {color} for the color, which allowed you to choose {animal} for the animal.")
 
 
 @slash_command(name="ac_basic_example", guild_ids=[...])
 async def autocomplete_basic_example(
     ctx: discord.ApplicationContext,
-    color: Option(str, "Pick a color from this big list", autocomplete=discord.utils.basic_autocomplete(color_searcher)),
-    animal: Option(str, "Pick an animal from this small list", autocomplete=discord.utils.basic_autocomplete(["snail", "python", "cricket", "orca"])),
+    color: Option(str, "Pick a color from this big list", autocomplete=discord.utils.basic_autocomplete(color_searcher)),  # Demonstrates passing a callback to discord.utils.basic_autocomplete
+    animal: Option(str, "Pick an animal from this small list", autocomplete=discord.utils.basic_autocomplete(["snail", "python", "cricket", "orca"])),  # Demonstrates passing a static iterable discord.utils.basic_autocomplete
 ):
+    """This demonstrates using the discord.utils.basic_autocomplete helper function.
+    For the `color` option, a callback is passed, where additional logic can be added to determine which values are returned.
+    For the `animal` option, a static iterable is passed.
+    While a small amount of values for `animal` are used in this example, iterables of any length can be passed to discord.utils.basic_autocomplete
+    Note that the basic_autocomplete function itself will still only return a maximum of 25 items."""
     await ctx.respond(f"You picked {color} as your color, and {animal} as your animal!")
 
 bot.run("TOKEN")

--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -132,7 +132,7 @@ async def autocomplete_example(
     await ctx.respond(f"You picked {color} for the color, which allowed you to choose {animal} for the animal.")
 
 
-@slash_command(name="ac_basic_example", guild_ids=[...])
+@bot.slash_command(name="ac_basic_example")
 async def autocomplete_basic_example(
     ctx: discord.ApplicationContext,
     color: Option(str, "Pick a color from this big list", autocomplete=discord.utils.basic_autocomplete(color_searcher)),  # Demonstrates passing a callback to discord.utils.basic_autocomplete

--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -122,7 +122,7 @@ async def get_animals(ctx: discord.AutocompleteContext):
         return ["rainbowfish"]
 
 
-@slash_command(name="ac_example", guild_ids=[...])
+@bot.slash_command(name="ac_example")
 async def autocomplete_example(
     ctx: discord.ApplicationContext,
     color: Option(str, "Pick a color!", autocomplete=get_colors),

--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -30,5 +30,5 @@ async def get_animals(ctx: discord.AutocompleteContext):
 
 
 @slash_command(name="ac_colors")
-async def autocomplete_basic_example(ctx: discord.ApplicationContext, color: Option(str, "Pick a color!", autocomplete=get_colors), animal: Option(str, "Pick an animal!", autocomplete=get_animals)):
+async def autocomplete_example(ctx: discord.ApplicationContext, color: Option(str, "Pick a color!", autocomplete=get_colors), animal: Option(str, "Pick an animal!", autocomplete=get_animals)):
     await ctx.respond(f"You picked {color} for the color, which allowed you to choose {animal} for the animal.")

--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -102,7 +102,7 @@ async def get_colors(ctx: discord.AutocompleteContext):
 
 
 async def get_animals(ctx: discord.AutocompleteContext):
-    """Returns an animal that is (mostly) the color selected for the "color" option."""
+    """Returns a list of animals that are (mostly) the color selected for the "color" option."""
     picked_color = ctx.options["color"]
     if picked_color == "red":
         return ["cardinal", "ladybug"]


### PR DESCRIPTION
## Summary

Adds an autocomplete example that demonstrates both basic usage, and usage of the `AutocompleteContext.options` parameter.

Closes #487 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue. (feature request)
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change  - new example
