### PR TITLE
Add slash command example to quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -78,7 +78,7 @@ On other systems:
 Now you can try playing around with your basic bot.
 
 A Minimal Bot with Slash Commands
----------------
+-----------------------------------
 
 As a continuation, let's create a bot that registers a simple slash command!
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,13 +5,13 @@
 .. currentmodule:: discord
 
 Quickstart
-============
+==========
 
 This page gives a brief introduction to the library. It assumes you have the library installed,
 if you don't check the :ref:`installing` portion.
 
 A Minimal Bot
----------------
+-------------
 
 Let's make a bot that responds to a specific message and walk you through it.
 
@@ -79,7 +79,7 @@ On other systems:
 Now you can try playing around with your basic bot.
 
 A Minimal Bot with Slash Commands
------------------------------------
+---------------------------------
 
 As a continuation, let's create a bot that registers a simple slash command!
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -40,7 +40,7 @@ It looks something like this:
 Let's name this file ``example_bot.py``. Make sure not to name it ``discord.py`` as that'll conflict
 with the library.
 
-There's a lot going on here, so let's walk you through it step by step.
+There's a lot going on here, so let's walk you through it step by step:
 
 1. The first line just imports the library, if this raises a `ModuleNotFoundError` or `ImportError`
    then head on over to :ref:`installing` section to properly install.
@@ -77,3 +77,42 @@ On other systems:
     $ python3 example_bot.py
 
 Now you can try playing around with your basic bot.
+
+A Minimal Bot with Slash Commands
+---------------
+
+As a continuation, let's create a bot that registers a simple slash command!
+
+It looks something like this:
+
+.. code-block:: python3
+
+    import discord
+
+    bot = discord.Bot()
+
+    @bot.event
+    async def on_ready():
+        print(f'We have logged in as {bot.user}')
+
+    @bot.slash_command(name="hello", guild_ids=[your, guild_ids, here])
+    async def hello_slash(ctx):
+        await ctx.respond("Hello!")
+
+    bot.run('your token here')
+
+Let's look at the differences compared to the previous example, step-by-step:
+
+1. The first line remains unchanged.
+2. Next, we create an instance of :class:`Bot`. This is different from :class:`Client`, as it supports
+   slash command creation and other features, while inheriting all the features of :class:`Client`.
+3. We then use the :meth:`Bot.slash_command` decorator to register a new slash command. The first
+   keyword-argument, ``name``, sets the command's name to ``hello``. The ``guild_ids`` attribute contains
+   a list of guilds where this command will be active. If you omit it, the command will be globally
+   available, and may take up to an hour to register.
+4. Afterwards, we trigger a response to the slash command in the form of a text reply. Please note that
+   all slash commands must have some form of response, otherwise they will fail.
+6. Finally, we, once again, run the bot with our login token.
+
+
+Congratulations! Now you have created your first slash command!

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -55,7 +55,8 @@ There's a lot going on here, so let's walk you through it step by step:
    sure that we ignore messages from ourselves. We do this by checking if the :attr:`Message.author`
    is the same as the :attr:`Client.user`.
 5. Afterwards, we check if the :class:`Message.content` starts with ``'$hello'``. If it does,
-   then we send a message in the channel it was used in with ``'Hello!'``.
+   then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
+   handling commands, which can be later automated with the :doc:`./ext/commands/index` framework.
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord-intro` section.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -55,8 +55,7 @@ There's a lot going on here, so let's walk you through it step by step:
    sure that we ignore messages from ourselves. We do this by checking if the :attr:`Message.author`
    is the same as the :attr:`Client.user`.
 5. Afterwards, we check if the :class:`Message.content` starts with ``'$hello'``. If it does,
-   then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
-   handling commands, which can be later automated with the :doc:`./ext/commands/index` framework.
+   then we send a message in the channel it was used in with ``'Hello!'``.
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord-intro` section.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -104,9 +104,9 @@ It looks something like this:
 Let's look at the differences compared to the previous example, step-by-step:
 
 1. The first line remains unchanged.
-2. Next, we create an instance of :class:`Bot`. This is different from :class:`Client`, as it supports
-   slash command creation and other features, while inheriting all the features of :class:`Client`.
-3. We then use the :meth:`Bot.slash_command` decorator to register a new slash command. 
+2. Next, we create an instance of :class:`.Bot`. This is different from :class:`.Client`, as it supports
+   slash command creation and other features, while inheriting all the features of :class:`.Client`.
+3. We then use the :meth:`.Bot.slash_command` decorator to register a new slash command. 
    The ``guild_ids`` attribute contains a list of guilds where this command will be active. 
    If you omit it, the command will be globally available, and may take up to an hour to register.
 4. Afterwards, we trigger a response to the slash command in the form of a text reply. Please note that

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -98,7 +98,7 @@ It looks something like this:
     async def hello_slash(ctx):
         await ctx.respond("Hello!")
 
-    bot.run('your token here')
+    bot.run("your token here")
 
 Let's look at the differences compared to the previous example, step-by-step:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -92,7 +92,7 @@ It looks something like this:
 
     @bot.event
     async def on_ready():
-        print(f'We have logged in as {bot.user}')
+        print(f"We have logged in as {bot.user}")
 
     @bot.slash_command(name="hello", guild_ids=[your, guild_ids, here])
     async def hello_slash(ctx):

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -94,8 +94,8 @@ It looks something like this:
     async def on_ready():
         print(f"We have logged in as {bot.user}")
 
-    @bot.slash_command(name="hello", guild_ids=[your, guild_ids, here])
-    async def hello_slash(ctx):
+    @bot.slash_command(guild_ids=[your, guild_ids, here])
+    async def hello(ctx):
         await ctx.respond("Hello!")
 
     bot.run("your token here")
@@ -105,10 +105,9 @@ Let's look at the differences compared to the previous example, step-by-step:
 1. The first line remains unchanged.
 2. Next, we create an instance of :class:`Bot`. This is different from :class:`Client`, as it supports
    slash command creation and other features, while inheriting all the features of :class:`Client`.
-3. We then use the :meth:`Bot.slash_command` decorator to register a new slash command. The first
-   keyword-argument, ``name``, sets the command's name to ``hello``. The ``guild_ids`` attribute contains
-   a list of guilds where this command will be active. If you omit it, the command will be globally
-   available, and may take up to an hour to register.
+3. We then use the :meth:`Bot.slash_command` decorator to register a new slash command. 
+   The ``guild_ids`` attribute contains a list of guilds where this command will be active. 
+   If you omit it, the command will be globally available, and may take up to an hour to register.
 4. Afterwards, we trigger a response to the slash command in the form of a text reply. Please note that
    all slash commands must have some form of response, otherwise they will fail.
 6. Finally, we, once again, run the bot with our login token.


### PR DESCRIPTION
## Summary

Currently the quickstart is written in a way that is best-suited for the older commands framework. This PR aims to somewhat modernize the quickstart and introduce users to slash commands earlier on.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
