### PR TITLE
fix: typo in `remove_user`

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -682,7 +682,7 @@ class Thread(Messageable, Hashable):
         Parameters
         -----------
         user: :class:`abc.Snowflake`
-            The user to add to the thread.
+            The user to remove from the thread.
 
         Raises
         -------


### PR DESCRIPTION
## Summary

fixes typo in the `remove_user` function.

https://discord.com/channels/881207955029110855/881735314987708456/931363674608771165

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
