### PR TITLE
Add back missing PartialMessageable import

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
 from . import utils
 from .enums import try_enum, InteractionType, InteractionResponseType
 from .errors import InteractionResponded, ClientException, InvalidArgument
-from .channel import ChannelType
+from .channel import ChannelType, PartialMessageable
 from .file import File
 from .user import User
 from .member import Member


### PR DESCRIPTION
## Summary

This adds back the import for PartialMessageable which was inadvertently removed in #821.

Fixes #827 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
