### PR TITLE
Add typing back to actx.author 

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -159,7 +159,7 @@ class ApplicationContext(discord.abc.Messageable):
     def user(self) -> Optional[Union[Member, User]]:
         return self.interaction.user
 
-    author = user
+    author: Optional[Union[Member, User]] = user
 
     @property
     def voice_client(self) -> Optional[VoiceProtocol]:


### PR DESCRIPTION
## Summary

Redo of #464, which was reverted without explanation in #848

After reflection, this new PR handles it in a slightly more appropriate way instead of defining an entirely new cached_property for what's effectively an alias from `author` to `user`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
