### PR TITLE
Update on_member_update in event reference docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -955,6 +955,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     - nickname
     - roles
     - pending
+    - communication_disabled_until
+    - timed_out
 
     This requires :attr:`Intents.members` to be enabled.
 


### PR DESCRIPTION
# Warning: We have a feature freeze till release
That means we won't accept new features for now. Only bug fixes.

## Summary
If a user is given a timeout, this is captured by on_member_update, so it should reflect in the docs to avoid people being confused as to whether on_member_update is called when a user is given/no longer has a timeout
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
