### PR TITLE
Remove discord.Bot.debug_guild

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -699,12 +699,6 @@ class BotBase(ApplicationCommandMixin, CogMixin):
                 f"owner_ids must be a collection not {self.owner_ids.__class__!r}"
             )
 
-        if self.debug_guild:
-            if self.debug_guilds is None:
-                self.debug_guilds = [self.debug_guild]
-            else:
-                raise TypeError("Both debug_guild and debug_guilds are set.")
-
         self._checks = []
         self._check_once = []
         self._before_invoke = None

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -687,9 +687,6 @@ class BotBase(ApplicationCommandMixin, CogMixin):
         self.owner_id = options.get("owner_id")
         self.owner_ids = options.get("owner_ids", set())
 
-        self.debug_guild = options.pop(
-            "debug_guild", None
-        )  # TODO: remove or reimplement
         self.debug_guilds = options.pop("debug_guilds", None)
 
         if self.owner_id and self.owner_ids:
@@ -1086,17 +1083,10 @@ class Bot(BotBase, Client):
         for the collection. You cannot set both ``owner_id`` and ``owner_ids``.
 
         .. versionadded:: 1.3
-    debug_guild: Optional[:class:`int`]
-        Guild ID of a guild to use for testing commands. Prevents setting global commands
-        in favor of guild commands, which update instantly.
-        .. note::
-
-            The bot will not create any global commands if a debug_guild is passed.
+           
     debug_guilds: Optional[List[:class:`int`]]
         Guild IDs of guilds to use for testing commands. This is similar to debug_guild.
-        .. note::
-
-            You cannot set both debug_guild and debug_guilds.
+        The bot will not create any global commands if a debug_guilds is passed.
     """
 
     pass


### PR DESCRIPTION
## Summary

Remove `discord.Bot.debug_guild` as it is redundant next to `debug_guilds` and may create unnecessary confusion.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
