### PR TITLE
Fix crash caused by locales

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -143,8 +143,8 @@ class Interaction:
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, 'channel_id')
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
-        self.locale: Optional[str] = data['locale']
-        self.guild_locale: Optional[str] = data['guild_locale']
+        self.locale: Optional[str] = data.get('locale')
+        self.guild_locale: Optional[str] = data.get('guild_locale')
 
         self.message: Optional[Message]
         try:


### PR DESCRIPTION
## Summary

Using application commands outside of guilds (e.g. DMs) crashes the bot due to KeyError for guild_locale, this simple change fixes this crash

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
