### PR TITLE
Add: Add register_commands_on_connect option

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -690,6 +690,9 @@ class BotBase(ApplicationCommandMixin, CogMixin):
             "debug_guild", None
         )  # TODO: remove or reimplement
         self.debug_guilds = options.pop("debug_guilds", None)
+        self.register_commands_on_connect = options.pop(
+            "register_commands_on_connect", True
+        )
 
         if self.owner_id and self.owner_ids:
             raise TypeError("Both owner_id and owner_ids are set.")
@@ -713,7 +716,8 @@ class BotBase(ApplicationCommandMixin, CogMixin):
         self._after_invoke = None
 
     async def on_connect(self):
-        await self.register_commands()
+        if self.register_commands_on_connect:
+            await self.register_commands()
 
     async def on_interaction(self, interaction):
         await self.process_application_commands(interaction)
@@ -1059,6 +1063,10 @@ class Bot(BotBase, Client):
         .. note::
 
             You cannot set both debug_guild and debug_guilds.
+    
+    register_commands_on_connect: bool
+        Whether to run :meth:`.register_commands` on connect. This is useful when you are
+        using other library to register application commands. Defaults to ``true``.
     """
 
     pass

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1066,7 +1066,7 @@ class Bot(BotBase, Client):
     
     register_commands_on_connect: bool
         Whether to run :meth:`.register_commands` on connect. This is useful when you are
-        using other library to register application commands. Defaults to ``true``.
+        using another library to register application commands. Defaults to ``true``.
     """
 
     pass


### PR DESCRIPTION
## Summary

This PR will add `register_commands_on_connect ` to discord.Bot. This will be useful to register commands manually.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
