### PR TITLE
Update menu to pages in example

### DIFF
--- a/docs/ext/pages/index.rst
+++ b/docs/ext/pages/index.rst
@@ -36,7 +36,7 @@ Example usage in a cog:
         async def pagetest(self, ctx):
             await ctx.defer()
             # initializing the paginator
-            paginator = menus.Paginator(pages=self.get_pages(), show_disabled=False, show_indicator=True)
+            paginator = pages.Paginator(pages=self.get_pages(), show_disabled=False, show_indicator=True)
 
             # customising buttons
             paginator.customize_button("next", button_label=">", button_style=discord.ButtonStyle.green)
@@ -59,7 +59,7 @@ Example usage in a cog:
                     options=[discord.SelectOption(label="Example Option", value="Example Value", description="This menu does nothing!")],
                 )
             )
-            paginator = menus.Paginator(pages=self.get_pages(), show_disabled=False, show_indicator=True, custom_view=view)
+            paginator = pages.Paginator(pages=self.get_pages(), show_disabled=False, show_indicator=True, custom_view=view)
             await paginator.send(ctx, ephemeral=False)
 
 


### PR DESCRIPTION
## Summary

Fix the `ext.pages` example to properly use `pages` instead of `menus`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
