### PR TITLE
Add a note about using ctx.respond in slash_basic example

### DIFF
--- a/examples/app_commands/slash_basic.py
+++ b/examples/app_commands/slash_basic.py
@@ -14,8 +14,9 @@ bot = discord.Bot()
 async def hello(ctx):
     """Say hello to the bot"""  # the command description can be supplied as the docstring
     await ctx.respond(f"Hello {ctx.author}!")
-    # Please note that you MUST use ctx.respond(), ctx.defer(), or any other interaction response
-    # in your slash command code, otherwise the interaction will fail.
+    # Please note that you MUST respond with ctx.respond(), ctx.defer(), or any other
+    # interaction response within 3 seconds in your slash command code, otherwise the
+    # interaction will fail.
 
 
 @bot.slash_command(

--- a/examples/app_commands/slash_basic.py
+++ b/examples/app_commands/slash_basic.py
@@ -14,6 +14,8 @@ bot = discord.Bot()
 async def hello(ctx):
     """Say hello to the bot"""  # the command description can be supplied as the docstring
     await ctx.respond(f"Hello {ctx.author}!")
+    # Please note that you MUST either use ctx.respond() or ctx.defer() in your
+    # slash command code, otherwise the interaction will fail.
 
 
 @bot.slash_command(

--- a/examples/app_commands/slash_basic.py
+++ b/examples/app_commands/slash_basic.py
@@ -14,8 +14,8 @@ bot = discord.Bot()
 async def hello(ctx):
     """Say hello to the bot"""  # the command description can be supplied as the docstring
     await ctx.respond(f"Hello {ctx.author}!")
-    # Please note that you MUST either use ctx.respond() or ctx.defer() in your
-    # slash command code, otherwise the interaction will fail.
+    # Please note that you MUST use ctx.respond(), ctx.defer(), or any other interaction response
+    # in your slash command code, otherwise the interaction will fail.
 
 
 @bot.slash_command(


### PR DESCRIPTION
## Summary

I see way too many people being confused about having to use `ctx.respond()` in a slash command context, so I thought I would clarify the fact that interactions need some form of response issued.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
