### PR TITLE
Fix documentation table of contents

### DIFF
--- a/docs/ext/pages/index.rst
+++ b/docs/ext/pages/index.rst
@@ -289,10 +289,10 @@ Example usage in a cog:
 .. _discord_ext_pages_api:
 
 API Reference
-=============
+-------------
 
 Paginator
----------
+~~~~~~~~~
 
 .. attributetable:: discord.ext.pages.Paginator
 
@@ -301,7 +301,7 @@ Paginator
     :inherited-members:
 
 PaginatorButton
----------------
+~~~~~~~~~~~~~~~
 
 .. attributetable:: discord.ext.pages.PaginatorButton
 
@@ -310,7 +310,7 @@ PaginatorButton
     :inherited-members:
 
 PaginatorMenu
--------------
+~~~~~~~~~~~~~
 
 .. attributetable:: discord.ext.pages.PaginatorMenu
 
@@ -319,7 +319,7 @@ PaginatorMenu
     :inherited-members:
 
 PageGroup
----------
+~~~~~~~~~
 
 .. attributetable:: discord.ext.pages.PageGroup
 


### PR DESCRIPTION
## Summary

Currently the documentation looks like this due to an incorrect heading usage in the `ext.pages` docs:

![image](https://user-images.githubusercontent.com/935885/150404315-c45aeb8d-0b7b-4d84-ac82-929b921c97ef.png)

This PR fixes it and the docs will now look like this:

![image](https://user-images.githubusercontent.com/935885/150404479-df4e46ab-5d75-4b8c-b358-f687a41d85c3.png)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
