### PR TITLE
Fix voice_client in ApplicationContext

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -109,6 +109,9 @@ class ApplicationContext(discord.abc.Messageable):
 
     @property
     def voice_client(self):
+        if self.guild is None:
+            return None
+        
         return self.guild.voice_client
 
     @cached_property


### PR DESCRIPTION
## Summary

Accessing `voice_client` via `ApplicationContext` while not in a guild raises an `AttributeError`, as opposed to returning `None`

Full traceback from some random guy in `help-1` on Discord:
```py
Traceback (most recent call last):
  File "/home/container/.local/lib/python3.9/site-packages/discord/client.py", line 352, in _run_event
    await coro(*args, **kwargs)
  File "/home/container/.local/lib/python3.9/site-packages/discord/bot.py", line 562, in on_interaction
    await self.process_application_commands(interaction)
  File "/home/container/.local/lib/python3.9/site-packages/discord/bot.py", line 384, in process_application_commands
    await ctx.command.invoke(ctx)
  File "/home/container/.local/lib/python3.9/site-packages/discord/commands/commands.py", line 130, in invoke
    await self.prepare(ctx)
  File "/home/container/.local/lib/python3.9/site-packages/discord/commands/commands.py", line 127, in prepare
    await self.call_before_hooks(ctx)
  File "/home/container/.local/lib/python3.9/site-packages/discord/commands/commands.py", line 264, in call_before_hooks
    await hook(ctx)
  File "/home/container/cogs/basic.py", line 25, in cog_before_invoke
    player = ctx.voice_client
  File "/home/container/.local/lib/python3.9/site-packages/discord/commands/context.py", line 107, in voice_client
    return self.guild.voice_client
AttributeError: 'NoneType' object has no attribute 'voice_client'
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
