### PR TITLE
Change `get_commands()` to `get_application_commands`

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -242,7 +242,7 @@ class Cog(metaclass=CogMeta):
 
         return self
 
-    def get_commands(self) -> List[ApplicationCommand]:
+    def get_application_commands(self) -> List[ApplicationCommand]:
         r"""
         Returns
         --------


### PR DESCRIPTION
`get_application_commands()` is better name than `get_commands()` for only application commands, rather than mixing between `Command` with `ApplicationCommand`

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
