### PR TITLE
Fix #812 and Option.channel_types' Type Annotation

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -629,6 +629,7 @@ class SlashCommand(ApplicationCommand):
 
         check_annotations = [
             lambda o, a: o.input_type == SlashCommandOptionType.string and o.converter is not None,  # pass on converters
+            lambda o, a: isinstance(o.input_type, SlashCommandOptionType),  # pass on slash cmd option type enums
             lambda o, a: isinstance(o._raw_type, tuple) and a == Union[o._raw_type],  # type: ignore (union types)
             lambda o, a: self._is_typing_optional(a) and not o.required and o._raw_type in a.__args__,  # optional
             lambda o, a: inspect.isclass(a) and issubclass(a, o._raw_type)  # 'normal' types

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -38,7 +38,7 @@ class Option:
         self.description = description or "No description provided"
         self.converter = None
         self._raw_type = input_type
-        self.channel_types: List[SlashCommandOptionType] = kwargs.pop(
+        self.channel_types: List[ChannelType] = kwargs.pop(
             "channel_types", []
         )
         if not isinstance(input_type, SlashCommandOptionType):


### PR DESCRIPTION
## Summary

Closes #812.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
