### PR TITLE
Made `AutocompleteContext.cog` `ApplicationContext.cog` and `ApplicationContext.voice_client` into one liners.

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -45,7 +45,7 @@ from ..utils import cached_property
 
 __all__ = (
     "ApplicationContext",
-    "AutocompleteContext"
+    "AutocompleteContext",
 )
 
 class ApplicationContext(discord.abc.Messageable):
@@ -109,10 +109,7 @@ class ApplicationContext(discord.abc.Messageable):
 
     @property
     def voice_client(self):
-        if self.guild is None:
-            return None
-        
-        return self.guild.voice_client
+        return getattr(self.guild, "voice_client", None)
 
     @cached_property
     def response(self) -> InteractionResponse:
@@ -145,10 +142,7 @@ class ApplicationContext(discord.abc.Messageable):
     @property
     def cog(self) -> Optional[Cog]:
         """Optional[:class:`.Cog`]: Returns the cog associated with this context's command. ``None`` if it does not exist."""
-        if self.command is None:
-            return None
-       
-        return self.command.cog
+        return getattr(self.command, "cog", None)
 
 
 class AutocompleteContext:
@@ -188,7 +182,4 @@ class AutocompleteContext:
     @property
     def cog(self) -> Optional[Cog]:
         """Optional[:class:`.Cog`]: Returns the cog associated with this context's command. ``None`` if it does not exist."""
-        if self.command is None:
-            return None
-       
-        return self.command.cog
+        return getattr(self.command, "cog", None)


### PR DESCRIPTION
## Summary

Makes `AutocompleteContext.cog` `ApplicationContext.cog` and `ApplicationContext.voice_client` into one liners.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
