### PR TITLE
Ability to reload application command callbacks

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -124,7 +124,14 @@ class ApplicationCommandMixin:
 
         if self.debug_guilds and command.guild_ids is None:
             command.guild_ids = self.debug_guilds
-        self._pending_application_commands.append(command)
+
+        for cmd in self.pending_application_commands:
+            if cmd == command:
+                command.id = cmd.id
+                self._application_commands[command.id] = command
+                break
+        else:
+            self._pending_application_commands.append(command)
 
     def remove_application_command(
         self, command: ApplicationCommand


### PR DESCRIPTION
## Summary
This solves #477 and allows cogs with application commands to be reloaded in order to change the callback of the commands.
- Modifies `bot.add_application_command` to set the id attribute of a reloaded command.
- Modifies `bot.process_application_commands` to check for the command using the name and guilds_ids when the command id isn't set.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
