### PR TITLE
Fix: Fix discord.errors not working

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -60,7 +60,7 @@ from .interactions import *
 from .components import *
 from .threads import *
 from .bot import *
-from .commands import *
+from .commands.__init__ import *
 from .cog import Cog
 from .welcome_screen import *
 from .scheduled_events import ScheduledEvent, ScheduledEventLocation


### PR DESCRIPTION
## Summary

It fixes `discord.errors.XXX` not working.
Currently, `discord.errors` is overridden by `discord.commands.errors` because of `from .commands import *`.
So I changed to `from .commands.__init__ import *`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
