### PR TITLE
Fix 2 for emoji-only buttons being overriden in ext.pages

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -430,7 +430,7 @@ class Paginator(discord.ui.View):
         self.buttons[button.button_type] = {
             "object": discord.ui.Button(
                 style=button.style,
-                label=button.label or button.button_type.capitalize()
+                label=button.label if button.label or button.emoji else button.button_type.capitalize()
                 if button.button_type != "page_indicator"
                 else f"{self.current_page + 1}/{self.page_count + 1}",
                 disabled=button.disabled,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -78,7 +78,7 @@ class PaginatorButton(discord.ui.Button):
             row=0,
         )
         self.button_type = button_type
-        self.label = label or button_type.capitalize()
+        self.label = label if label or emoji else button_type.capitalize()
         self.emoji = emoji
         self.style = style
         self.disabled = disabled


### PR DESCRIPTION
## Summary

Fix 2: Electric Boogaloo actually fixes the issue. Followup of #782 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
