### PR TITLE
Using Strings In .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
   builder: html
 
 python:
-  version: 3.8
+  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Summary

[readthedocs require python versions be a string](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
