### PR TITLE
Make Default Arguments for embed in pages with Interaction as MISSING

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Optional, Union
 
 import discord
 from discord import abc
+from discord.utils import MISSING
 from discord.commands import ApplicationContext
 from discord.ext.commands import Context
 
@@ -200,7 +201,7 @@ class Paginator(discord.ui.View):
         self.update_buttons()
         page = self.pages[page_number]
         await interaction.response.edit_message(
-            content=page if isinstance(page, str) else None, embed=page if isinstance(page, discord.Embed) else None, view=self
+            content=page if isinstance(page, str) else None, embed=page if isinstance(page, discord.Embed) else MISSING, view=self
         )
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -315,7 +316,7 @@ class Paginator(discord.ui.View):
         if isinstance(ctx, ApplicationContext):
             msg = await ctx.respond(
                 content=page if isinstance(page, str) else None,
-                embed=page if isinstance(page, discord.Embed) else None,
+                embed=page if isinstance(page, discord.Embed) else MISSING,
                 view=self,
                 ephemeral=ephemeral,
             )
@@ -354,12 +355,12 @@ class Paginator(discord.ui.View):
 
         if interaction.response.is_done():
             msg = await interaction.followup.send(
-                content=page if isinstance(page, str) else None, embed=page if isinstance(page, discord.Embed) else None, view=self, ephemeral=ephemeral
+                content=page if isinstance(page, str) else None, embed=page if isinstance(page, discord.Embed) else MISSING, view=self, ephemeral=ephemeral
             )
 
         else:
             msg = await interaction.response.send_message(
-                content=page if isinstance(page, str) else None, embed=page if isinstance(page, discord.Embed) else None, view=self, ephemeral=ephemeral
+                content=page if isinstance(page, str) else None, embed=page if isinstance(page, discord.Embed) else MISSING, view=self, ephemeral=ephemeral
             )
         if isinstance(msg, (discord.WebhookMessage, discord.Message)):
             self.message = msg


### PR DESCRIPTION
## Summary

So I was just randomly helping people in help channels until I stumbled upon [someone asking for help about a weird, internal error](https://discord.com/channels/881207955029110855/881309496385884180/925693314123067392).

Of course, I tried to reproduce it. I did not get that rather odd error, but instead, I got a different one.
```
Ignoring exception in command <discord.commands.SlashCommand name=pager>:
Traceback (most recent call last):
  File ".../pycord/discord/commands/commands.py", line 95, in wrapped
    ret = await coro(arg)
  File ".../pycord/discord/commands/commands.py", line 552, in _invoke
    await self.callback(self.cog, ctx, **kwargs)
  File "test.py", line 26, in pager
    await paginator.send(ctx, ephemeral=False)
  File ".../pycord/discord/ext/pages/pagination.py", line 316, in send
    msg = await ctx.respond(
  File ".../pycord/discord/interactions.py", line 571, in send_message
    payload['embeds'] = [e.to_dict() for e in embeds]
  File ".../pycord/discord/interactions.py", line 571, in <listcomp>
    payload['embeds'] = [e.to_dict() for e in embeds]
AttributeError: 'NoneType' object has no attribute 'to_dict'
```

Here's the Minimal Reproducible Code:
```py
from discord.ext import commands


class PageTest(commands.Cog):
    def __init__(self, bot):
        self.bot = bot

    @slash_command(guild_ids=[...])
    async def pager(self, ctx):
        paginator = pages.Paginator(
            pages=["Page One", "Page Two", "Page Three"],
            show_disabled=False,
            show_indicator=True
        )
        await paginator.send(ctx, ephemeral=False)

bot.add_cog(PageTest(bot))
```

This PR fixes that specific error.
(read the title of this PR for the "specifics" of what I changed)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
