### PR TITLE
fix for ext.pages rename in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ These extensions help you during development when it comes to common tasks.
 
   ext/commands/index.rst
   ext/tasks/index.rst
-  ext/menus/index.rst
+  ext/pages/index.rst
 
 Manuals
 ---------
@@ -63,7 +63,7 @@ These pages go into great detail about everything the API can do.
   api
   discord.ext.commands API Reference <ext/commands/api.rst>
   discord.ext.tasks API Reference <ext/tasks/index.rst>
-  discord.ext.menus API Reference <ext/menus/index.rst>
+  discord.ext.pages API Reference <ext/pages/index.rst>
 
 Meta
 ------


### PR DESCRIPTION
## Summary

Fixes incorrect ext.menus references in docs/index.rst, updates them to ext.pages

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
