### PR TITLE
Add Thread As A Slash Command Option

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -700,7 +700,8 @@ channel_type_map = {
     'TextChannel': ChannelType.text,
     'VoiceChannel': ChannelType.voice,
     'StageChannel': ChannelType.stage_voice,
-    'CategoryChannel': ChannelType.category
+    'CategoryChannel': ChannelType.category,
+    'Thread': ChannelType.public_thread
 }
 
 class ThreadOption:

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -648,7 +648,8 @@ class SlashCommandOptionType(Enum):
         if datatype.__name__ in [
             "GuildChannel", "TextChannel",
             "VoiceChannel", "StageChannel",
-            "CategoryChannel", "ThreadOption"
+            "CategoryChannel", "ThreadOption",
+            'Thread'
         ]:
             return cls.channel
         if datatype.__name__ == "Role":

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -643,6 +643,19 @@ class SlashCommandOptionType(Enum):
             else:
                 raise TypeError('Invalid usage of typing.Union')
 
+        if datatype.__name__ in ["Member", "User"]:
+            return cls.user
+        if datatype.__name__ in [
+            "GuildChannel", "TextChannel",
+            "VoiceChannel", "StageChannel",
+            "CategoryChannel", "ThreadOption"
+        ]:
+            return cls.channel
+        if datatype.__name__ == "Role":
+            return cls.role
+        if datatype.__name__ == "Mentionable":
+            return cls.mentionable
+
         if issubclass(datatype, str):
             return cls.string
         if issubclass(datatype, bool):
@@ -651,19 +664,6 @@ class SlashCommandOptionType(Enum):
             return cls.integer
         if issubclass(datatype, float):
             return cls.number
-
-        if datatype.__name__ in ["Member", "User"]:
-            return cls.user
-        if datatype.__name__ in [
-            "GuildChannel", "TextChannel",
-            "VoiceChannel", "StageChannel",
-            "CategoryChannel"
-        ]:
-            return cls.channel
-        if datatype.__name__ == "Role":
-            return cls.role
-        if datatype.__name__ == "Mentionable":
-            return cls.mentionable
 
         # TODO: Improve the error message
         raise TypeError(f'Invalid class {datatype} used as an input type for an Option')


### PR DESCRIPTION
## Summary

Closes #480.

You use the new `ThreadOption` like this:
```py
Option(ThreadOption("'public', 'private' or 'news'"), ...)
```
BTW the default channel type for `discord.Thread` is the public thread type.

May need some feedback on ~~everything~~ `ThreadOption`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
