### PR TITLE
Separate ApplicationContext.respond() and followup()

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -144,7 +144,7 @@ class ApplicationContext(discord.abc.Messageable):
         if self.response.is_done():
             return self.followup.send
         else:
-            raise RuntimeError("Interaction was not yet issued a response. Try using {type(self).__name__}.respond() first.")
+            raise RuntimeError(f"Interaction was not yet issued a response. Try using {type(self).__name__}.respond() first.")
 
     @property
     def defer(self):

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -137,7 +137,7 @@ class ApplicationContext(discord.abc.Messageable):
         if not self.response.is_done():
             return self.interaction.response.send_message
         else:
-            raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.followup() instead.")
+            raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.send_followup() instead.")
     
     @property
     def send_followup(self):

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -138,7 +138,15 @@ class ApplicationContext(discord.abc.Messageable):
             return self.interaction.response.send_message
         else:
             raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.send_followup() instead.")
-    
+
+    @property
+    async def send_response(self) -> Callable[..., Union[Interaction, Webhook]]:
+        """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response or a followup response depending if the interaction has been responded to yet or not.
+        if not self.response.is_done():
+            return self.interaction.response.send_message  # self.response
+        else:
+            return self.followup.send  # self.send_followup
+
     @property
     def send_followup(self):
         if self.response.is_done():

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -151,7 +151,7 @@ class ApplicationContext(discord.abc.Messageable):
         return self.interaction.response.defer
 
     @property
-    def followup_webhook(self):
+    def followup(self):
         return self.interaction.followup
 
     async def delete(self):

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -144,7 +144,7 @@ class ApplicationContext(discord.abc.Messageable):
         if self.response.is_done():
             return self.followup.send
         else:
-            raise RuntimeError("Interaction was not yet issued a response. Try using ApplicationContext.respond() first.")
+            raise RuntimeError("Interaction was not yet issued a response. Try using {type(self).__name__}.respond() first.")
 
     @property
     def defer(self):

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -141,7 +141,8 @@ class ApplicationContext(discord.abc.Messageable):
 
     @property
     async def send_response(self) -> Callable[..., Union[Interaction, Webhook]]:
-        """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response or a followup response depending if the interaction has been responded to yet or not.
+        """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response
+        or a followup response depending if the interaction has been responded to yet or not."""
         if not self.response.is_done():
             return self.interaction.response.send_message  # self.response
         else:

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -137,7 +137,7 @@ class ApplicationContext(discord.abc.Messageable):
         if not self.response.is_done():
             return self.interaction.response.send_message
         else:
-            raise RuntimeError("Interaction was already issued a response. Try using ApplicationContext.followup() instead.")
+            raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.followup() instead.")
     
     @property
     def followup(self):

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -140,7 +140,7 @@ class ApplicationContext(discord.abc.Messageable):
             raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.followup() instead.")
     
     @property
-    def followup(self):
+    def send_followup(self):
         if self.response.is_done():
             return self.followup.send
         else:

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -134,14 +134,24 @@ class ApplicationContext(discord.abc.Messageable):
 
     @property
     def respond(self):
-        return self.followup.send if self.response.is_done() else self.interaction.response.send_message
+        if not self.response.is_done():
+            return self.interaction.response.send_message
+        else:
+            raise RuntimeError("Interaction was already issued a response. Try using ApplicationContext.followup() instead.")
+    
+    @property
+    def followup(self):
+        if self.response.is_done():
+            return self.followup.send
+        else:
+            raise RuntimeError("Interaction was not yet issued a response. Try using ApplicationContext.respond() first.")
 
     @property
     def defer(self):
         return self.interaction.response.defer
 
     @property
-    def followup(self):
+    def followup_webhook(self):
         return self.interaction.followup
 
     async def delete(self):


### PR DESCRIPTION
## Summary

Closes #438 
This PR aims to separate `ApplicationContext.respond()` and `ApplicationContext.followup()` (new function) into two seperate functions. It also renames `ApplicationContext.followup` (attribute) to `ApplicationContext.followup_webhook`, but I am honestly unsure how to resolve this naming conflict, so please let me know if this should be adjusted.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
