### PR TITLE
Remove useless var, `entry`

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -364,8 +364,7 @@ class DiscordWebSocket:
         """
 
         future = self.loop.create_future()
-        entry = EventListener(event=event, predicate=predicate, result=result, future=future)
-        self._dispatch_listeners.append(entry)
+        self._dispatch_listeners.append(EventListener(event=event, predicate=predicate, result=result, future=future))
         return future
 
     async def identify(self):


### PR DESCRIPTION
## Summary

It removes a variable in `DiscordWebSocket.wait_for` called `entry` it is only used once so it is basically useless.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
