### PR TITLE
Remove MISSING check from embed, embeds, view (fix for #303)

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -502,9 +502,9 @@ class InteractionResponse:
         self,
         content: Optional[Any] = None,
         *,
-        embed: Embed = MISSING,
-        embeds: List[Embed] = MISSING,
-        view: View = MISSING,
+        embed: Embed = None,
+        embeds: List[Embed] = None,
+        view: View = None,
         tts: bool = False,
         ephemeral: bool = False,
         allowed_mentions: AllowedMentions = None,
@@ -563,10 +563,10 @@ class InteractionResponse:
             'tts': tts,
         }
 
-        if embed is not MISSING and embeds is not MISSING:
+        if embed is not None and embeds is not None:
             raise TypeError('cannot mix embed and embeds keyword arguments')
 
-        if embed is not MISSING and embed is not None:
+        if embed is not None:
             embeds = [embed]
 
         if embeds:
@@ -580,7 +580,7 @@ class InteractionResponse:
         if ephemeral:
             payload['flags'] = 64
 
-        if view is not MISSING and view is not None:
+        if view is not None:
             payload['components'] = view.to_components()
 
         state = self._parent._state
@@ -624,7 +624,7 @@ class InteractionResponse:
                 for file in files:
                     file.close()
 
-        if view is not MISSING and view is not None:
+        if view is not None:
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 


### PR DESCRIPTION
# Warning: We have a feature freeze till release
That means we won't accept new features for now. Only bug fixes.

## Summary

This fixes #303 by replacing all MISSING checks in `InteractionResponse.send_message()` with None checks.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
