### PR TITLE
Add `type` property to `InputText`

### DIFF
--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -72,6 +72,10 @@ class InputText(Item):
         self.row = row
 
     @property
+    def type(self) -> ComponentType:
+        return self._underlying.type
+        
+    @property
     def style(self) -> InputTextStyle:
         """:class:`discord.InputTextStyle`: The style of the input text field."""
         return self._underlying.style


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`InputText` was probably supposed to implement the `type` property as it is a subclass of `Item`, however, it doesn't.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue, i guess.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
