### PR TITLE
Remove debug_guild references

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1403,8 +1403,8 @@ class Bot(BotBase, Client):
 
         .. versionadded:: 1.3
     debug_guilds: Optional[List[:class:`int`]]
-        Guild IDs of guilds to use for testing commands. This is similar to debug_guild.
-        The bot will not create any global commands if a debug_guilds is passed.
+        Guild IDs of guilds to use for testing commands.
+        The bot will not create any global commands if debug guild IDs are passed.
 
         ..versionadded:: 2.0
     auto_sync_commands: :class:`bool`

--- a/examples/app_commands/slash_cog_groups.py
+++ b/examples/app_commands/slash_cog_groups.py
@@ -2,7 +2,7 @@ import discord
 from discord.commands import CommandPermission, SlashCommandGroup
 from discord.ext import commands
 
-bot = discord.Bot(debug_guild=..., owner_id=...)  # main file
+bot = discord.Bot(debug_guilds=[...], owner_id=...)  # main file
 
 
 class Example(commands.Cog):


### PR DESCRIPTION
## Summary
This parameter has been deprecated.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)