### PR TITLE
Convert id to an int

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -127,7 +127,7 @@ class ApplicationCommandMixin:
 
         for cmd in self.pending_application_commands:
             if cmd == command:
-                command.id = cmd.id
+                command.id = int(cmd.id)
                 self._application_commands[command.id] = command
                 break
         self._pending_application_commands.append(command)


### PR DESCRIPTION
## Summary
I made this pull request because even though api returns a string, in all the other classes that were made by Danny, the string IDs were also converted to INTs.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
