### PR TITLE
Type-hinted, un typehinted dunder methods

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -132,10 +132,10 @@ class Permissions(BaseFlags):
         """Returns ``True`` if the permissions on other are a strict superset of those on self."""
         return self.is_superset(other) and self != other
 
-    __le__ = is_subset
-    __ge__ = is_superset
-    __lt__ = is_strict_subset
-    __gt__ = is_strict_superset
+    __le__: Callable[[Permissions], bool] = is_subset
+    __ge__: Callable[[Permissions], bool] = is_superset
+    __lt__: Callable[[Permissions], bool] = is_strict_subset
+    __gt__: Callable[[Permissions], bool] = is_strict_superset
 
     @classmethod
     def none(cls: Type[P]) -> P:


### PR DESCRIPTION
## Summary
Type hints some non-typehinted dunder methods in `permissions.py`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
