### PR TITLE
Fix reST list in quickstart docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -111,7 +111,7 @@ Let's look at the differences compared to the previous example, step-by-step:
    If you omit it, the command will be globally available, and may take up to an hour to register.
 4. Afterwards, we trigger a response to the slash command in the form of a text reply. Please note that
    all slash commands must have some form of response, otherwise they will fail.
-6. Finally, we, once again, run the bot with our login token.
+5. Finally, we, once again, run the bot with our login token.
 
 
 Congratulations! Now you have created your first slash command!


### PR DESCRIPTION
## Summary

Fixed the numbering of a list on the Quickstart page to fix this issue:

![Separate lists](https://user-images.githubusercontent.com/37779854/151044193-7e79145b-b220-4f14-83b9-323a0b4a1c95.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
