### PR TITLE
[ext-pages] Fix for specifying an initial page before sending the paginator

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -604,7 +604,7 @@ class Paginator(discord.ui.View):
             raise TypeError(f"expected abc.Messageable not {target.__class__!r}")
 
         self.update_buttons()
-        page = self.pages[self.current_page]
+        page = self.pages[0]
         page = self.get_page_content(page)
 
         self.user = ctx.author
@@ -657,7 +657,7 @@ class Paginator(discord.ui.View):
 
         self.update_buttons()
 
-        page = self.pages[self.current_page]
+        page = self.pages[0]
         page = self.get_page_content(page)
 
         self.user = interaction.user

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -604,7 +604,7 @@ class Paginator(discord.ui.View):
             raise TypeError(f"expected abc.Messageable not {target.__class__!r}")
 
         self.update_buttons()
-        page = self.pages[0]
+        page = self.pages[self.current_page]
         page = self.get_page_content(page)
 
         self.user = ctx.author
@@ -657,7 +657,7 @@ class Paginator(discord.ui.View):
 
         self.update_buttons()
 
-        page = self.pages[0]
+        page = self.pages[self.current_page]
         page = self.get_page_content(page)
 
         self.user = interaction.user


### PR DESCRIPTION
## Summary

This sets the initial page in `Paginator.respond()` and `Paginator.send()` to `Paginator.current_page` instead of the current value of `0`. Since `current_page` defaults to 0, this should not be a breaking change.

This allows users to set the initial page before sending the paginator. For example:

```py
@slash_command()
async def pagetest_initial(self, ctx: discord.ApplicationContext):
    """Demonstrates setting an initial page before sending."""
    paginator = pages.Paginator(pages=["Page 1", "Page 2", "Page 3", "Page 4"])
    paginator.current_page = 2
    await paginator.respond(ctx.interaction)
```
Fixes #858 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
