### PR TITLE
Add `selected_options` and `unselected_options` properties to `ApplicationContext`

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Optional, TypeVar, Union, Dict, List
 
 import discord.abc
 from discord.interactions import InteractionMessage
@@ -171,6 +171,26 @@ class ApplicationContext(discord.abc.Messageable):
     @cached_property
     def response(self) -> InteractionResponse:
         return self.interaction.response
+
+    @property
+    def selected_options(self) -> Optional[List[Dict]]:
+        """Returns a dictionary containing the options and values that were selected by the user, if applicable."""
+        if "options" in self.interaction.data:
+            return self.interaction.data["options"]
+        return None
+
+    @property
+    def unselected_options(self) -> Optional[List[Dict]]:
+        """Returns a dictionary containing the options that were not selected by the user, if applicable."""
+        if self.command.options is not None:  # type: ignore
+            selected = [opt["name"] for opt in self.selected_options]
+            return [
+                {"name": option.to_dict()["name"]}
+                for option in self.command.options  # type: ignore
+                if option.to_dict()["name"] not in selected
+            ]
+
+        return None
 
     @property
     def respond(self) -> Callable[..., Awaitable[Union[Interaction, WebhookMessage]]]:

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -185,7 +185,7 @@ class ApplicationContext(discord.abc.Messageable):
         if self.command.options is not None:  # type: ignore
             selected = [opt["name"] for opt in self.selected_options]
             return [
-                {"name": option.to_dict()["name"]}
+                option.to_dict()
                 for option in self.command.options  # type: ignore
                 if option.to_dict()["name"] not in selected
             ]

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -178,14 +178,26 @@ class ApplicationContext(discord.abc.Messageable):
 
     @property
     def selected_options(self) -> Optional[List[Dict]]:
-        """Returns a dictionary containing the options and values that were selected by the user when the command was processed, if applicable."""
+        """The options and values that were selected by the user when sending the command.
+
+        Returns
+        -------
+        Optional[List[Dict]]
+            A dictionary containing the options and values that were selected by the user when the command was processed, if applicable.
+        """
         if "options" in self.interaction.data:
             return self.interaction.data["options"]
         return None
 
     @property
     def unselected_options(self) -> Optional[List[Option]]:
-        """Returns a list of Option objects (if any) that were not selected by the user when the command was processed."""
+        """The options that were not provided by the user when sending the command.
+
+        Returns
+        -------
+        Optional[List[:class:`.Option`]]
+            A list of Option objects (if any) that were not selected by the user when the command was processed.
+        """
         if self.command.options is not None:  # type: ignore
             return [
                 option

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -174,22 +174,20 @@ class ApplicationContext(discord.abc.Messageable):
 
     @property
     def selected_options(self) -> Optional[List[Dict]]:
-        """Returns a dictionary containing the options and values that were selected by the user, if applicable."""
+        """Returns a dictionary containing the options and values that were selected by the user when the command was processed, if applicable."""
         if "options" in self.interaction.data:
             return self.interaction.data["options"]
         return None
 
     @property
-    def unselected_options(self) -> Optional[List[Dict]]:
-        """Returns a dictionary containing the options that were not selected by the user, if applicable."""
+    def unselected_options(self) -> Optional[List[Option]]:
+        """Returns a list of Option objects (if any) that were not selected by the user when the command was processed."""
         if self.command.options is not None:  # type: ignore
-            selected = [opt["name"] for opt in self.selected_options]
             return [
                 option
                 for option in self.command.options  # type: ignore
-                if option.to_dict()["name"] not in selected
+                if option.to_dict()["name"] not in [opt["name"] for opt in self.selected_options]
             ]
-
         return None
 
     @property

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -185,7 +185,7 @@ class ApplicationContext(discord.abc.Messageable):
         if self.command.options is not None:  # type: ignore
             selected = [opt["name"] for opt in self.selected_options]
             return [
-                option.to_dict()
+                option
                 for option in self.command.options  # type: ignore
                 if option.to_dict()["name"] not in selected
             ]


### PR DESCRIPTION
## Summary

Adds two new properties to `ApplicationContext`:

`selected_options` - Returns a dictionary containing the options and values that were selected by the user when the command was processed, if applicable.

`unselected_options` - Returns a list of Option objects (if any) that were not selected by the user when the command was processed.

These are mostly useful for handling things like command logging in `on_application_command` and such, and serves as an easier way to get the data than the user needing to do the parsing of `actx.interaction.data` themselves.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
