### PR TITLE
Fixes #704

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -130,8 +130,7 @@ class ApplicationCommandMixin:
                 command.id = cmd.id
                 self._application_commands[command.id] = command
                 break
-        else:
-            self._pending_application_commands.append(command)
+        self._pending_application_commands.append(command)
 
     def remove_application_command(
         self, command: ApplicationCommand


### PR DESCRIPTION
## Summary

When the break triggers, the else doesn't execute which prevents the slash command from being added

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
