### PR TITLE
[bugfix] Use kwargs when copying group

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -877,11 +877,11 @@ class SlashCommandGroup(ApplicationCommand, Option):
         Returns
         --------
         :class:`SlashCommandGroup`
-            A new instance of this command.
+            A new instance of this command group.
         """
         ret = self.__class__(
-            self.name,
-            self.description,
+            name=self.name,
+            description=self.description,
             **self.__original_kwargs__,
         )
         return self._ensure_assignment_on_copy(ret)


### PR DESCRIPTION
## Summary
Fixes an issue in which group name and description get multiple values.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
