### PR TITLE
Fix to autocomplete's values (OptionChoices)

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -565,7 +565,8 @@ class SlashCommand(ApplicationCommand):
                     result = await result
                     
                 choices = [
-                    o if isinstance(o, OptionChoice) else OptionChoice(o)
+                    o if isinstance(o, OptionChoice) 
+                    else (OptionChoice(*o) if isinstance(o, tuple) else OptionChoice(o))
                     for o in result
                 ][:25]
                 return await ctx.interaction.response.send_autocomplete_result(choices=choices)

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -565,8 +565,7 @@ class SlashCommand(ApplicationCommand):
                     result = await result
                     
                 choices = [
-                    o if isinstance(o, OptionChoice) 
-                    else (OptionChoice(*o) if isinstance(o, tuple) else OptionChoice(o))
+                    o if isinstance(o, OptionChoice) else OptionChoice(o)
                     for o in result
                 ][:25]
                 return await ctx.interaction.response.send_autocomplete_result(choices=choices)

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1094,13 +1094,13 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
 
     Parameters
     -----------
-    values: Union[Union[Iterable[:class:`tuple`], Iterable[:class:`OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Callable[[:class:`AutocompleteContext`], Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
+    values: Union[Union[Iterable[:class:`OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Callable[[:class:`AutocompleteContext`], Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         Possible values for the option. Accepts an iterable of :class:`str`, a callable (sync or async) that takes a
         single argument of :class:`AutocompleteContext`, or a coroutine. Must resolve to an iterable of :class:`str`.
 
     Returns
     --------
-    Callable[[:class:`AutocompleteContext`], Awaitable[Union[Iterable[:class:`tuple`], Iterable[:class:`OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
+    Callable[[:class:`AutocompleteContext`], Awaitable[Union[Iterable[:class:`OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         A wrapped callback for the autocomplete.
     """
     async def autocomplete_callback(ctx: AutocompleteContext) -> V:
@@ -1112,20 +1112,6 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
             _values = await _values
 
         def check(item: Any) -> bool:
-            """Comparator method
-
-            Parameters
-            ----------
-            item : Any
-                parameter
-
-            Returns
-            -------
-            bool
-                if valid
-            """
-            if isinstance(item, tuple):
-                item, _ = item
             if hasattr(item, "to_dict"):
                 item = item.to_dict()["name"]
             return str(item).lower().startswith(str(ctx.value or "").lower())

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1116,7 +1116,7 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
 
             Parameters
             ----------
-            x : str
+            item : Any
                 parameter
 
             Returns

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1111,7 +1111,26 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
         if asyncio.iscoroutine(_values):
             _values = await _values
 
-        gen = (val for val in _values if str(val).lower().startswith(str(ctx.value or "").lower()))
+        def check(item: Any) -> bool:
+            """Comparator method
+
+            Parameters
+            ----------
+            x : str
+                parameter
+
+            Returns
+            -------
+            bool
+                if valid
+            """
+            if isinstance(item, tuple):
+                item, _ = item
+            if hasattr(item, "to_dict"):
+                item = item.to_dict()["name"]
+            return str(item).lower().startswith(str(ctx.value or "").lower())
+        
+        gen = (val for val in _values if check(val))
         return iter(itertools.islice(gen, 25))
 
     return autocomplete_callback

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1112,8 +1112,7 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
             _values = await _values
 
         def check(item: Any) -> bool:
-            if hasattr(item, "to_dict"):
-                item = item.to_dict()["name"]
+            item = getattr(item, "name", item)
             return str(item).lower().startswith(str(ctx.value or "").lower())
         
         gen = (val for val in _values if check(val))

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1094,13 +1094,13 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
 
     Parameters
     -----------
-    values: Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Callable[[:class:`AutocompleteContext`], Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
+    values: Union[Union[Iterable[:class:`tuple`], Iterable[:class:`OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Callable[[:class:`AutocompleteContext`], Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         Possible values for the option. Accepts an iterable of :class:`str`, a callable (sync or async) that takes a
         single argument of :class:`AutocompleteContext`, or a coroutine. Must resolve to an iterable of :class:`str`.
 
     Returns
     --------
-    Callable[[:class:`AutocompleteContext`], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
+    Callable[[:class:`AutocompleteContext`], Awaitable[Union[Iterable[:class:`tuple`], Iterable[:class:`OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         A wrapped callback for the autocomplete.
     """
     async def autocomplete_callback(ctx: AutocompleteContext) -> V:


### PR DESCRIPTION
## Summary

Currently the autocomplete has the issue of trying to convert tuples into string, and not being able to work with OptionChoices, this commit fixes all those issues and allows it to work with tuples, OptionChoices and such.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
