### PR TITLE
Revert #817 due to high-severity prefix command errors introduced by its changes

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -97,10 +97,6 @@ class ApplicationCommandMixin:
         return self._pending_application_commands
 
     @property
-    def all_commands(self):
-        return self._application_commands
-    
-    @property
     def commands(self) -> List[Union[ApplicationCommand, Any]]:
         commands = self.application_commands
         if self._supports_prefixed_commands:
@@ -153,15 +149,9 @@ class ApplicationCommandMixin:
         Returns
         --------
         Optional[:class:`.ApplicationCommand`]
-            The command that was removed. If the command is not valid then
+            The command that was removed. If the name is not valid then
             ``None`` is returned instead.
         """
-        if command.id is None:
-            try:
-                index = self._pending_application_commands.index(command)
-            except ValueError:
-                return None
-            return self._pending_application_commands.pop(index)
         return self._application_commands.pop(command.id)
 
     @property

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1174,10 +1174,8 @@ class GroupMixin(Generic[CogT]):
     @property
     def all_commands(self):
         # merge app and prefixed commands
-        if hasattr(self, "_application_commands"):
-            return {**self._application_commands, **self.prefixed_commands}
-        return self.prefixed_commands
-
+        return {**self._application_commands, **self.prefixed_commands}
+        
     @property
     def commands(self) -> Set[Command[CogT, Any, Any]]:
         """Set[:class:`.Command`]: A unique set of commands without aliases that are registered."""

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1159,7 +1159,7 @@ class GroupMixin(Generic[CogT]):
 
     Attributes
     -----------
-    prefixed_commands: :class:`dict`
+    all_commands: :class:`dict`
         A mapping of command name to :class:`.Command`
         objects.
     case_insensitive: :class:`bool`
@@ -1167,22 +1167,17 @@ class GroupMixin(Generic[CogT]):
     """
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         case_insensitive = kwargs.get('case_insensitive', False)
-        self.prefixed_commands: Dict[str, Command[CogT, Any, Any]] = _CaseInsensitiveDict() if case_insensitive else {}
+        self.all_commands: Dict[str, Command[CogT, Any, Any]] = _CaseInsensitiveDict() if case_insensitive else {}
         self.case_insensitive: bool = case_insensitive
         super().__init__(*args, **kwargs)
 
-    @property
-    def all_commands(self):
-        # merge app and prefixed commands
-        return {**self._application_commands, **self.prefixed_commands}
-        
     @property
     def commands(self) -> Set[Command[CogT, Any, Any]]:
         """Set[:class:`.Command`]: A unique set of commands without aliases that are registered."""
         return set(self.all_commands.values())
 
     def recursively_remove_all_commands(self) -> None:
-        for command in self.prefixed_commands.copy().values():
+        for command in self.all_commands.copy().values():
             if isinstance(command, GroupMixin):
                 command.recursively_remove_all_commands()
             self.remove_command(command.name)
@@ -1215,15 +1210,15 @@ class GroupMixin(Generic[CogT]):
         if isinstance(self, Command):
             command.parent = self
 
-        if command.name in self.prefixed_commands:
+        if command.name in self.all_commands:
             raise CommandRegistrationError(command.name)
 
-        self.prefixed_commands[command.name] = command
+        self.all_commands[command.name] = command
         for alias in command.aliases:
-            if alias in self.prefixed_commands:
+            if alias in self.all_commands:
                 self.remove_command(command.name)
                 raise CommandRegistrationError(alias, alias_conflict=True)
-            self.prefixed_commands[alias] = command
+            self.all_commands[alias] = command
 
     def remove_command(self, name: str) -> Optional[Command[CogT, Any, Any]]:
         """Remove a :class:`.Command` from the internal list
@@ -1242,7 +1237,7 @@ class GroupMixin(Generic[CogT]):
             The command that was removed. If the name is not valid then
             ``None`` is returned instead.
         """
-        command = self.prefixed_commands.pop(name, None)
+        command = self.all_commands.pop(name, None)
 
         # does not exist
         if command is None:
@@ -1254,12 +1249,12 @@ class GroupMixin(Generic[CogT]):
 
         # we're not removing the alias so let's delete the rest of them.
         for alias in command.aliases:
-            cmd = self.prefixed_commands.pop(alias, None)
+            cmd = self.all_commands.pop(alias, None)
             # in the case of a CommandRegistrationError, an alias might conflict
             # with an already existing command. If this is the case, we want to
             # make sure the pre-existing command is not removed.
             if cmd is not None and cmd != command:
-                self.prefixed_commands[alias] = cmd
+                self.all_commands[alias] = cmd
         return command
 
     def walk_commands(self) -> Generator[Command[CogT, Any, Any], None, None]:
@@ -1301,18 +1296,18 @@ class GroupMixin(Generic[CogT]):
 
         # fast path, no space in name.
         if ' ' not in name:
-            return self.prefixed_commands.get(name)
+            return self.all_commands.get(name)
 
         names = name.split()
         if not names:
             return None
-        obj = self.prefixed_commands.get(names[0])
+        obj = self.all_commands.get(names[0])
         if not isinstance(obj, GroupMixin):
             return obj
 
         for name in names[1:]:
             try:
-                obj = obj.prefixed_commands[name]  # type: ignore
+                obj = obj.all_commands[name]  # type: ignore
             except (AttributeError, KeyError):
                 return None
 
@@ -1468,7 +1463,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
 
         if trigger:
             ctx.subcommand_passed = trigger
-            ctx.invoked_subcommand = self.prefixed_commands.get(trigger, None)
+            ctx.invoked_subcommand = self.all_commands.get(trigger, None)
 
         if early_invoke:
             injected = hooked_wrapped_callback(self, ctx, self.callback)
@@ -1502,7 +1497,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
 
         if trigger:
             ctx.subcommand_passed = trigger
-            ctx.invoked_subcommand = self.prefixed_commands.get(trigger, None)
+            ctx.invoked_subcommand = self.all_commands.get(trigger, None)
 
         if early_invoke:
             try:


### PR DESCRIPTION
## Summary

This reverts #817 (and by extension, #826) due to the issues it introduced being higher in severity than the intended fix.

For example, using the prefix-based help command causes this error:

```
Traceback (most recent call last):
  File "C:\Users\ben\PycharmProjects\cbot\venv3.10\lib\site-packages\discord\ext\commands\core.py", line 179, in wrapped
    ret = await coro(*args, **kwargs)
  File "C:\Users\ben\PycharmProjects\cbot\venv3.10\lib\site-packages\discord\ext\commands\help.py", line 838, in command_callback
    mapping = self.get_bot_mapping()
  File "C:\Users\ben\PycharmProjects\cbot\venv3.10\lib\site-packages\discord\ext\commands\help.py", line 382, in get_bot_mapping
    mapping[None] = [c for c in bot.commands if c.cog is None]
  File "C:\Users\ben\PycharmProjects\cbot\venv3.10\lib\site-packages\discord\ext\commands\core.py", line 1185, in commands
    return set(self.all_commands.values())
TypeError: unhashable type: 'SlashCommand'
```

Using `bot.reload_extension` causes this error:

```
Traceback (most recent call last):
[jishaku-related traceback removed]

  File "<repl>", line 2, in _repl_coroutine
    bot.reload_extension("extensions.ext_libtests")
  File "C:\Users\ben\PycharmProjects\cbot\venv3.10\lib\site-packages\discord\cog.py", line 816, in reload_extension
    self._remove_module_references(lib.__name__)
  File "C:\Users\ben\PycharmProjects\cbot\venv3.10\lib\site-packages\discord\cog.py", line 614, in _remove_module_references
    if cmd.module is not None and _is_submodule(name, cmd.module):
AttributeError: 'SlashCommand' object has no attribute 'module'
```

There are also reports of other related issues in our discord server, (such as error handlers being broken), but I haven't tested that one myself.

I believe all of these issues are caused by the merging of the app and prefix command dicts and we should revert until we can fully test a more thorough implementation of the intended fix from #817.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
