### PR TITLE
chore: bump version to `2.0.0-rc.1`

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -13,7 +13,7 @@ __title__ = 'discord'
 __author__ = 'Pycord Development'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2021 Rapptz & Copyright 2021-present Pycord Development'
-__version__ = '2.0.0a'
+__version__ = '2.0.0'
 
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
@@ -74,6 +74,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel='alpha', serial=0)
+version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel='final', serial=0)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -13,7 +13,7 @@ __title__ = 'discord'
 __author__ = 'Pycord Development'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2021 Rapptz & Copyright 2021-present Pycord Development'
-__version__ = '2.0.0'
+__version__ = '2.0.0-rc.1'
 
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
@@ -74,6 +74,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel='final', serial=0)
+version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel='candidate', serial=0)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -74,6 +74,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel='candidate', serial=0)
+version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel='candidate', serial=1)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
## Summary

Bumps version from alpha to a release candidate as bob wanted.
**not to be merged until** 1/19/22 the "feature freeze"

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
