### PR TITLE
Add support for slash-command groups on cogs

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -118,6 +118,12 @@ class ApplicationCommandMixin:
         command: :class:`.ApplicationCommand`
             The command to add.
         """
+        try:
+            if getattr("parent", command) is not None:
+                raise TypeError("The provided command is a sub-command of group")
+        except AttributeError:
+            pass
+
         if self.debug_guilds and command.guild_ids is None:
             command.guild_ids = self.debug_guilds
         self._pending_application_commands.append(command)

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -29,7 +29,7 @@ import sys
 import discord.utils
 import types
 from . import errors
-from .commands import SlashCommand, UserCommand, MessageCommand, ApplicationCommand
+from .commands import SlashCommand, UserCommand, MessageCommand, ApplicationCommand, SlashCommandGroup
 
 from typing import Any, Callable, Mapping, ClassVar, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Type
 
@@ -144,6 +144,13 @@ class CogMeta(type):
                     del commands[elem]
                 if elem in listeners:
                     del listeners[elem]
+
+                try:
+                    if getattr(value, "parent") is not None:
+                        # Skip commands if they are apart of a group
+                        continue
+                except AttributeError:
+                    pass
 
                 is_static_method = isinstance(value, staticmethod)
                 if is_static_method:
@@ -445,7 +452,8 @@ class Cog(metaclass=CogMeta):
         # we've added so far for some form of atomic loading.
         
         for index, command in enumerate(self.__cog_commands__):
-            command.cog = self
+            command._set_cog(self)
+
             if not isinstance(command, ApplicationCommand):
                 if command.parent is None:
                     try:

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -147,7 +147,7 @@ class CogMeta(type):
 
                 try:
                     if getattr(value, "parent") is not None:
-                        # Skip commands if they are apart of a group
+                        # Skip commands if they are a part of a group
                         continue
                 except AttributeError:
                     pass

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -317,6 +317,9 @@ class ApplicationCommand(_BaseCommand):
         else:
             return self.name
 
+    def _set_cog(self, cog):
+        self.cog = cog
+
 class SlashCommand(ApplicationCommand):
     r"""A class that implements the protocol for a slash command.
 
@@ -771,6 +774,7 @@ class SlashCommandGroup(ApplicationCommand, Option):
             "name": self.name,
             "description": self.description,
             "options": [c.to_dict() for c in self.subcommands],
+            "default_permission": self.default_permission
         }
 
         if self.parent is not None:
@@ -847,6 +851,49 @@ class SlashCommandGroup(ApplicationCommand, Option):
         command = find(lambda x: x.name == option["name"], self.subcommands)
         ctx.interaction.data = option
         await command.invoke_autocomplete_callback(ctx)
+
+    def copy(self):
+        """Creates a copy of this command group.
+
+        Returns
+        --------
+        :class:`SlashCommandGroup`
+            A new instance of this command.
+        """
+        ret = self.__class__(
+            self.name,
+            self.description,
+            **self.__original_kwargs__)
+        return self._ensure_assignment_on_copy(ret)
+
+    def _ensure_assignment_on_copy(self, other):
+        other.parent = self.parent
+
+        other._before_invoke = self._before_invoke
+        other._after_invoke = self._after_invoke
+
+        if self.subcommands != other.subcommands:
+            other.subcommands = self.subcommands.copy()
+        
+        if self.checks != other.checks:
+            other.checks = self.checks.copy()
+
+        return other
+
+    def _update_copy(self, kwargs: Dict[str, Any]):
+        if kwargs:
+            kw = kwargs.copy()
+            kw.update(self.__original_kwargs__)
+            copy = self.__class__(self.callback, **kw)
+            return self._ensure_assignment_on_copy(copy)
+        else:
+            return self.copy()
+
+    def _set_cog(self, cog):
+        self.cog = cog
+        for subcommand in self.subcommands:
+            subcommand._set_cog(cog)
+        
 
 
 class ContextMenuCommand(ApplicationCommand):

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -774,7 +774,7 @@ class SlashCommandGroup(ApplicationCommand, Option):
             "name": self.name,
             "description": self.description,
             "options": [c.to_dict() for c in self.subcommands],
-            "default_permission": self.default_permission
+            "default_permission": self.default_permission,
         }
 
         if self.parent is not None:

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -863,7 +863,8 @@ class SlashCommandGroup(ApplicationCommand, Option):
         ret = self.__class__(
             self.name,
             self.description,
-            **self.__original_kwargs__)
+            **self.__original_kwargs__,
+        )
         return self._ensure_assignment_on_copy(ret)
 
     def _ensure_assignment_on_copy(self, other):

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1144,6 +1144,9 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         finally:
             ctx.command = original
 
+    def _set_cog(self, cog):
+        self.cog = cog
+
 class GroupMixin(Generic[CogT]):
     """A mixin that implements common functionality for classes that behave
     similar to :class:`.Group` and are allowed to register commands.

--- a/examples/app_commands/slash_cog_groups.py
+++ b/examples/app_commands/slash_cog_groups.py
@@ -17,7 +17,7 @@ class Example(commands.Cog):
     international_greetings = greetings.command_group("international", "International greetings")
 
     secret_greetings = SlashCommandGroup("secret_greetings", "Secret greetings", permissions=[
-        Permission("owner", 2, True) # Ensures the owner_id user can access this, and noone else
+        Permission("owner", 2, True) # Ensures the owner_id user can access this, and no one else
     ])
  
     @greetings.command()

--- a/examples/app_commands/slash_cog_groups.py
+++ b/examples/app_commands/slash_cog_groups.py
@@ -1,0 +1,44 @@
+from discord.commands.permissions import Permission
+import discord
+from discord.commands.commands import SlashCommandGroup
+from discord.ext import commands
+
+# Set these
+GUILD_ID=0
+OWNER_ID=0
+
+bot = discord.Bot(debug_guild=GUILD_ID, owner_id=OWNER_ID)
+
+class Example(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    greetings = SlashCommandGroup("greetings", "Various greeting from cogs!")
+    international_greetings = greetings.command_group("international", "International greetings")
+
+    secret_greetings = SlashCommandGroup("secret_greetings", "Secret greetings", permissions=[
+        Permission("owner", 2, True) # Ensures the owner_id user can access this, and noone else
+    ])
+ 
+    @greetings.command()
+    async def hello(self, ctx):
+        await ctx.respond("Hi, this is a slash command from a cog!")
+
+    @international_greetings.command()
+    async def aloha(self, ctx):
+        await ctx.respond("Aloha, a Hawaiian greeting")
+    
+
+    @greetings.command()
+    async def hi(self, ctx):
+        await ctx.respond(f"Hi, this is a slash sub-command from a cog!")
+
+    @secret_greetings.command()
+    async def secret_handshake(self, ctx, member: discord.Member):
+        await ctx.respond(f"{member.mention} secret handshakes you")
+
+
+bot.add_cog(Example(bot))
+
+
+bot.run("TOKEN")


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds support for slash-command groups on cogs

An example has been provided, also demoing that permissions work

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
