### PR TITLE
Followup for #838

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -314,7 +314,7 @@ class BotBase(GroupMixin, discord.cog.CogMixin):
         ctx.invoked_with = invoker
         # type-checker fails to narrow invoked_prefix type.
         ctx.prefix = invoked_prefix  # type: ignore
-        ctx.command = self.all_commands.get(invoker)
+        ctx.command = self.prefixed_commands.get(invoker)
         return ctx
 
     async def invoke(self, ctx: Context) -> None:


### PR DESCRIPTION
## Summary

Fixes usage of case insensitive commands, as they were being fetched from the incorrect property by the library.
Fixes #885

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
