### PR TITLE
Fix typo in comment

### DIFF
--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -135,7 +135,7 @@ async def autocomplete_example(
     color: Option(str, "Pick a color!", autocomplete=get_colors),
     animal: Option(str, "Pick an animal!", autocomplete=get_animals),
 ):
-    """This demonstrates using the ctx.options parameter to to create slash command options that are dependent on the values entered for other options."""
+    """This demonstrates using the ctx.options parameter to create slash command options that are dependent on the values entered for other options."""
     await ctx.respond(
         f"You picked {color} for the color, which allowed you to choose {animal} for the animal."
     )


### PR DESCRIPTION
## Summary

fix: typo

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
 