### PR TITLE
Fix `ApplicationCommand.__eq__`

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -138,8 +138,19 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
     def __repr__(self):
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__)
+    def __eq__(self, other) -> bool:
+        if hasattr(self, "id") and hasattr(other, "id"):
+            check = self.id == other.id
+        else:
+            check = (
+                self.name == other.name
+                and self.guild_ids == self.guild_ids
+            )
+        return (
+            isinstance(other, self.__class__)
+            and self.parent == other.parent
+            and check
+        )
 
     async def __call__(self, ctx, *args, **kwargs):
         """|coro|
@@ -573,13 +584,6 @@ class SlashCommand(ApplicationCommand):
             as_dict["type"] = SlashCommandOptionType.sub_command.value
 
         return as_dict
-
-    def __eq__(self, other) -> bool:
-        return (
-            isinstance(other, SlashCommand)
-            and other.name == self.name
-            and other.description == self.description
-        )
 
     async def _invoke(self, ctx: ApplicationContext) -> None:
         # TODO: Parse the args better


### PR DESCRIPTION
## Summary
Fixes a new issue caused by two different commands being seen as the same.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
