### PR TITLE
Application commands followup fix

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -259,8 +259,6 @@ class ApplicationCommandMixin:
                 }.items():
                     if key == "options":
                         for i, option_dict in enumerate(as_dict[key]):
-                            if command.name == "recent":
-                                print(option_dict, "|||||", match[key][i])
                             for key2 in more_keys:
                                 pendingVal = None
                                 if key2 in option_dict.keys():

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -253,13 +253,13 @@ class ApplicationCommandMixin:
             7: default_props_choice,
             8: default_props_choice,
             9: default_props_choice,
-            10: default_props_choice
+            10: default_props_choice,
         }
         missing_props_cmd = {
             # specific to type: 1 - 3 app command types
             1: default_props_cmd_type,
             2: default_props_cmd_type,
-            3: default_props_cmd_type
+            3: default_props_cmd_type,
         }
 
         def fill_missing_props(layer, command):
@@ -332,7 +332,11 @@ class ApplicationCommandMixin:
 
         await self.register_commands(commands_to_bulk, needs_update)
 
-    async def register_commands(self, commands, needs_update) -> None:
+    async def register_commands(
+        self,
+        commands: List[ApplicationCommand],
+        needs_update: bool = False,
+    ) -> None:
         """|coro|
         Registers all global commands in :list:`commands` if :bool:`needs_update` is true
         and guild commands that have been added through :meth:`.add_application_command`.
@@ -342,7 +346,7 @@ class ApplicationCommandMixin:
 
         Parameters
         -----------
-        commands: :list:
+        commands: List[:class:`.ApplicationCommand`]
             A bulk list of global commands to upsert
         """
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This is a follow-up of pull request #634 which was to fix the issue of Pycord bulk upserting global commands every single time the bot was started. This pull request is a follow-up for it to fix the issue of subcommands causing an error in the `register_commands` method.

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
