### PR TITLE
Fix guild sticker creation description was not optional

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2238,8 +2238,7 @@ class Guild(Hashable):
             'name': name,
         }
 
-        if description:
-            payload['description'] = description
+        payload['description'] = description or ""
 
         try:
             emoji = unicodedata.name(emoji)


### PR DESCRIPTION
## Summary

This fixes ``Guild.create_sticker`` method to allow for descriptions to be None.  According to the docs (https://discord.com/developers/docs/resources/sticker#create-guild-sticker-form-params), the description parameter is **not** optional, although it can be empty.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
