### PR TITLE
Fix role `icon` argument not setting unicode_emoji to None

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -374,7 +374,7 @@ class Role(Hashable):
         position: int = MISSING,
         reason: Optional[str] = MISSING,
         icon: Optional[bytes] = MISSING,
-        unicode_emoji: str = MISSING
+        unicode_emoji: Optional[str] = MISSING
     ) -> Optional[Role]:
         """|coro|
 

--- a/discord/role.py
+++ b/discord/role.py
@@ -461,6 +461,7 @@ class Role(Hashable):
                 payload['icon'] = None
             else:
                 payload['icon'] = _bytes_to_base64_data(icon)
+                payload['unicode_emoji'] = None
         
         if unicode_emoji is not MISSING:
             payload['unicode_emoji'] = unicode_emoji

--- a/discord/role.py
+++ b/discord/role.py
@@ -409,7 +409,7 @@ class Role(Hashable):
         reason: Optional[:class:`str`]
             The reason for editing this role. Shows up on the audit log.
         icon: Optional[:class:`bytes`]
-            A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG/WebP is supported.
+            A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG/WebP is supported. If this argument is passed, ``unicode_emoji`` is set to None.
             Only available to guilds that contain ``ROLE_ICONS`` in :attr:`Guild.features`.
             Could be ``None`` to denote removal of the icon.
         unicode_emoji: Optional[:class:`str`]


### PR DESCRIPTION
# Warning: We have a feature freeze till release
That means we won't accept new features for now. Only bug fixes.

## Summary

This pull request is for the issue https://github.com/Pycord-Development/pycord/issues/874. All it does is to pass `unicode_emoji` as None so that when `icon` is passed, the unicode_emoji will not conflict with the new `icon` set.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
