### PR TITLE
[ext.pages] Fix Paginator.update() example

### DIFF
--- a/docs/ext/pages/index.rst
+++ b/docs/ext/pages/index.rst
@@ -227,9 +227,7 @@ Example usage in a cog:
             paginator = pages.Paginator(pages=self.get_pages(), show_disabled=False)
             await paginator.respond(ctx.interaction)
             await asyncio.sleep(3)
-            await paginator.update(
-                ctx.interaction, show_disabled=True, show_indicator=False
-            )
+            await paginator.update(show_disabled=True, show_indicator=False)
 
         @pagetest.command(name="target")
         async def pagetest_target(self, ctx: discord.ApplicationContext):

--- a/examples/views/paginator.py
+++ b/examples/views/paginator.py
@@ -216,9 +216,7 @@ class PageTest(commands.Cog):
         paginator = pages.Paginator(pages=self.get_pages(), show_disabled=False)
         await paginator.respond(ctx.interaction)
         await asyncio.sleep(3)
-        await paginator.update(
-            ctx.interaction, show_disabled=True, show_indicator=False
-        )
+        await paginator.update(show_disabled=True, show_indicator=False)
 
     @pagetest.command(name="target")
     async def pagetest_target(self, ctx: discord.ApplicationContext):


### PR DESCRIPTION
## Summary

This fixes the example for `Paginator.update()` by removing the old reference to ctx.interaction.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
