### PR TITLE
Change if isinstance logic to elif

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1084,7 +1084,7 @@ class VoiceChannel(VocalGuildChannel):
         if isinstance(activity, EmbeddedActivity):
             activity = activity.value
 
-        if not isinstance(activity, int):
+        elif not isinstance(activity, int):
             raise TypeError('Invalid type provided for the activity.')
 
         return await self.create_invite(


### PR DESCRIPTION
Not checking if `activity` is instance of `int` when `activity` is an instance of `EmbeddedActivity` will result in better processing efficiency.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Improve efficiency while creating Activity Invites to Voice Channels

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
