### PR TITLE
[ext.pages] Fix missing current_page assignment, add page indicator update in goto_page

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -380,6 +380,12 @@ class Paginator(discord.ui.View):
             The message associated with the paginator.
         """
         self.update_buttons()
+        self.current_page = page_number
+        if self.show_indicator:
+            self.buttons["page_indicator"][
+                "object"
+            ].label = f"{self.current_page + 1}/{self.page_count + 1}"
+
         page = self.pages[page_number]
         page = self.get_page_content(page)
 


### PR DESCRIPTION
## Summary

This adds the missing `current_page` assignment in `goto_page()`, and also adds functionality to update the page indicator (if displayed) when `goto_page()` is used.

Closes #741 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
