### PR TITLE
[ext.pages] Add example for using emojis for buttons instead of labels

### DIFF
--- a/docs/ext/pages/index.rst
+++ b/docs/ext/pages/index.rst
@@ -125,6 +125,30 @@ Example usage in a cog:
             )
             await paginator.respond(ctx.interaction, ephemeral=False)
 
+        @pagetest.command(name="emoji_buttons")
+        async def pagetest_emoji_buttons(self, ctx: discord.ApplicationContext):
+            """Demonstrates using emojis for the paginator buttons instead of labels."""
+            page_buttons = [
+                pages.PaginatorButton(
+                    "first", emoji="⏪", style=discord.ButtonStyle.green
+                ),
+                pages.PaginatorButton("prev", emoji="⬅", style=discord.ButtonStyle.green),
+                pages.PaginatorButton(
+                    "page_indicator", style=discord.ButtonStyle.gray, disabled=True
+                ),
+                pages.PaginatorButton("next", emoji="➡", style=discord.ButtonStyle.green),
+                pages.PaginatorButton("last", emoji="⏩", style=discord.ButtonStyle.green),
+            ]
+            paginator = pages.Paginator(
+                pages=self.get_pages(),
+                show_disabled=True,
+                show_indicator=True,
+                use_default_buttons=False,
+                custom_buttons=page_buttons,
+                loop_pages=True,
+            )
+            await paginator.respond(ctx.interaction, ephemeral=False)
+
         @pagetest.command(name="custom_buttons")
         async def pagetest_custom_buttons(self, ctx: discord.ApplicationContext):
             """Demonstrates adding buttons to the paginator when the default buttons are not used."""

--- a/examples/views/paginator.py
+++ b/examples/views/paginator.py
@@ -140,6 +140,30 @@ class PageTest(commands.Cog):
         )
         await paginator.respond(ctx.interaction, ephemeral=False)
 
+    @pagetest.command(name="emoji_buttons")
+    async def pagetest_emoji_buttons(self, ctx: discord.ApplicationContext):
+        """Demonstrates using emojis for the paginator buttons instead of labels."""
+        page_buttons = [
+            pages.PaginatorButton(
+                "first", emoji="⏪", style=discord.ButtonStyle.green
+            ),
+            pages.PaginatorButton("prev", emoji="⬅", style=discord.ButtonStyle.green),
+            pages.PaginatorButton(
+                "page_indicator", style=discord.ButtonStyle.gray, disabled=True
+            ),
+            pages.PaginatorButton("next", emoji="➡", style=discord.ButtonStyle.green),
+            pages.PaginatorButton("last", emoji="⏩", style=discord.ButtonStyle.green),
+        ]
+        paginator = pages.Paginator(
+            pages=self.get_pages(),
+            show_disabled=True,
+            show_indicator=True,
+            use_default_buttons=False,
+            custom_buttons=page_buttons,
+            loop_pages=True,
+        )
+        await paginator.respond(ctx.interaction, ephemeral=False)
+
     @pagetest.command(name="custom_view")
     async def pagetest_custom_view(self, ctx: discord.ApplicationContext):
         """Demonstrates passing a custom view to the paginator."""


### PR DESCRIPTION
## Summary

This adds an example that shows how to use emojis for paginator buttons instead of labels.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
