### PR TITLE
Make channel_id default to the current channel

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -341,7 +341,11 @@ class PartialMessageConverter(Converter[discord.PartialMessage]):
         if not match:
             raise MessageNotFound(argument)
         data = match.groupdict()
-        channel_id = discord.utils._get_as_snowflake(data, 'channel_id')
+        channel_id = data.get('channel_id')
+        if channel_id is None:
+            channel_id = ctx.channel and ctx.channel.id
+        else:
+            channel_id = int(channel_id)
         message_id = int(data['message_id'])
         guild_id = data.get('guild_id')
         if guild_id is None:


### PR DESCRIPTION
## Summary

Makes `_get_id_matches` return the current channel if it couldn't find a channel in the provided argument.
Fixes: #801
Fixes: #185 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
