### PR TITLE
Fix for error when calling `send_response` property, fix for missing typing imports

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
     from .commands import ApplicationCommand, Option
     from ..cog import Cog
-    from ..webhook import Webhook
+    from ..webhook import WebhookMessage
     from typing import Callable
 
 from ..guild import Guild
@@ -142,7 +142,7 @@ class ApplicationContext(discord.abc.Messageable):
             )
 
     @property
-    def send_response(self) -> Callable[..., Union[Interaction, Webhook]]:
+    def send_response(self) -> Callable[..., Union[Interaction, WebhookMessage]]:
         """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response
         or a followup response depending if the interaction has been responded to yet or not."""
         if not self.response.is_done():

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
     from .commands import ApplicationCommand, Option
     from ..cog import Cog
+    from ..webhook import Webhook
+    from typing import Callable
 
 from ..guild import Guild
 from ..interactions import Interaction, InteractionResponse
@@ -140,7 +142,7 @@ class ApplicationContext(discord.abc.Messageable):
             raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.send_followup() instead.")
 
     @property
-    async def send_response(self) -> Callable[..., Union[Interaction, Webhook]]:
+    def send_response(self) -> Callable[..., Union[Interaction, Webhook]]:
         """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response
         or a followup response depending if the interaction has been responded to yet or not."""
         if not self.response.is_done():

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -45,10 +45,8 @@ from ..message import Message
 from ..user import User
 from ..utils import cached_property
 
-__all__ = (
-    "ApplicationContext",
-    "AutocompleteContext"
-)
+__all__ = ("ApplicationContext", "AutocompleteContext")
+
 
 class ApplicationContext(discord.abc.Messageable):
     """Represents a Discord application command interaction context.
@@ -127,7 +125,7 @@ class ApplicationContext(discord.abc.Messageable):
     def voice_client(self):
         if self.guild is None:
             return None
-        
+
         return self.guild.voice_client
 
     @cached_property
@@ -139,7 +137,9 @@ class ApplicationContext(discord.abc.Messageable):
         if not self.response.is_done():
             return self.interaction.response.send_message
         else:
-            raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.send_followup() instead.")
+            raise RuntimeError(
+                f"Interaction was already issued a response. Try using {type(self).__name__}.send_followup() instead."
+            )
 
     @property
     def send_response(self) -> Callable[..., Union[Interaction, Webhook]]:
@@ -155,7 +155,9 @@ class ApplicationContext(discord.abc.Messageable):
         if self.response.is_done():
             return self.followup.send
         else:
-            raise RuntimeError(f"Interaction was not yet issued a response. Try using {type(self).__name__}.respond() first.")
+            raise RuntimeError(
+                f"Interaction was not yet issued a response. Try using {type(self).__name__}.respond() first."
+            )
 
     @property
     def defer(self):
@@ -182,7 +184,7 @@ class ApplicationContext(discord.abc.Messageable):
         """Optional[:class:`.Cog`]: Returns the cog associated with this context's command. ``None`` if it does not exist."""
         if self.command is None:
             return None
-       
+
         return self.command.cog
 
 
@@ -196,7 +198,7 @@ class AutocompleteContext:
     Attributes
     -----------
     bot: :class:`.Bot`
-        The bot that the command belongs to.    
+        The bot that the command belongs to.
     interaction: :class:`.Interaction`
         The interaction object that invoked the autocomplete.
     command: :class:`.ApplicationCommand`
@@ -210,7 +212,7 @@ class AutocompleteContext:
     """
 
     __slots__ = ("bot", "interaction", "command", "focused", "value", "options")
-    
+
     def __init__(self, bot: Bot, interaction: Interaction) -> None:
         self.bot = bot
         self.interaction = interaction
@@ -225,5 +227,5 @@ class AutocompleteContext:
         """Optional[:class:`.Cog`]: Returns the cog associated with this context's command. ``None`` if it does not exist."""
         if self.command is None:
             return None
-       
+
         return self.command.cog


### PR DESCRIPTION
## Summary

This fixes the following error when calling `ApplicationContext.send_response()` which was introduced in #645:

```py
msg = await ctx.send_response("Test")
```
`discord.commands.errors.ApplicationCommandInvokeError: Application Command raised an exception: TypeError: 'coroutine' object is not callable`

It also adds missing imports for `Callable` and `Webhook` which were added for typing reasons in #645.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
