### PR TITLE
Make `guild.audit_logs(limit)` parameter optional

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2735,7 +2735,7 @@ class Guild(Hashable):
     def audit_logs(
         self,
         *,
-        limit: int = 100,
+        limit: Optional[int] = 100,
         before: Optional[SnowflakeTime] = None,
         after: Optional[SnowflakeTime] = None,
         oldest_first: Optional[bool] = None,


### PR DESCRIPTION
As written in the docs below the command:

```
limit: Optional[`int`]
            The number of entries to retrieve. If ``None`` retrieve all entries.
```

So the parameter should be Optional. Currently my IME returns the error `Expected type 'int', got 'None' instead `

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
