### PR TITLE
discord: client: Ignore RuntimeError when calling add_signal_handler()

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -639,7 +639,7 @@ class Client:
         try:
             loop.add_signal_handler(signal.SIGINT, lambda: loop.stop())
             loop.add_signal_handler(signal.SIGTERM, lambda: loop.stop())
-        except NotImplementedError:
+        except (NotImplementedError, RuntimeError):
             pass
 
         async def runner():


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
* When Client.run() is called in a new thread (using threading.Thread), add_signal_handler will raise the following exception:
* RuntimeError: set_wakeup_fd only works in main thread of the main interpreter
* We can ignore this as well

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
