### PR TITLE
Fix `Permissions.all()`

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -148,7 +148,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(8)
+        return cls(0b1111111111111111111111111111111111111111)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -148,7 +148,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(-1)
+        return cls(8)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -148,7 +148,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(0b1111111111111111111111111111111111111111)
+        return cls(0b11111111111111111111111111111111111111111)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:


### PR DESCRIPTION
## Summary
Fixes #793 (Kind of)

I saw this issue and tried to reproduce the error and didn't get a `401` but instead a `403`, either way it still appears that `Permissions.all()` will not work. This pr makes it return `0b1111111111111111111111111111111111111111` instead of `-1` This very long bit number is what I found sets all permissions to `True`


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
