### PR TITLE
Rename commands.py to core.py in discord.commands

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -23,17 +23,16 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
-import inspect
 import importlib
+import inspect
 import sys
-import discord.utils
 import types
+from typing import Any, Callable, Mapping, ClassVar, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar, \
+    Type
+
+import discord.utils
 from . import errors
-from .commands import SlashCommand, UserCommand, MessageCommand, ApplicationCommand, SlashCommandGroup
-
-from typing import Any, Callable, Mapping, ClassVar, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Type
-
-from .commands.commands import _BaseCommand
+from .commands.core import _BaseCommand
 
 if TYPE_CHECKING:
     from .commands import ApplicationContext, ApplicationCommand

--- a/discord/commands/__init__.py
+++ b/discord/commands/__init__.py
@@ -23,7 +23,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from .commands import *
 from .context import *
+from .core import *
 from .errors import *
 from .permissions import *

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
-from typing import Callable, TYPE_CHECKING, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
 import discord.abc
 
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from discord import Bot
     from discord.state import ConnectionState
 
-    from .commands import ApplicationCommand, Option
+    from .core import ApplicationCommand, Option
     from ..cog import Cog
     from ..webhook import WebhookMessage
     from typing import Callable
@@ -46,7 +46,6 @@ from ..member import Member
 from ..message import Message
 from ..user import User
 from ..utils import cached_property
-from ..webhook import Webhook
 
 T = TypeVar('T')
 CogT = TypeVar('CogT', bound="Cog")

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -66,7 +66,6 @@ if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
     from ..cog import Cog
-    from ..interactions import Interaction
 
 T = TypeVar('T')
 CogT = TypeVar('CogT', bound='Cog')

--- a/examples/views/button_roles.py
+++ b/examples/views/button_roles.py
@@ -1,5 +1,5 @@
 import discord
-from discord.commands.commands import slash_command
+from discord.commands.core import slash_command
 from discord.ext import commands
 
 """


### PR DESCRIPTION
## Summary

An internal renaming, should not affect most users. Should be merged quickly to avoid issues with merge conflicts.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
