### PR TITLE
Fix Permission->CommandPermission rename for ContextMenuCommand

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -948,7 +948,7 @@ class ContextMenuCommand(ApplicationCommand):
         The ids of the guilds where this command will be registered.
     default_permission: :class:`bool`
         Whether the command is enabled by default when it is added to a guild.
-    permissions: List[:class:`.Permission`]
+    permissions: List[:class:`.CommandPermission`]
         The permissions for this command.
 
         .. note::

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -999,7 +999,7 @@ class ContextMenuCommand(ApplicationCommand):
         self.validate_parameters()
 
         self.default_permission = kwargs.get("default_permission", True)
-        self.permissions: List[Permission] = getattr(func, "__app_cmd_perms__", []) + kwargs.get("permissions", [])
+        self.permissions: List[CommandPermission] = getattr(func, "__app_cmd_perms__", []) + kwargs.get("permissions", [])
         if self.permissions and self.default_permission:
             self.default_permission = False
 


### PR DESCRIPTION
## Summary

This adds the changes from #662 into the changes made in #631 by updating `Permission` to `CommandPermission` in the `ContextMenuCommand` class.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
