### PR TITLE
`OptionChoice` Bug Fix

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -773,7 +773,7 @@ class Option:
 class OptionChoice:
     def __init__(self, name: str, value: Optional[Union[str, int, float]] = None):
         self.name = name
-        self.value = value or name
+        self.value = value if value is not None else name
 
     def to_dict(self) -> Dict[str, Union[str, int, float]]:
         return {"name": self.name, "value": self.value}
@@ -857,6 +857,7 @@ class SlashCommandGroup(ApplicationCommand, Option):
         )
         self.name = name
         self.description = description
+        self.input_type = SlashCommandOptionType.sub_command_group
         self.subcommands: List[Union[SlashCommand, SlashCommandGroup]] = self.__initial_commands__
         self.guild_ids = guild_ids
         self.parent = parent


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
~~Adds `input_type` to `SlashCommandGroup` (Kind of adds on to #676)~~ Fixed in https://github.com/Pycord-Development/pycord/commit/f9e58a51d6a64f0891a5c7370bd1cea2610fde30

Fixed a bug in `OptionChoice` where you couldn't provide a false value (such as `0`) to `value`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
