### PR TITLE
Options: set required to False when default value is None

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -85,10 +85,10 @@ class Option:
                         self.channel_types.append(channel_type)
                 input_type = _type
         self.input_type = input_type
-        self.default = kwargs.pop("default", None)
         self.required: bool = (
-            kwargs.pop("required", True) if self.default is None else False
+            kwargs.pop("required", True) if "default" not in kwargs else False
         )
+        self.default = kwargs.pop("default", None)
         self.choices: List[OptionChoice] = [
             o if isinstance(o, OptionChoice) else OptionChoice(o)
             for o in kwargs.pop("choices", list())


### PR DESCRIPTION
## Summary

Fixes #902

When passing a default value of `None` to an option, `required` was set to `True` even though there _was_ a default value present. This PR allows None to be passed in and sets `required` to `False`.

By using the `in`-operator to perform this check, _any_ value is allowed - including `None`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
