### PR TITLE
Implemented attachments in Webhook.edit_message and WebhookMessage.edit

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -823,6 +823,7 @@ class InteractionMessage(Message):
         embed: Optional[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
         delete_after: Optional[float] = None,
@@ -845,6 +846,9 @@ class InteractionMessage(Message):
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all attachments are removed.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -872,12 +876,15 @@ class InteractionMessage(Message):
         :class:`InteractionMessage`
             The newly edited message.
         """
+        if attachments is MISSING:
+            attachments = self.attachments or MISSING
         return await self._state._interaction.edit_original_message(
             content=content,
             embeds=embeds,
             embed=embed,
             file=file,
             files=files,
+            attachments=attachments,
             view=view,
             allowed_mentions=allowed_mentions,
             delete_after=delete_after

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -278,6 +278,7 @@ class Interaction:
         embed: Optional[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
         delete_after: Optional[float] = None,
@@ -306,6 +307,9 @@ class Interaction:
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all attachments are removed.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -339,6 +343,7 @@ class Interaction:
             content=content,
             file=file,
             files=files,
+            attachments=attachments,
             embed=embed,
             embeds=embeds,
             view=view,

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -40,7 +40,7 @@ import aiohttp
 from .. import utils
 from ..object import Object
 from ..errors import InvalidArgument, HTTPException, Forbidden, NotFound, DiscordServerError
-from ..message import Message
+from ..message import Attachment, Message
 from ..enums import try_enum, WebhookType
 from ..user import BaseUser, User
 from ..asset import Asset
@@ -468,6 +468,7 @@ def handle_message_parameters(
     ephemeral: bool = False,
     file: File = MISSING,
     files: List[File] = MISSING,
+    attachments: List[Attachment] = MISSING,
     embed: Optional[Embed] = MISSING,
     embeds: List[Embed] = MISSING,
     view: Optional[View] = MISSING,
@@ -497,6 +498,9 @@ def handle_message_parameters(
         else:
             payload['content'] = None
 
+    if attachments is not MISSING:
+        payload['attachments'] = [a.to_dict() for a in attachments]
+    
     if view is not MISSING:
         if view is not None:
             payload['components'] = view.to_components()
@@ -683,6 +687,7 @@ class WebhookMessage(Message):
         embed: Optional[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> WebhookMessage:
@@ -712,6 +717,11 @@ class WebhookMessage(Message):
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
 
+            .. versionadded:: 2.0
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all attachments are removed.
+            
             .. versionadded:: 2.0
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
@@ -753,6 +763,7 @@ class WebhookMessage(Message):
             embed=embed,
             file=file,
             files=files,
+            attachments=attachments,
             view=view,
             allowed_mentions=allowed_mentions,
             thread=thread
@@ -1527,6 +1538,7 @@ class Webhook(BaseWebhook):
         embed: Optional[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
         thread: Optional[Snowflake] = MISSING
@@ -1554,6 +1566,9 @@ class Webhook(BaseWebhook):
         embed: Optional[:class:`Embed`]
             The embed to edit the message with. ``None`` suppresses the embeds.
             This should not be mixed with the ``embeds`` parameter.
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all attachments are removed.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
 
@@ -1609,6 +1624,7 @@ class Webhook(BaseWebhook):
             content=content,
             file=file,
             files=files,
+            attachments=attachments,
             embed=embed,
             embeds=embeds,
             view=view,

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -756,6 +756,9 @@ class WebhookMessage(Message):
         elif isinstance(self.channel, Thread):
             thread = Object(self.channel.id)
 
+        if attachments is MISSING:
+            attachments = self.attachments or MISSING
+
         return await self._state._webhook.edit_message(
             self.id,
             content=content,


### PR DESCRIPTION
## Summary

This allows webhooks to be able to edit attachments according to the implementation in [Discord's documentation](https://discord.com/developers/docs/resources/webhook#edit-webhook-message-jsonform-params)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
