### PR TITLE
Cooldowns and max concurrency for application commands

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -154,7 +154,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
     def _prepare_cooldowns(self, ctx: ApplicationContext):
         if self._buckets.valid:
             current = datetime.datetime.now().timestamp()
-            bucket = self._buckets.get_bucket(ctx, current)  # type: ignore (ctx instead of non-existant message)
+            bucket = self._buckets.get_bucket(ctx, current)  # type: ignore (ctx instead of non-existent message)
 
             if bucket is not None:
                 retry_after = bucket.update_rate_limit(current)
@@ -172,14 +172,14 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
 
         if self._max_concurrency is not None:
             # For this application, context can be duck-typed as a Message
-            await self._max_concurrency.acquire(ctx)  # type: ignore (ctx instead of non-existant message)
+            await self._max_concurrency.acquire(ctx)  # type: ignore (ctx instead of non-existent message)
 
         try:
             self._prepare_cooldowns(ctx)
             await self.call_before_hooks(ctx)
         except:
             if self._max_concurrency is not None:
-                await self._max_concurrency.release(ctx)  # type: ignore (ctx instead of non-existant message)
+                await self._max_concurrency.release(ctx)  # type: ignore (ctx instead of non-existent message)
             raise
 
     def reset_cooldown(self, ctx: ApplicationContext) -> None:
@@ -191,7 +191,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             The invocation context to reset the cooldown under.
         """
         if self._buckets.valid:
-            bucket = self._buckets.get_bucket(ctx)  # type: ignore (ctx instead of non-existant message)
+            bucket = self._buckets.get_bucket(ctx)  # type: ignore (ctx instead of non-existent message)
             bucket.reset()
 
     async def invoke(self, ctx: ApplicationContext) -> None:

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -356,6 +356,10 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             await hook(ctx)
 
     @property
+    def cooldown(self):
+        return self._buckets._cooldown
+
+    @property
     def full_parent_name(self) -> str:
         """:class:`str`: Retrieves the fully qualified parent command name.
 
@@ -427,6 +431,11 @@ class SlashCommand(ApplicationCommand):
         :exc:`.CommandError` should be used. Note that if the checks fail then
         :exc:`.CheckFailure` exception is raised to the :func:`.on_application_command_error`
         event.
+    cooldown: Optional[:class:`~discord.ext.commands.Cooldown`]
+        The cooldown applied when the command is invoked. ``None`` if the command
+        doesn't have a cooldown.
+
+        .. versionadded:: 2.0
     """
     type = 1
 
@@ -1012,6 +1021,11 @@ class ContextMenuCommand(ApplicationCommand):
         :exc:`.CommandError` should be used. Note that if the checks fail then
         :exc:`.CheckFailure` exception is raised to the :func:`.on_application_command_error`
         event.
+    cooldown: Optional[:class:`~discord.ext.commands.Cooldown`]
+        The cooldown applied when the command is invoked. ``None`` if the command
+        doesn't have a cooldown.
+
+        .. versionadded:: 2.0
     """
     def __new__(cls, *args, **kwargs) -> ContextMenuCommand:
         self = super().__new__(cls)

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -2153,7 +2153,7 @@ def is_nsfw() -> Callable[[T], T]:
     return check(pred)
 
 def cooldown(rate: int, per: float, type: Union[BucketType, Callable[[Message], Any]] = BucketType.default) -> Callable[[T], T]:
-    """A decorator that adds a cooldown to a :class:`.Command`
+    """A decorator that adds a cooldown to a command
 
     A cooldown allows a command to only be used a specific amount
     of times in a specific time frame. These cooldowns can be based
@@ -2188,7 +2188,7 @@ def cooldown(rate: int, per: float, type: Union[BucketType, Callable[[Message], 
     return decorator  # type: ignore
 
 def dynamic_cooldown(cooldown: Union[BucketType, Callable[[Message], Any]], type: BucketType = BucketType.default) -> Callable[[T], T]:
-    """A decorator that adds a dynamic cooldown to a :class:`.Command`
+    """A decorator that adds a dynamic cooldown to a command
 
     This differs from :func:`.cooldown` in that it takes a function that
     accepts a single parameter of type :class:`.discord.Message` and must
@@ -2228,7 +2228,7 @@ def dynamic_cooldown(cooldown: Union[BucketType, Callable[[Message], Any]], type
     return decorator  # type: ignore
 
 def max_concurrency(number: int, per: BucketType = BucketType.default, *, wait: bool = False) -> Callable[[T], T]:
-    """A decorator that adds a maximum concurrency to a :class:`.Command` or its subclasses.
+    """A decorator that adds a maximum concurrency to a command
 
     This enables you to only allow a certain number of command invocations at the same time,
     for example if a command takes too long or if only one user can use it at a time. This

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -53,7 +53,13 @@ from .errors import *
 from ...errors import *
 from .cooldowns import Cooldown, BucketType, CooldownMapping, MaxConcurrency, DynamicCooldownMapping
 from .converter import run_converters, get_converter, Greedy
-from ...commands import _BaseCommand, slash_command, user_command, message_command
+from ...commands import (
+    ApplicationCommand,
+    _BaseCommand,
+    slash_command,
+    user_command,
+    message_command,
+)
 from .cog import Cog
 from .context import Context
 
@@ -2174,7 +2180,7 @@ def cooldown(rate: int, per: float, type: Union[BucketType, Callable[[Message], 
     """
 
     def decorator(func: Union[Command, CoroFunc]) -> Union[Command, CoroFunc]:
-        if isinstance(func, Command):
+        if isinstance(func, (Command, ApplicationCommand)):
             func._buckets = CooldownMapping(Cooldown(rate, per), type)
         else:
             func.__commands_cooldown__ = CooldownMapping(Cooldown(rate, per), type)
@@ -2247,7 +2253,7 @@ def max_concurrency(number: int, per: BucketType = BucketType.default, *, wait: 
 
     def decorator(func: Union[Command, CoroFunc]) -> Union[Command, CoroFunc]:
         value = MaxConcurrency(number, per=per, wait=wait)
-        if isinstance(func, Command):
+        if isinstance(func, (Command, ApplicationCommand)):
             func._max_concurrency = value
         else:
             func.__commands_max_concurrency__ = value


### PR DESCRIPTION
## Summary
A replacement for #458 that doesn't move cooldowns out of ext.commands.
Also allows using max concurrency with application commands.
Tested with a guild user command and a guild slash command.
Closes #266 and #453.

## Checklist
- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)