### PR TITLE
Replace First Argument of Paginator.send to be only Context

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -291,14 +291,14 @@ class Paginator(discord.ui.View):
 
         return self.buttons
 
-    async def send(self, messageable: abc.Messageable, ephemeral: bool = False) -> Union[discord.Message, discord.WebhookMessage]:
+    async def send(self, ctx: Union[ApplicationContext, Context], ephemeral: bool = False) -> Union[discord.Message, discord.WebhookMessage]:
         """Sends a message with the paginated items.
 
 
         Parameters
         ------------
-        messageable: :class:`discord.abc.Messageable`
-            The messageable channel to send to.
+        ctx: Union[:class:`~discord.ext.commands.Context`, :class:`~discord.ApplicationContext`]
+            The invocation context.
         ephemeral: :class:`bool`
             Choose whether the message is ephemeral or not. Only works with slash commands.
 
@@ -308,16 +308,12 @@ class Paginator(discord.ui.View):
             The message that was sent with the paginator.
         """
 
-        if not isinstance(messageable, abc.Messageable):
-            raise TypeError("messageable should be a subclass of abc.Messageable")
-
         page = self.pages[0]
 
-        if isinstance(messageable, (ApplicationContext, Context)):
-            self.user = messageable.author
+        self.user = ctx.author
 
-        if isinstance(messageable, ApplicationContext):
-            msg = await messageable.respond(
+        if isinstance(ctx, ApplicationContext):
+            msg = await ctx.respond(
                 content=page if isinstance(page, str) else None,
                 embed=page if isinstance(page, discord.Embed) else None,
                 view=self,
@@ -325,7 +321,7 @@ class Paginator(discord.ui.View):
             )
 
         else:
-            msg = await messageable.send(
+            msg = await ctx.send(
                 content=page if isinstance(page, str) else None,
                 embed=page if isinstance(page, discord.Embed) else None,
                 view=self,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -298,7 +298,7 @@ class Paginator(discord.ui.View):
         Parameters
         ------------
         ctx: Union[:class:`~discord.ext.commands.Context`, :class:`~discord.ApplicationContext`]
-            The invocation context.
+            A command's invocation context.
         ephemeral: :class:`bool`
             Choose whether the message is ephemeral or not. Only works with slash commands.
 


### PR DESCRIPTION
## Summary

Fixed clear-up on `Paginator.send`'s first parameter. (see #651)

~~I feel like I made an error on the documentation so please double-check thanks~~

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
