### PR TITLE
Add `created_at` to `Thread`

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -120,6 +120,9 @@ class Thread(Messageable, Hashable):
         Usually a value of 60, 1440, 4320 and 10080.
     archive_timestamp: :class:`datetime.datetime`
         An aware timestamp of when the thread's archived status was last updated in UTC.
+    created_at: Optional[:class:`datetime.datetime`]
+        An aware timestamp of when the thread was created.
+        Only available for threads created after 2022-01-09.
     """
 
     __slots__ = (
@@ -141,6 +144,7 @@ class Thread(Messageable, Hashable):
         'invitable',
         'auto_archive_duration',
         'archive_timestamp',
+        'created_at',
     )
 
     def __init__(self, *, guild: Guild, state: ConnectionState, data: ThreadPayload):
@@ -186,6 +190,7 @@ class Thread(Messageable, Hashable):
         self.archive_timestamp = parse_time(data['archive_timestamp'])
         self.locked = data.get('locked', False)
         self.invitable = data.get('invitable', True)
+        self.created_at = data.get('create_timestamp')
 
     def _update(self, data):
         try:

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -190,7 +190,7 @@ class Thread(Messageable, Hashable):
         self.archive_timestamp = parse_time(data['archive_timestamp'])
         self.locked = data.get('locked', False)
         self.invitable = data.get('invitable', True)
-        self.created_at = data.get('create_timestamp')
+        self.created_at = parse_time(data.get('create_timestamp'))
 
     def _update(self, data):
         try:


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/53ee0109b874bde5ec2316379bf266bb332630a0

Yes, I know there's a feature freeze.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
