### PR TITLE
Add permissions to context menu commands

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -935,6 +935,14 @@ class ContextMenuCommand(ApplicationCommand):
         The coroutine that is executed when the command is called.
     guild_ids: Optional[List[:class:`int`]]
         The ids of the guilds where this command will be registered.
+    default_permission: :class:`bool`
+        Whether the command is enabled by default when it is added to a guild.
+    permissions: List[:class:`Permission`]
+        The permissions for this command.
+
+        .. note::
+
+            If this is not empty then default_permissions will be set to False.
     cog: Optional[:class:`Cog`]
         The cog that this command belongs to. ``None`` if there isn't one.
     checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -943,6 +943,7 @@ class ContextMenuCommand(ApplicationCommand):
         .. note::
 
             If this is not empty then default_permissions will be set to False.
+
     cog: Optional[:class:`Cog`]
         The cog that this command belongs to. ``None`` if there isn't one.
     checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -942,7 +942,7 @@ class ContextMenuCommand(ApplicationCommand):
 
         .. note::
 
-            If this is not empty then default_permissions will be set to False.
+            If this is not empty then default_permissions will be set to ``False``.
 
     cog: Optional[:class:`Cog`]
         The cog that this command belongs to. ``None`` if there isn't one.

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -979,8 +979,10 @@ class ContextMenuCommand(ApplicationCommand):
 
         self.validate_parameters()
 
-        # Context Menu commands don't have permissions
-        self.permissions = []
+        self.default_permission = kwargs.get("default_permission", True)
+        self.permissions: List[Permission] = getattr(func, "__app_cmd_perms__", []) + kwargs.get("permissions", [])
+        if self.permissions and self.default_permission:
+            self.default_permission = False
 
         # Context Menu commands can't have parents
         self.parent = None
@@ -1023,7 +1025,7 @@ class ContextMenuCommand(ApplicationCommand):
         return self.name
 
     def to_dict(self) -> Dict[str, Union[str, int]]:
-        return {"name": self.name, "description": self.description, "type": self.type}
+        return {"name": self.name, "description": self.description, "type": self.type, "default_permission": self.default_permission}
 
 
 class UserCommand(ContextMenuCommand):


### PR DESCRIPTION
## Summary

Adds permissions (i.e. graying out commands based on user/role) for context menu commands (both user and message)

Implementation works exactly as it currently does for slash commands.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
