### PR TITLE
Use a comment for feature freeze notice

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-# Warning: We have a feature freeze till release
-That means we won't accept new features for now. Only bug fixes.
+<!-- Warning: No new features will be merged until the next stable release. -->
 
 ## Summary
 


### PR DESCRIPTION
## Summary
Turns the feature freeze notice into a comment instead of a heading.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
