### PR TITLE
Automatically set discord.Option.required to False if possible

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -730,12 +730,12 @@ class Option:
                         self.channel_types.append(channel_type)
                 input_type = _type
         self.input_type = input_type
-        self.required: bool = kwargs.pop("required", True)
+        self.default = kwargs.pop("default", None)
+        self.required: bool = kwargs.pop("required", True) if self.default is None else False
         self.choices: List[OptionChoice] = [
             o if isinstance(o, OptionChoice) else OptionChoice(o)
             for o in kwargs.pop("choices", list())
         ]
-        self.default = kwargs.pop("default", None)
 
         if self.input_type == SlashCommandOptionType.integer:
             minmax_types = (int, type(None))


### PR DESCRIPTION
## Summary
If `discord.Option` with default value was created automatically set `required` attribute to `None`. Overwise user can specify it manually using `required=True/False`.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
