### PR TITLE
Add extras attribute to ApplicationCommand class

### DIFF
--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -730,12 +730,12 @@ class Option:
                         self.channel_types.append(channel_type)
                 input_type = _type
         self.input_type = input_type
-        self.required: bool = kwargs.pop("required", True)
+        self.default = kwargs.pop("default", None)
+        self.required: bool = kwargs.pop("required", True) if self.default is None else False
         self.choices: List[OptionChoice] = [
             o if isinstance(o, OptionChoice) else OptionChoice(o)
             for o in kwargs.pop("choices", list())
         ]
-        self.default = kwargs.pop("default", None)
 
         if self.input_type == SlashCommandOptionType.integer:
             minmax_types = (int, type(None))

--- a/discord/commands/commands.py
+++ b/discord/commands/commands.py
@@ -136,6 +136,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             max_concurrency = kwargs.get('max_concurrency')
 
         self._max_concurrency: Optional[MaxConcurrency] = max_concurrency
+        self.extras: Dict[str, Any] = kwargs.get('extras', {})
 
     def __repr__(self):
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"


### PR DESCRIPTION
## Summary
Added `extras` attribute (like for message commands) to `discord.ApplicationCommand` class. It's allow users to store their custom data. Useful when creating help command for more information.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
