### PR TITLE
Made `qualified_name` A Property For Application Commands

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -375,6 +375,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
 
         return ' '.join(reversed(entries))
 
+    @property
     def qualified_name(self) -> str:
         """:class:`str`: Retrieves the fully qualified command name.
 
@@ -1110,6 +1111,7 @@ class ContextMenuCommand(ApplicationCommand):
         except StopIteration:
             pass
 
+    @property
     def qualified_name(self):
         return self.name
 


### PR DESCRIPTION
## Summary

I will shoot myself in the head if this was intentional

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
