### PR TITLE
Make `get_desynced_commands` work with slash command groups

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -939,6 +939,7 @@ class ApplicationCommandMixin(ABC):
         name: str,
         description: Optional[str] = None,
         guild_ids: Optional[List[int]] = None,
+        **kwargs
     ) -> SlashCommandGroup:
         """A shortcut method that creates a slash command group with no subcommands and adds it to the internal
         command list via :meth:`~.ApplicationCommandMixin.add_application_command`.
@@ -954,6 +955,8 @@ class ApplicationCommandMixin(ABC):
         guild_ids: Optional[List[:class:`int`]]
             A list of the IDs of each guild this group should be added to, making it a guild command.
             This will be a global command if ``None`` is passed.
+        kwargs:
+            Any additional keyword arguments to pass to :class:`.SlashCommandGroup`.
 
         Returns
         --------
@@ -961,7 +964,7 @@ class ApplicationCommandMixin(ABC):
             The slash command group that was created.
         """
         description = description or "No description provided."
-        group = SlashCommandGroup(name, description, guild_ids)
+        group = SlashCommandGroup(name, description, guild_ids, **kwargs)
         self.add_application_command(group)
         return group
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -289,7 +289,7 @@ class ApplicationCommandMixin(ABC):
                             ]:
                                 # We have a difference
                                 return True
-                    elif getattr(cmd, check) != match[check]:
+                    elif getattr(cmd, check) != match.get(check):
                         # We have a difference
                         return True
                 return False

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -940,6 +940,8 @@ class SlashCommandGroup(ApplicationCommand):
         self.permissions: List[CommandPermission] = kwargs.get("permissions", [])
         if self.permissions and self.default_permission:
             self.default_permission = False
+        self.name_localizations: Optional[Dict[str, str]] = kwargs.get("name_localizations", None)
+        self.description_localizations: Optional[Dict[str, str]] = kwargs.get("description_localizations", None)
 
     @property
     def module(self) -> Optional[str]:
@@ -952,6 +954,10 @@ class SlashCommandGroup(ApplicationCommand):
             "options": [c.to_dict() for c in self.subcommands],
             "default_permission": self.default_permission,
         }
+        if self.name_localizations is not None:
+            as_dict["name_localizations"] = self.name_localizations
+        if self.description_localizations is not None:
+            as_dict["description_localizations"] = self.description_localizations
 
         if self.parent is not None:
             as_dict["type"] = self.input_type.value


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary
Update `get_desynced_commands` function to be able to properly work with slash command groups.
This PR implements recursive slash commands traversing to compare all nested subcommands.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
