### PR TITLE
Fix empty labels being overriden if emoji is present

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -69,7 +69,6 @@ class PaginatorButton(discord.ui.Button):
         custom_id: str = None,
         loop_label: str = None,
     ):
-
         super().__init__(
             label=label if label or emoji else button_type.capitalize(),
             emoji=emoji,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -69,8 +69,9 @@ class PaginatorButton(discord.ui.Button):
         custom_id: str = None,
         loop_label: str = None,
     ):
+
         super().__init__(
-            label=label or button_type.capitalize(),
+            label=label if label or emoji else button_type.capitalize(),
             emoji=emoji,
             style=style,
             disabled=disabled,


### PR DESCRIPTION
## Summary

Fix empty labels being overriden even in the event of an emoji being present, thus preventing the use of emoji-only buttons.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
