### PR TITLE
Fix groups

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -618,7 +618,7 @@ class ApplicationCommandMixin:
 
     def group(
         self,
-        name: str,
+        name: Optional[str] = None,
         description: Optional[str] = None,
         guild_ids: Optional[List[int]] = None,
     ) -> Callable[[Type[SlashCommandGroup]], SlashCommandGroup]:
@@ -629,8 +629,8 @@ class ApplicationCommandMixin:
 
         Parameters
         ----------
-        name: :class:`str`
-            The name of the group to create.
+        name: Optional[:class:`str`]
+            The name of the group to create. This will resolve to the name of the decorated class if ``None`` is passed.
         description: Optional[:class:`str`]
             The description of the group to create.
         guild_ids: Optional[List[:class:`int`]]
@@ -644,7 +644,7 @@ class ApplicationCommandMixin:
         """
         def inner(cls: Type[SlashCommandGroup]) -> SlashCommandGroup:
             group = cls(
-                name,
+                name or cls.__name__,
                 (
                     description or inspect.cleandoc(cls.__doc__).splitlines()[0]
                     if cls.__doc__ is not None else "No description provided"

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -904,8 +904,8 @@ class SlashCommandGroup(ApplicationCommand, Option):
 
     def subgroup(
         self,
-        name: str,
-        description: str = None, 
+        name: Optional[str] = None,
+        description: Optional[str] = None,
         guild_ids: Optional[List[int]] = None,
     ) -> Callable[[Type[SlashCommandGroup]], SlashCommandGroup]:
         """A shortcut decorator that initializes the provided subclass of :class:`.SlashCommandGroup`
@@ -915,8 +915,8 @@ class SlashCommandGroup(ApplicationCommand, Option):
 
         Parameters
         ----------
-        name: :class:`str`
-            The name of the group to create.
+        name: Optional[:class:`str`]
+            The name of the group to create. This will resolve to the name of the decorated class if ``None`` is passed.
         description: Optional[:class:`str`]
             The description of the group to create.
         guild_ids: Optional[List[:class:`int`]]
@@ -930,7 +930,7 @@ class SlashCommandGroup(ApplicationCommand, Option):
         """
         def inner(cls: Type[SlashCommandGroup]) -> SlashCommandGroup:
             group = cls(
-                name,
+                name or cls.__name__,
                 description or (
                     inspect.cleandoc(cls.__doc__).splitlines()[0]
                     if cls.__doc__ is not None
@@ -997,7 +997,6 @@ class SlashCommandGroup(ApplicationCommand, Option):
         self.cog = cog
         for subcommand in self.subcommands:
             subcommand._set_cog(cog)
-        
 
 
 class ContextMenuCommand(ApplicationCommand):

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -787,7 +787,7 @@ def option(name, type=None, **kwargs):
         return func
     return decor
 
-class SlashCommandGroup(ApplicationCommand, Option):
+class SlashCommandGroup(ApplicationCommand):
     r"""A class that implements the protocol for a slash command group.
 
     These can be created manually, but they should be created via the
@@ -850,13 +850,9 @@ class SlashCommandGroup(ApplicationCommand, Option):
     ) -> None:
         validate_chat_input_name(name)
         validate_chat_input_description(description)
-        super().__init__(
-            SlashCommandOptionType.sub_command_group,
-            name=name,
-            description=description,
-        )
         self.name = name
         self.description = description
+        self.input_type = SlashCommandOptionType.sub_command_group
         self.subcommands: List[Union[SlashCommand, SlashCommandGroup]] = self.__initial_commands__
         self.guild_ids = guild_ids
         self.parent = parent


### PR DESCRIPTION
## Summary
Fixes issues with groups.
- Allows not passing the name argument of the bot.group decorator.
- Fixes an error with groups not having cooldown/max concurrency attributes.
- Makes Group not inherit from Option since the required attributes are being set now.

## Checklist
- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)