### PR TITLE
Prepare `Client.loop` for Python 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ __pycache__
 .vs/slnx.sqlite
 env/
 build/
+test.py

--- a/discord/client.py
+++ b/discord/client.py
@@ -113,7 +113,7 @@ def _cleanup_loop(loop: asyncio.AbstractEventLoop) -> None:
         loop.close()
 
 
-def get_event_loop():
+def get_event_loop() -> asyncio.AbstractEventLoop:
     running_loop = events._get_running_loop()
     if running_loop is not None:
         return running_loop


### PR DESCRIPTION
## Summary
This pr adds a new function called `get_event_loop` because Python 3.11 will remove `asyncio.get_event_loop()` this will fix that.

This idea was suggested in the py-cord server.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
