### PR TITLE
changed discord.ext.menus to discord.ext.pages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ packages = [
     "discord.commands",
     "discord.ext.commands",
     "discord.ext.tasks",
-    "discord.ext.menus",
+    "discord.ext.pages",
 ]
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

  writing manifest file 'C:\Users\Philskillz\AppData\Local\Temp\pip-pip-egg-info-9aqyscq8\py_cord.egg-info\SOURCES.txt'
  error: package directory 'discord\ext\menus' does not exist
  ----------------------------------------
WARNING: Discarding git+https://github.com/Pycord-Development/pycord. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
