### PR TITLE
Revert docs changes from #822

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1680,7 +1680,7 @@ def check(predicate: Check) -> Callable[[T], T]:
 
     .. code-block:: python3
 
-        async def owner_or_permissions(**perms):
+        def owner_or_permissions(**perms):
             original = commands.has_permissions(**perms).predicate
             async def extended_check(ctx):
                 if ctx.guild is None:


### PR DESCRIPTION
## Summary

Reverts #822 which was incorrectly changed - I missed that it was part of a decorator.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
