### PR TITLE
Fixed type mismatch in sync_commands

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -577,7 +577,7 @@ class ApplicationCommandMixin:
 
             for i in commands:
                 cmd = find(lambda cmd: cmd.name == i["name"] and str(cmd.type) == str(i["type"]) and cmd.guild_ids is not None
-                                       and (int(i["guild_id"])) in cmd.guild_ids, self.pending_application_commands)
+                                       and int(i["guild_id"]) in cmd.guild_ids, self.pending_application_commands)
                 if not cmd:
                     # command has not been added yet
                     continue

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -577,8 +577,8 @@ class ApplicationCommandMixin:
             guild_permissions: List = []
 
             for i in commands:
-                cmd = find(lambda cmd: cmd.name == i["name"] and cmd.type == i["type"] and cmd.guild_ids is not None
-                                       and (i["guild_id"]) in cmd.guild_ids, self.pending_application_commands)
+                cmd = find(lambda cmd: cmd.name == i["name"] and str(cmd.type) == str(i["type"]) and cmd.guild_ids is not None
+                                       and (int(i["guild_id"])) in cmd.guild_ids, self.pending_application_commands)
                 cmd.id = i["id"]
                 self._application_commands[cmd.id] = cmd
 


### PR DESCRIPTION
## Summary

Previously, the 'type' and 'guild_id' variables couldn't match because they weren't of the same type. I've now changed the types so they can compare with the correct types.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
