### PR TITLE
Extension fixes

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -153,11 +153,14 @@ class ApplicationCommandMixin:
         Returns
         --------
         Optional[:class:`.ApplicationCommand`]
-            The command that was removed. If the name is not valid then
+            The command that was removed. If the command is not valid then
             ``None`` is returned instead.
         """
         if command.id is None:
-            index = self._pending_application_commands.index(command)
+            try:
+                index = self._pending_application_commands.index(command)
+            except ValueError:
+                return None
             return self._pending_application_commands.pop(index)
         return self._application_commands.pop(command.id)
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -97,6 +97,10 @@ class ApplicationCommandMixin:
         return self._pending_application_commands
 
     @property
+    def all_commands(self):
+        return self._application_commands
+    
+    @property
     def commands(self) -> List[Union[ApplicationCommand, Any]]:
         commands = self.application_commands
         if self._supports_prefixed_commands:

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -156,6 +156,9 @@ class ApplicationCommandMixin:
             The command that was removed. If the name is not valid then
             ``None`` is returned instead.
         """
+        if command.id is None:
+            index = self._pending_application_commands.index(command)
+            return self._pending_application_commands.pop(index)
         return self._application_commands.pop(command.id)
 
     @property

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1159,7 +1159,7 @@ class GroupMixin(Generic[CogT]):
 
     Attributes
     -----------
-    prefix_commands: :class:`dict`
+    prefixed_commands: :class:`dict`
         A mapping of command name to :class:`.Command`
         objects.
     case_insensitive: :class:`bool`

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1468,7 +1468,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
 
         if trigger:
             ctx.subcommand_passed = trigger
-            ctx.invoked_subcommand = self.all_commands.get(trigger, None)
+            ctx.invoked_subcommand = self.prefixed_commands.get(trigger, None)
 
         if early_invoke:
             injected = hooked_wrapped_callback(self, ctx, self.callback)
@@ -1502,7 +1502,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
 
         if trigger:
             ctx.subcommand_passed = trigger
-            ctx.invoked_subcommand = self.all_commands.get(trigger, None)
+            ctx.invoked_subcommand = self.prefixed_commands.get(trigger, None)
 
         if early_invoke:
             try:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1159,7 +1159,7 @@ class GroupMixin(Generic[CogT]):
 
     Attributes
     -----------
-    all_commands: :class:`dict`
+    prefix_commands: :class:`dict`
         A mapping of command name to :class:`.Command`
         objects.
     case_insensitive: :class:`bool`
@@ -1167,17 +1167,22 @@ class GroupMixin(Generic[CogT]):
     """
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         case_insensitive = kwargs.get('case_insensitive', False)
-        self.all_commands: Dict[str, Command[CogT, Any, Any]] = _CaseInsensitiveDict() if case_insensitive else {}
+        self.prefixed_commands: Dict[str, Command[CogT, Any, Any]] = _CaseInsensitiveDict() if case_insensitive else {}
         self.case_insensitive: bool = case_insensitive
         super().__init__(*args, **kwargs)
 
+    @property
+    def all_commands(self):
+        # merge app and prefixed commands
+        return {**self._application_commands, **self.prefixed_commands}
+        
     @property
     def commands(self) -> Set[Command[CogT, Any, Any]]:
         """Set[:class:`.Command`]: A unique set of commands without aliases that are registered."""
         return set(self.all_commands.values())
 
     def recursively_remove_all_commands(self) -> None:
-        for command in self.all_commands.copy().values():
+        for command in self.prefixed_commands.copy().values():
             if isinstance(command, GroupMixin):
                 command.recursively_remove_all_commands()
             self.remove_command(command.name)
@@ -1210,15 +1215,15 @@ class GroupMixin(Generic[CogT]):
         if isinstance(self, Command):
             command.parent = self
 
-        if command.name in self.all_commands:
+        if command.name in self.prefixed_commands:
             raise CommandRegistrationError(command.name)
 
         self.all_commands[command.name] = command
         for alias in command.aliases:
-            if alias in self.all_commands:
+            if alias in self.prefixed_commands:
                 self.remove_command(command.name)
                 raise CommandRegistrationError(alias, alias_conflict=True)
-            self.all_commands[alias] = command
+            self.prefixed_commands[alias] = command
 
     def remove_command(self, name: str) -> Optional[Command[CogT, Any, Any]]:
         """Remove a :class:`.Command` from the internal list
@@ -1237,7 +1242,7 @@ class GroupMixin(Generic[CogT]):
             The command that was removed. If the name is not valid then
             ``None`` is returned instead.
         """
-        command = self.all_commands.pop(name, None)
+        command = self.prefixed_commands.pop(name, None)
 
         # does not exist
         if command is None:
@@ -1249,12 +1254,12 @@ class GroupMixin(Generic[CogT]):
 
         # we're not removing the alias so let's delete the rest of them.
         for alias in command.aliases:
-            cmd = self.all_commands.pop(alias, None)
+            cmd = self.prefixed_commands.pop(alias, None)
             # in the case of a CommandRegistrationError, an alias might conflict
             # with an already existing command. If this is the case, we want to
             # make sure the pre-existing command is not removed.
             if cmd is not None and cmd != command:
-                self.all_commands[alias] = cmd
+                self.prefixed_commands[alias] = cmd
         return command
 
     def walk_commands(self) -> Generator[Command[CogT, Any, Any], None, None]:
@@ -1296,18 +1301,18 @@ class GroupMixin(Generic[CogT]):
 
         # fast path, no space in name.
         if ' ' not in name:
-            return self.all_commands.get(name)
+            return self.prefixed_commands.get(name)
 
         names = name.split()
         if not names:
             return None
-        obj = self.all_commands.get(names[0])
+        obj = self.prefixed_commands.get(names[0])
         if not isinstance(obj, GroupMixin):
             return obj
 
         for name in names[1:]:
             try:
-                obj = obj.all_commands[name]  # type: ignore
+                obj = obj.prefixed_commands[name]  # type: ignore
             except (AttributeError, KeyError):
                 return None
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1218,7 +1218,7 @@ class GroupMixin(Generic[CogT]):
         if command.name in self.prefixed_commands:
             raise CommandRegistrationError(command.name)
 
-        self.all_commands[command.name] = command
+        self.prefixed_commands[command.name] = command
         for alias in command.aliases:
             if alias in self.prefixed_commands:
                 self.remove_command(command.name)


### PR DESCRIPTION
## Summary

Fixes issues with unloading extensions:
- Raising `AttributeError` when an extension was unloaded on discord.Bot
- Raising `KeyError` when an extension with a command was unloaded before the bot was ready

Also fixes some other small issue with the behavior of `remove_application_command` not matching the docstring.

Fixes #816

**Changes made could be considered breaking changes**, however, I don't believe these attributes are used very often externally, or that they should.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
