### PR TITLE
Fix for missing self.name/self.description in SlashCommandGroup

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -855,6 +855,8 @@ class SlashCommandGroup(ApplicationCommand, Option):
             name=name,
             description=description,
         )
+        self.name = name
+        self.description = description
         self.subcommands: List[Union[SlashCommand, SlashCommandGroup]] = self.__initial_commands__
         self.guild_ids = guild_ids
         self.parent = parent


### PR DESCRIPTION
## Summary

This adds self.name and self.description to `SlashCommandGroup` which are needed as of commit 67f1e139 (though I'm not entirely sure **why**).

Closes #675 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
