### PR TITLE
Update recent change to CogMeta class to only apply to ApplicationCommand groups

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -146,7 +146,7 @@ class CogMeta(type):
                     del listeners[elem]
 
                 try:
-                    if getattr(value, "parent") is not None:
+                    if getattr(value, "parent") is not None and isinstance(value, ApplicationCommand):
                         # Skip commands if they are a part of a group
                         continue
                 except AttributeError:


### PR DESCRIPTION
## Summary

Updates the recent changes from 6646129 to the base CogMeta class to make them only apply to ApplicationCommand groups.

I've tested the fix and both prefix command groups and slash command groups in cogs now work as expected.

This closes #571 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
