### PR TITLE
Improving a sentence in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The following is a set of guidelines for contributing to the repository. These a
 Generally speaking questions are better suited in our resources below.
 
 - The official support server: https://discord.gg/UCXwPR7Pew
-- The Discord API server under #python_discord-py: https://discord.gg/discord-api
+- The #python_discord-py channel in the Discord API server: https://discord.gg/discord-api
 - [The FAQ in the documentation](https://docs.pycord.dev/en/master/faq.html)
 - [StackOverflow's `pycord` tag](https://stackoverflow.com/questions/tagged/pycord)
 


### PR DESCRIPTION
The original sentence was incorrect because the Discord API server is not *under* #python_discord-py, rather it is the other way around.

## Summary

This PR fixes a sentence grammatically in CONTRIBUTING.md

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
