### PR TITLE
fix cog.walk_commands() and SlashCommandGroup

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Mapping, ClassVar, Dict, Generator, List, Opti
 
 import discord.utils
 from . import errors
-from .commands import _BaseCommand, ApplicationCommand, ApplicationContext
+from .commands import _BaseCommand, ApplicationCommand, ApplicationContext, SlashCommandGroup
 
 __all__ = (
     'CogMeta',
@@ -275,8 +275,13 @@ class Cog(metaclass=CogMeta):
             A command or group from the cog.
         """
         for command in self.__cog_commands__:
-            if command.parent is None:
-                yield command
+            if isinstance(command, SlashCommandGroup):
+                for subcommand in command.subcommands:
+                    if subcommand.parent is not None:
+                        for sub_subcommand in subcommand.subcommands:
+                            yield sub_subcommand
+                    else:
+                        yield subcommand
 
     def get_listeners(self) -> List[Tuple[str, Callable[..., Any]]]:
         """Returns a :class:`list` of (name, function) listener pairs that are defined in this cog.

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -276,12 +276,7 @@ class Cog(metaclass=CogMeta):
         """
         for command in self.__cog_commands__:
             if isinstance(command, SlashCommandGroup):
-                for subcommand in command.subcommands:
-                    if subcommand.parent is not None:
-                        for sub_subcommand in subcommand.subcommands:
-                            yield sub_subcommand
-                    else:
-                        yield subcommand
+                yield from command.walk_commands()
 
     def get_listeners(self) -> List[Tuple[str, Callable[..., Any]]]:
         """Returns a :class:`list` of (name, function) listener pairs that are defined in this cog.

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -184,10 +184,9 @@ class ApplicationContext(discord.abc.Messageable):
         -------
         Optional[List[Dict]]
             A dictionary containing the options and values that were selected by the user when the command was processed, if applicable.
+            Returns ``None`` if the command has not yet been invoked, or if there are no options defined for that command.
         """
-        if "options" in self.interaction.data:
-            return self.interaction.data["options"]
-        return None
+        return self.interaction.data.get("options", None)
 
     @property
     def unselected_options(self) -> Optional[List[Option]]:
@@ -197,13 +196,17 @@ class ApplicationContext(discord.abc.Messageable):
         -------
         Optional[List[:class:`.Option`]]
             A list of Option objects (if any) that were not selected by the user when the command was processed.
+            Returns ``None`` if there are no options defined for that command.
         """
         if self.command.options is not None:  # type: ignore
-            return [
-                option
-                for option in self.command.options  # type: ignore
-                if option.to_dict()["name"] not in [opt["name"] for opt in self.selected_options]
-            ]
+            if self.selected_options:
+                return [
+                    option
+                    for option in self.command.options  # type: ignore
+                    if option.to_dict()["name"] not in [opt["name"] for opt in self.selected_options]
+                ]
+            else:
+                return self.command.options  # type: ignore
         return None
 
     @property

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -495,6 +495,9 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         else:
             return self.name
 
+    def __str__(self) -> str:
+        return self.qualified_name
+
     def _set_cog(self, cog):
         self.cog = cog
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -59,7 +59,6 @@ class Cog(Cog):
             A command or group from the cog.
         """
         from .core import GroupMixin
-        print(self.__cog_commands__)
         for command in self.__cog_commands__:
             if not isinstance(command, ApplicationCommand):
                 if command.parent is None:
@@ -67,15 +66,7 @@ class Cog(Cog):
                     if isinstance(command, GroupMixin):
                         yield from command.walk_commands()
             elif isinstance(command, SlashCommandGroup):
-                for subcommand in command.subcommands:
-                    print(subcommand)
-                    print(subcommand.parent)
-                    if subcommand.parent is not None and isinstance(subcommand, SlashCommandGroup):
-                        print("reach")
-                        for sub_subcommand in subcommand.subcommands:
-                            yield sub_subcommand
-                    else:
-                        yield subcommand
+                yield from command.walk_commands()
             else:
                 yield command
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -29,7 +29,7 @@ from ...cog import Cog
 
 from typing import Any, Callable, Generator, TYPE_CHECKING, List, TypeVar, Type, Union
 
-from ...commands import ApplicationCommand
+from ...commands import ApplicationCommand, SlashCommandGroup
 
 if TYPE_CHECKING:
     from .core import Command
@@ -59,14 +59,25 @@ class Cog(Cog):
             A command or group from the cog.
         """
         from .core import GroupMixin
+        print(self.__cog_commands__)
         for command in self.__cog_commands__:
-            if isinstance(command, ApplicationCommand):
-                yield command
-            else:
+            if not isinstance(command, ApplicationCommand):
                 if command.parent is None:
                     yield command
                     if isinstance(command, GroupMixin):
                         yield from command.walk_commands()
+            elif isinstance(command, SlashCommandGroup):
+                for subcommand in command.subcommands:
+                    print(subcommand)
+                    print(subcommand.parent)
+                    if subcommand.parent is not None and isinstance(subcommand, SlashCommandGroup):
+                        print("reach")
+                        for sub_subcommand in subcommand.subcommands:
+                            yield sub_subcommand
+                    else:
+                        yield subcommand
+            else:
+                yield command
 
     def get_commands(self) -> List[Union[ApplicationCommand, Command]]:
         r"""


### PR DESCRIPTION
## Summary

SlashCommandGroup's don't show their subcommands inside cog.walk_commands()

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)