### PR TITLE
Allow Loop.change_interval to be called in before_loop and after_loop

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -121,6 +121,8 @@ class Loop(Generic[LF]):
 
         self._before_loop = None
         self._after_loop = None
+        self._before_loop_running = False
+        self._after_loop_running = False
         self._is_being_cancelled = False
         self._has_failed = False
         self._stop_next_iteration = False
@@ -141,10 +143,16 @@ class Loop(Generic[LF]):
         if coro is None:
             return
 
+        if name.endswith('_loop'):
+            setattr(self, f'_{name}_running', True)
+
         if self._injected is not None:
             await coro(self._injected, *args, **kwargs)
         else:
             await coro(*args, **kwargs)
+
+        if name.endswith('_loop'):
+            setattr(self, f'_{name}_running', False)
 
     def _try_sleep_until(self, dt: datetime.datetime):
         self._handle = SleepHandle(dt=dt, loop=self.loop)
@@ -680,7 +688,7 @@ class Loop(Generic[LF]):
             self._time = self._get_time_parameter(time)
             self._sleep = self._seconds = self._minutes = self._hours = MISSING
 
-        if self.is_running():
+        if self.is_running() and not (self._before_loop_running or self._after_loop_running):
             if self._time is not MISSING:
                 # prepare the next time index starting from after the last iteration
                 self._prepare_time_index(now=self._last_iteration)


### PR DESCRIPTION
## Summary

Closes #578

The changes made basically makes a new attribute to check if `before_loop` or `after_loop` are running.
Correspondingly, I've named these attributes `_before_loop_running` and `_after_loop_running`.

With this, we can now check if the `before_loop` or `after_loop` functions are currently running :D

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
