### PR TITLE
[bugfix] Move `ParamSpec` import into `if TYPE_CHECKING`

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -32,7 +32,6 @@ import re
 import types
 from collections import OrderedDict
 from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union, TYPE_CHECKING
-from typing_extensions import ParamSpec
 
 from .context import ApplicationContext, AutocompleteContext
 from .errors import ApplicationCommandError, CheckFailure, ApplicationCommandInvokeError
@@ -63,6 +62,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING: 
+    from typing_extensions import ParamSpec
+
     from ..cog import Cog
     from ..interactions import Interaction
 


### PR DESCRIPTION
## Summary
Fixes an issue in #652 leading to a fatal error when importing `discord`.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
