### PR TITLE
[ext.pages] Add disable/cancel methods to `Paginator` class

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -21,7 +21,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-import copy
 from typing import Dict, List, Optional, Union
 
 import discord
@@ -274,7 +273,6 @@ class Paginator(discord.ui.View):
         self.default_button_row = default_button_row
         self.loop_pages = loop_pages
         self.custom_view = custom_view
-        self.custom_view_items = []
         self.message: Union[discord.Message, discord.WebhookMessage, None] = None
 
         if self.custom_buttons and not self.use_default_buttons:
@@ -395,6 +393,7 @@ class Paginator(discord.ui.View):
         page: Optional[Union[:class:`str`, Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
             The page content to show after disabling the paginator.
         """
+        page = self.get_page_content(page)
         for item in self.children:
             if item not in self.custom_view_items or include_custom:
                 item.disabled = True
@@ -421,9 +420,10 @@ class Paginator(discord.ui.View):
         page: Optional[Union[:class:`str`, Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
             The page content to show after canceling the paginator.
         """
-        items = copy.copy(self.children)
+        items = self.children.copy()
+        page = self.get_page_content(page)
         for item in items:
-            if item not in self.custom_view_items or include_custom:
+            if item not in self.custom_view.children or include_custom:
                 self.remove_item(item)
         if page:
             await self.message.edit(
@@ -613,9 +613,7 @@ class Paginator(discord.ui.View):
         # The bot developer should handle row assignments for their view before passing it to Paginator
         if self.custom_view:
             for item in self.custom_view.children:
-                self.custom_view_items.append(item)
                 self.add_item(item)
-
         return self.buttons
 
     @staticmethod

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -273,6 +273,7 @@ class Paginator(discord.ui.View):
         self.default_button_row = default_button_row
         self.loop_pages = loop_pages
         self.custom_view = custom_view
+        self.custom_view_items = []
         self.message: Union[discord.Message, discord.WebhookMessage, None] = None
 
         if self.custom_buttons and not self.use_default_buttons:
@@ -382,7 +383,7 @@ class Paginator(discord.ui.View):
     async def disable(self) -> None:
         """Stops the paginator, disabling all of its components. Does not disable components added via custom views."""
         for item in self.children:
-            if isinstance(item, (PaginatorButton, PaginatorMenu)):
+            if item not in self.custom_view_items:
                 item.disabled = True
         await self.message.edit(view=self)
 
@@ -565,6 +566,7 @@ class Paginator(discord.ui.View):
         # The bot developer should handle row assignments for their view before passing it to Paginator
         if self.custom_view:
             for item in self.custom_view.children:
+                self.custom_view_items.append(item)
                 self.add_item(item)
 
         return self.buttons

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -380,12 +380,52 @@ class Paginator(discord.ui.View):
                 item.disabled = True
             await self.message.edit(view=self)
 
-    async def disable(self) -> None:
-        """Stops the paginator, disabling all of its components. Does not disable components added via custom views."""
+    async def disable(
+        self,
+        include_custom: bool = False,
+        page: Optional[Union[str, Union[List[discord.Embed], discord.Embed]]] = None,
+    ) -> None:
+        """Stops the paginator, disabling all of its components.
+
+        Parameters
+        ----------
+        include_custom: :class:`bool`
+            Whether to disable components added via custom views.
+        page: Optional[Union[:class:`str`, Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
+            The page content to show after disabling the paginator.
+        """
         for item in self.children:
-            if item not in self.custom_view_items:
+            if item not in self.custom_view_items or include_custom:
                 item.disabled = True
-        await self.message.edit(view=self)
+
+        await self.message.edit(
+            content=page if isinstance(page, str) else None,
+            embeds=[] if isinstance(page, str) else page,
+            view=self,
+        )
+
+    async def cancel(
+        self,
+        include_custom: bool = False,
+        page: Optional[Union[str, Union[List[discord.Embed], discord.Embed]]] = None,
+    ) -> None:
+        """Cancels the paginator, removing all of its components from the message.
+
+        Parameters
+        ----------
+        include_custom: :class:`bool`
+            Whether to remove components added via custom views.
+        page: Optional[Union[:class:`str`, Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
+            The page content to show after canceling the paginator.
+        """
+        for item in self.children:
+            if item not in self.custom_view_items or include_custom:
+                self.remove_item(item)
+        await self.message.edit(
+            content=page if isinstance(page, str) else None,
+            embeds=[] if isinstance(page, str) else page,
+            view=self,
+        )
 
     async def goto_page(self, page_number=0) -> discord.Message:
         """Updates the paginator message to show the specified page number.

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -171,7 +171,9 @@ class PageGroup:
         self.label = label
         self.description = description
         self.emoji: Union[str, discord.Emoji, discord.PartialEmoji] = emoji
-        self.pages: Union[List[str], List[Union[List[discord.Embed], discord.Embed]]] = pages
+        self.pages: Union[
+            List[str], List[Union[List[discord.Embed], discord.Embed]]
+        ] = pages
         self.show_disabled = show_disabled
         self.show_indicator = show_indicator
         self.author_check = author_check
@@ -263,7 +265,9 @@ class Paginator(discord.ui.View):
 
         if all(isinstance(pg, PageGroup) for pg in pages):
             self.page_groups = self.pages if show_menu else None
-            self.pages: Union[List[str], List[Union[List[discord.Embed], discord.Embed]]] = self.page_groups[0].pages
+            self.pages: Union[
+                List[str], List[Union[List[discord.Embed], discord.Embed]]
+            ] = self.page_groups[0].pages
 
         self.page_count = len(self.pages) - 1
         self.buttons = {}
@@ -337,7 +341,7 @@ class Paginator(discord.ui.View):
         # Update pages and reset current_page to 0 (default)
         self.pages: Union[
             List[PageGroup], List[str], List[Union[List[discord.Embed], discord.Embed]]
-        ] = pages if pages is not None else self.pages
+        ] = (pages if pages is not None else self.pages)
         self.page_count = len(self.pages) - 1
         self.current_page = 0
         # Apply config changes, if specified

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+import copy
 from typing import Dict, List, Optional, Union
 
 import discord
@@ -397,12 +398,14 @@ class Paginator(discord.ui.View):
         for item in self.children:
             if item not in self.custom_view_items or include_custom:
                 item.disabled = True
-
-        await self.message.edit(
-            content=page if isinstance(page, str) else None,
-            embeds=[] if isinstance(page, str) else page,
-            view=self,
-        )
+        if page:
+            await self.message.edit(
+                content=page if isinstance(page, str) else None,
+                embeds=[] if isinstance(page, str) else page,
+                view=self,
+            )
+        else:
+            await self.message.edit(view=self)
 
     async def cancel(
         self,
@@ -418,16 +421,18 @@ class Paginator(discord.ui.View):
         page: Optional[Union[:class:`str`, Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
             The page content to show after canceling the paginator.
         """
-        for item in self.children:
-            if include_custom:
-                self.clear_items()
-            elif item not in self.custom_view_items:
+        items = copy.copy(self.children)
+        for item in items:
+            if item not in self.custom_view_items or include_custom:
                 self.remove_item(item)
-        await self.message.edit(
-            content=page if isinstance(page, str) else None,
-            embeds=[] if isinstance(page, str) else page,
-            view=self,
-        )
+        if page:
+            await self.message.edit(
+                content=page if isinstance(page, str) else None,
+                embeds=[] if isinstance(page, str) else page,
+                view=self,
+            )
+        else:
+            await self.message.edit(view=self)
 
     async def goto_page(self, page_number=0) -> discord.Message:
         """Updates the paginator message to show the specified page number.

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -379,6 +379,13 @@ class Paginator(discord.ui.View):
                 item.disabled = True
             await self.message.edit(view=self)
 
+    async def stop(self) -> None:
+        """Stops the paginator, disabling all of its components. Does not disable components added via custom views."""
+        for item in self.children:
+            if isinstance(item, (PaginatorButton, PaginatorMenu)):
+                item.disabled = True
+        await self.message.edit(view=self)
+
     async def goto_page(self, page_number=0) -> discord.Message:
         """Updates the paginator message to show the specified page number.
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -80,7 +80,7 @@ class PaginatorButton(discord.ui.Button):
         )
         self.button_type = button_type
         self.label = label if label or emoji else button_type.capitalize()
-        self.emoji = emoji
+        self.emoji: Union[str, discord.Emoji, discord.PartialEmoji] = emoji
         self.style = style
         self.disabled = disabled
         self.loop_label = self.label if not loop_label else loop_label
@@ -170,8 +170,8 @@ class PageGroup:
     ):
         self.label = label
         self.description = description
-        self.emoji = emoji
-        self.pages = pages
+        self.emoji: Union[str, discord.Emoji, discord.PartialEmoji] = emoji
+        self.pages: Union[List[str], List[Union[List[discord.Embed], discord.Embed]]] = pages
         self.show_disabled = show_disabled
         self.show_indicator = show_indicator
         self.author_check = author_check
@@ -179,9 +179,9 @@ class PageGroup:
         self.use_default_buttons = use_default_buttons
         self.default_button_row = default_button_row
         self.loop_pages = loop_pages
-        self.custom_view = custom_view
-        self.timeout = timeout
-        self.custom_buttons = custom_buttons
+        self.custom_view: discord.ui.View = custom_view
+        self.timeout: float = timeout
+        self.custom_buttons: List = custom_buttons
 
 
 class Paginator(discord.ui.View):
@@ -252,8 +252,10 @@ class Paginator(discord.ui.View):
         custom_buttons: Optional[List[PaginatorButton]] = None,
     ) -> None:
         super().__init__(timeout=timeout)
-        self.timeout = timeout
-        self.pages = pages
+        self.timeout: float = timeout
+        self.pages: Union[
+            List[PageGroup], List[str], List[Union[List[discord.Embed], discord.Embed]]
+        ] = pages
         self.current_page = 0
         self.menu: Optional[PaginatorMenu] = None
         self.show_menu = show_menu
@@ -261,18 +263,18 @@ class Paginator(discord.ui.View):
 
         if all(isinstance(pg, PageGroup) for pg in pages):
             self.page_groups = self.pages if show_menu else None
-            self.pages = self.page_groups[0].pages
+            self.pages: Union[List[str], List[Union[List[discord.Embed], discord.Embed]]] = self.page_groups[0].pages
 
         self.page_count = len(self.pages) - 1
         self.buttons = {}
-        self.custom_buttons = custom_buttons
+        self.custom_buttons: List = custom_buttons
         self.show_disabled = show_disabled
         self.show_indicator = show_indicator
         self.disable_on_timeout = disable_on_timeout
         self.use_default_buttons = use_default_buttons
         self.default_button_row = default_button_row
         self.loop_pages = loop_pages
-        self.custom_view = custom_view
+        self.custom_view: discord.ui.View = custom_view
         self.message: Union[discord.Message, discord.WebhookMessage, None] = None
 
         if self.custom_buttons and not self.use_default_buttons:
@@ -333,7 +335,9 @@ class Paginator(discord.ui.View):
         """
 
         # Update pages and reset current_page to 0 (default)
-        self.pages = pages if pages is not None else self.pages
+        self.pages: Union[
+            List[PageGroup], List[str], List[Union[List[discord.Embed], discord.Embed]]
+        ] = pages if pages is not None else self.pages
         self.page_count = len(self.pages) - 1
         self.current_page = 0
         # Apply config changes, if specified
@@ -360,8 +364,8 @@ class Paginator(discord.ui.View):
             else self.default_button_row
         )
         self.loop_pages = loop_pages if loop_pages is not None else self.loop_pages
-        self.custom_view = None if custom_view is None else custom_view
-        self.timeout = timeout if timeout is not None else self.timeout
+        self.custom_view: discord.ui.View = None if custom_view is None else custom_view
+        self.timeout: float = timeout if timeout is not None else self.timeout
         if custom_buttons and not self.use_default_buttons:
             self.buttons = {}
             for button in custom_buttons:
@@ -395,7 +399,7 @@ class Paginator(discord.ui.View):
         """
         page = self.get_page_content(page)
         for item in self.children:
-            if item not in self.custom_view_items or include_custom:
+            if item not in self.custom_view.children or include_custom:
                 item.disabled = True
         if page:
             await self.message.edit(

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -419,7 +419,9 @@ class Paginator(discord.ui.View):
             The page content to show after canceling the paginator.
         """
         for item in self.children:
-            if item not in self.custom_view_items or include_custom:
+            if include_custom:
+                self.clear_items()
+            elif item not in self.custom_view_items:
                 self.remove_item(item)
         await self.message.edit(
             content=page if isinstance(page, str) else None,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -379,7 +379,7 @@ class Paginator(discord.ui.View):
                 item.disabled = True
             await self.message.edit(view=self)
 
-    async def stop(self) -> None:
+    async def disable(self) -> None:
         """Stops the paginator, disabling all of its components. Does not disable components added via custom views."""
         for item in self.children:
             if isinstance(item, (PaginatorButton, PaginatorMenu)):

--- a/examples/views/paginator.py
+++ b/examples/views/paginator.py
@@ -182,6 +182,26 @@ class PageTest(commands.Cog):
         paginator = pages.Paginator(pages=self.get_pages(), custom_view=view)
         await paginator.respond(ctx.interaction, ephemeral=False)
 
+    @pagetest.command(name="disable")
+    async def pagetest_disable(self, ctx: discord.ApplicationContext):
+        """Demonstrates disabling the paginator buttons and showing a custom page when disabled."""
+        paginator = pages.Paginator(pages=self.get_pages())
+        await paginator.respond(ctx.interaction, ephemeral=False)
+        await ctx.respond("Disabling paginator in 5 seconds...")
+        await asyncio.sleep(5)
+        disable_page = discord.Embed(title="Paginator Disabled!", description="This page is only shown when the paginator is disabled.")
+        await paginator.disable(page=disable_page)
+
+    @pagetest.command(name="cancel")
+    async def pagetest_cancel(self, ctx: discord.ApplicationContext):
+        """Demonstrates canceling (stopping) the paginator and showing a custom page when cancelled."""
+        paginator = pages.Paginator(pages=self.get_pages())
+        await paginator.respond(ctx.interaction, ephemeral=False)
+        await ctx.respond("Canceling paginator in 5 seconds...")
+        await asyncio.sleep(5)
+        cancel_page = discord.Embed(title="Paginator Cancelled!", description="This page is only shown when the paginator is cancelled.")
+        await paginator.cancel(page=cancel_page)
+
     @pagetest.command(name="groups")
     async def pagetest_groups(self, ctx: discord.ApplicationContext):
         """Demonstrates using page groups to switch between different sets of pages."""


### PR DESCRIPTION
## Summary

This adds two new methods to the `Paginator` class: `disable()` and `cancel()`. These allow users to disable or remove the paginator components, respectively.

There are two optional arguments added for each method: `include_custom` and `page`:
- `include_custom` specifies whether to disable/remove any custom view components
- `page` allows you to specify the content shown in the paginator message once the paginator is disabled/removed

pagetest_disable and pagetest_cancel examples have also been included.

Partially fulfills #870 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
