### PR TITLE
fix: typo in `MessageFlags.loading`

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -306,7 +306,7 @@ class MessageFlags(BaseFlags):
 
     @flag_value
     def loading(self):
-        """:class:`bool`: Returns ``True`` if the source message an deferred.
+        """:class:`bool`: Returns ``True`` if the source message is deferred.
 
         The user sees a 'thinking' state
 


### PR DESCRIPTION
## Summary

https://discordapp.com/channels/881207955029110855/881735314987708456/931805212849610872

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
