### PR TITLE
update: fix typo in CONTRIBUTING (line 49)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,7 +46,7 @@ By submitting a pull request, you agree that; 1) You hold the copyright on all s
 
 Not following this guideline could lead to your pull being squashed for a cleaner commit history
 
-Some style guides we would recommed using in your pulls:
+Some style guides we would recommend using in your pulls:
 
 The [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style is a very widely used style and a good style to start with.
 


### PR DESCRIPTION
# Warning: We have a feature freeze till release
That means we won't accept new features for now. Only bug fixes.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)


## Comment
In CONTRIBUTING.md line 49, "recommend" had a typo and was fixed:
```diff
- Some style guides we would recommed using in your pulls:
+ Some style guides we would recommend using in your pulls:
```