### PR TITLE
Bugfix/modify mypy ci

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,4 +9,4 @@ jobs:
       - run: pip install mypy
       - run: pip install -r requirements.txt
       - run: mkdir --parents --verbose .mypy_cache
-      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: mypy --ignore-missing-imports --install-types --non-interactive .

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -164,7 +164,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
     def _prepare_cooldowns(self, ctx: ApplicationContext):
         if self._buckets.valid:
             current = datetime.datetime.now().timestamp()
-            bucket = self._buckets.get_bucket(ctx, current)  # type: ignore (ctx instead of non-existent message)
+            bucket = self._buckets.get_bucket(ctx, current)  # type: ignore # ctx instead of non-existent message
 
             if bucket is not None:
                 retry_after = bucket.update_rate_limit(current)
@@ -183,14 +183,14 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         if hasattr(self, "_max_concurrency"):
             if self._max_concurrency is not None:
                 # For this application, context can be duck-typed as a Message
-                await self._max_concurrency.acquire(ctx)  # type: ignore (ctx instead of non-existent message)
+                await self._max_concurrency.acquire(ctx)  # type: ignore # ctx instead of non-existent message
 
             try:
                 self._prepare_cooldowns(ctx)
                 await self.call_before_hooks(ctx)
             except:
                 if self._max_concurrency is not None:
-                    await self._max_concurrency.release(ctx)  # type: ignore (ctx instead of non-existent message)
+                    await self._max_concurrency.release(ctx)  # type: ignore # ctx instead of non-existent message
                 raise
 
     def is_on_cooldown(self, ctx: ApplicationContext) -> bool:
@@ -226,7 +226,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             The invocation context to reset the cooldown under.
         """
         if self._buckets.valid:
-            bucket = self._buckets.get_bucket(ctx)  # type: ignore (ctx instead of non-existent message)
+            bucket = self._buckets.get_bucket(ctx)  # type: ignore # ctx instead of non-existent message
             bucket.reset()
 
     def get_cooldown_retry_after(self, ctx: ApplicationContext) -> float:
@@ -629,7 +629,7 @@ class SlashCommand(ApplicationCommand):
 
         check_annotations = [
             lambda o, a: o.input_type == SlashCommandOptionType.string and o.converter is not None,  # pass on converters
-            lambda o, a: isinstance(o._raw_type, tuple) and a == Union[o._raw_type],  # type: ignore (union types)
+            lambda o, a: isinstance(o._raw_type, tuple) and a == Union[o._raw_type],  # type: ignore # union types
             lambda o, a: self._is_typing_optional(a) and not o.required and o._raw_type in a.__args__,  # optional
             lambda o, a: inspect.isclass(a) and issubclass(a, o._raw_type)  # 'normal' types
         ]

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -630,7 +630,7 @@ class SlashCommand(ApplicationCommand):
         check_annotations = [
             lambda o, a: o.input_type == SlashCommandOptionType.string and o.converter is not None,  # pass on converters
             lambda o, a: isinstance(o.input_type, SlashCommandOptionType),  # pass on slash cmd option type enums
-            lambda o, a: isinstance(o._raw_type, tuple) and a == Union[o._raw_type],  # type: ignore # union types)
+            lambda o, a: isinstance(o._raw_type, tuple) and a == Union[o._raw_type],  # type: ignore # union types
             lambda o, a: self._is_typing_optional(a) and not o.required and o._raw_type in a.__args__,  # optional
             lambda o, a: inspect.isclass(a) and issubclass(a, o._raw_type)  # 'normal' types
         ]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_errors = True


### PR DESCRIPTION
## Summary

fix #788 

Current mypy CI ignore all errors including fatal one because of `|| true` .

```sh
mypy --ignore-missing-imports --install-types --non-interactive . || true
```

Fatal errors prevented further checking.
![image](https://user-images.githubusercontent.com/33354327/149532882-62f6b6c7-9b92-43b0-ab09-6e9829097fd3.png)

I fixed `type: ignore` comment with explaining why. That solves the fatal errors.

But, mypy returns normal errors by further checking.

Error log gist: <https://gist.github.com/pollenjp/6bae2f13181abfeb4ef5ed11cc07c337>

Temporally, to ignore normal errors I introduced `mypy.ini` file and added `ignore_errors = True` .

```sh
 % mypy --ignore-missing-imports --install-types --non-interactive .
Success: no issues found in 152 source files
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
