### PR TITLE
Add alias use_application_commands for slash

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -487,6 +487,14 @@ class Permissions(BaseFlags):
         .. versionadded:: 1.7
         """
         return 1 << 31
+    
+    @make_permission_alias('use_slash_commands')
+    def use_application_commands(self) -> int:
+        """:class:`bool`: An alias for :attr:`use_slash_commands`.
+
+        .. versionadded:: 2.0
+        """
+        return 1 << 31
 
     @flag_value
     def request_to_speak(self) -> int:


### PR DESCRIPTION
This was missing till yet.
The permission was renamed to use application commands a while ago