### PR TITLE
Treating None embeds and views as not having embeds and views in send_message

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -562,7 +562,7 @@ class InteractionResponse:
         if embed is not MISSING and embeds is not MISSING:
             raise TypeError('cannot mix embed and embeds keyword arguments')
 
-        if embed is not MISSING:
+        if embed is not MISSING and embed is not None:
             embeds = [embed]
 
         if embeds:
@@ -576,7 +576,7 @@ class InteractionResponse:
         if ephemeral:
             payload['flags'] = 64
 
-        if view is not MISSING:
+        if view is not MISSING and view is not None:
             payload['components'] = view.to_components()
 
         state = self._parent._state
@@ -620,7 +620,7 @@ class InteractionResponse:
                 for file in files:
                     file.close()
 
-        if view is not MISSING:
+        if view is not MISSING and view is not None:
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 


### PR DESCRIPTION
## Summary

When you call `ctx.respond` (sending messages, not editing them) and other similar methods, you currently have to put them in an if block to decide whether to include embeds and/or views. With this PR, they'll be able to correctly handle a None, allowing usage of a variable or ternary expression. For instance,

```python
if msg != NO_REMINDERS_MESSAGE:
    view =MyView()
    await ctx.respond(msg, view=view, ephemeral=True)
else:
    await ctx.respond(msg, ephemeral=True)
```

can now be simplified to:

```python
view = None if msg == NO_REMINDERS_MESSAGE else MyView()
await ctx.respond(msg, view=view, ephemeral=True)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why (N/A)
- [x] This PR fixes an issue. (Debatable)
- [x] This PR adds something new (e.g. new method or parameters).  (Debatable)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
