### PR TITLE
Revert behavior change to ApplicationContext.respond, make send_response and send_followup explicit in their usage

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
     from .commands import ApplicationCommand, Option
     from ..cog import Cog
+    from ..webhook import Webhook
+    from typing import Callable
 
 from ..guild import Guild
 from ..interactions import Interaction, InteractionResponse
@@ -43,10 +45,8 @@ from ..message import Message
 from ..user import User
 from ..utils import cached_property
 
-__all__ = (
-    "ApplicationContext",
-    "AutocompleteContext"
-)
+__all__ = ("ApplicationContext", "AutocompleteContext")
+
 
 class ApplicationContext(discord.abc.Messageable):
     """Represents a Discord application command interaction context.
@@ -125,7 +125,7 @@ class ApplicationContext(discord.abc.Messageable):
     def voice_client(self):
         if self.guild is None:
             return None
-        
+
         return self.guild.voice_client
 
     @cached_property
@@ -133,14 +133,7 @@ class ApplicationContext(discord.abc.Messageable):
         return self.interaction.response
 
     @property
-    def respond(self):
-        if not self.response.is_done():
-            return self.interaction.response.send_message
-        else:
-            raise RuntimeError(f"Interaction was already issued a response. Try using {type(self).__name__}.send_followup() instead.")
-
-    @property
-    async def send_response(self) -> Callable[..., Union[Interaction, Webhook]]:
+    def respond(self) -> Callable[..., Union[Interaction, Webhook]]:
         """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response
         or a followup response depending if the interaction has been responded to yet or not."""
         if not self.response.is_done():
@@ -149,11 +142,22 @@ class ApplicationContext(discord.abc.Messageable):
             return self.followup.send  # self.send_followup
 
     @property
+    def send_response(self):
+        if not self.response.is_done():
+            return self.interaction.response.send_message
+        else:
+            raise RuntimeError(
+                f"Interaction was already issued a response. Try using {type(self).__name__}.send_followup() instead."
+            )
+
+    @property
     def send_followup(self):
         if self.response.is_done():
             return self.followup.send
         else:
-            raise RuntimeError(f"Interaction was not yet issued a response. Try using {type(self).__name__}.respond() first.")
+            raise RuntimeError(
+                f"Interaction was not yet issued a response. Try using {type(self).__name__}.respond() first."
+            )
 
     @property
     def defer(self):
@@ -180,7 +184,7 @@ class ApplicationContext(discord.abc.Messageable):
         """Optional[:class:`.Cog`]: Returns the cog associated with this context's command. ``None`` if it does not exist."""
         if self.command is None:
             return None
-       
+
         return self.command.cog
 
 
@@ -194,7 +198,7 @@ class AutocompleteContext:
     Attributes
     -----------
     bot: :class:`.Bot`
-        The bot that the command belongs to.    
+        The bot that the command belongs to.
     interaction: :class:`.Interaction`
         The interaction object that invoked the autocomplete.
     command: :class:`.ApplicationCommand`
@@ -208,7 +212,7 @@ class AutocompleteContext:
     """
 
     __slots__ = ("bot", "interaction", "command", "focused", "value", "options")
-    
+
     def __init__(self, bot: Bot, interaction: Interaction) -> None:
         self.bot = bot
         self.interaction = interaction
@@ -223,5 +227,5 @@ class AutocompleteContext:
         """Optional[:class:`.Cog`]: Returns the cog associated with this context's command. ``None`` if it does not exist."""
         if self.command is None:
             return None
-       
+
         return self.command.cog

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
     from .commands import ApplicationCommand, Option
     from ..cog import Cog
-    from ..webhook import Webhook
+    from ..webhook import WebhookMessage
     from typing import Callable
 
 from ..guild import Guild
@@ -133,7 +133,7 @@ class ApplicationContext(discord.abc.Messageable):
         return self.interaction.response
 
     @property
-    def respond(self) -> Callable[..., Union[Interaction, Webhook]]:
+    def respond(self) -> Callable[..., Union[Interaction, WebhookMessage]]:
         """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response
         or a followup response depending if the interaction has been responded to yet or not."""
         if not self.response.is_done():


### PR DESCRIPTION
## Summary

This reverts the change made to `ApplicationContext.respond()` in #645, but moves its behavior from that PR to `ApplicationContext.send_response()` instead. This creates a more consistent experience in that both `send_response` and `send_followup` now explicitly do what their method names suggest. 

While `ApplicationContext.respond()` may still be worth renaming, its current naming does make sense from a language point of view in that "responding" to something can consist of a "response" or a "follow-up" - the original context remains the same in both cases.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
