### PR TITLE
Add support for seconds to be passed into timeout()

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -795,7 +795,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Parameters
         -----------
-        until: Union[:class:`int, :class:`datetime.datetime`]
+        until: Union[:class:`int`, :class:`datetime.datetime`]
             The date and time or seconds to timeout the member for. If this is ``None`` then the member is removed from timeout.
         reason: Optional[:class:`str`]
             The reason for doing this action. Shows up on the audit log.

--- a/discord/member.py
+++ b/discord/member.py
@@ -795,7 +795,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Parameters
         -----------
-        until: Union[:class:`datetime.datetime`, :class:`int`]
+        until: Union[:class:`int, :class:`datetime.datetime`]
             The date and time or seconds to timeout the member for. If this is ``None`` then the member is removed from timeout.
         reason: Optional[:class:`str`]
             The reason for doing this action. Shows up on the audit log.

--- a/discord/member.py
+++ b/discord/member.py
@@ -795,8 +795,8 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Parameters
         -----------
-        until: :class:`datetime.datetime`
-            The date and time to timeout the member for. If this is ``None`` then the member is removed from timeout.
+        until: Union[:class:`datetime.datetime`, :class:`int`]
+            The date and time or seconds to timeout the member for. If this is ``None`` then the member is removed from timeout.
         reason: Optional[:class:`str`]
             The reason for doing this action. Shows up on the audit log.
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -785,7 +785,7 @@ class Member(discord.abc.Messageable, _UserTag):
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)
             return Member(data=data, guild=self.guild, state=self._state)
 
-    async def timeout(self, until: Optional[datetime.datetime], *, reason: Optional[str] = None) -> None:
+    async def timeout(self, until: Optional[Union[int, datetime.datetime]], *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Timeouts a member from the guild for the set duration.
@@ -807,6 +807,9 @@ class Member(discord.abc.Messageable, _UserTag):
         HTTPException
             An error occurred doing the request.
         """
+        if isinstance(until, int):
+            until = datetime.datetime(seconds=until)
+
         await self.edit(communication_disabled_until=until, reason=reason)
 
     async def remove_timeout(self, *, reason: Optional[str] = None) -> None:


### PR DESCRIPTION
## Summary

Adds support for seconds to be passed into timeout()

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
