### PR TITLE
Use WeakValueDictionary for webhook locks.

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -29,6 +29,7 @@ import logging
 import asyncio
 import json
 import re
+import weakref
 
 from urllib.parse import quote as urlquote
 from typing import Any, Dict, List, Literal, NamedTuple, Optional, TYPE_CHECKING, Tuple, Union, overload
@@ -98,7 +99,7 @@ class AsyncDeferredLock:
 
 class AsyncWebhookAdapter:
     def __init__(self):
-        self._locks: Dict[Any, asyncio.Lock] = {}
+        self._locks: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
     async def request(
         self,

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -36,6 +36,7 @@ import logging
 import json
 import time
 import re
+import weakref
 
 from urllib.parse import quote as urlquote
 from typing import Any, Dict, List, Literal, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Union, overload
@@ -94,7 +95,7 @@ class DeferredLock:
 
 class WebhookAdapter:
     def __init__(self):
-        self._locks: Dict[Any, threading.Lock] = {}
+        self._locks: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
     def request(
         self,


### PR DESCRIPTION
## Summary

Fixes #420.

Webhook adapters used simple `dict` to store locks for ratelimit handling. This caused memory spikes for bots using interactions since they are mostly webhooks based. The size of dict kept growing. This PR fixes this issue by using `WeakValueDictionary` for storing locks.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
