### PR TITLE
Modal and InputText updates/fixes

### DIFF
--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -181,6 +181,7 @@ class InputText(Item):
 
 
 def input_text(
+    *,
     style: InputTextStyle = InputTextStyle.short,
     custom_id: str = MISSING,
     label: Optional[str] = None,

--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -63,6 +63,7 @@ class InputText(Item):
         super().__init__()
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         self._underlying = InputTextComponent._raw_construct(
+            type=ComponentType.input_text,
             style=style,
             custom_id=custom_id,
             label=label,
@@ -201,8 +202,6 @@ def input_text(
     In order to get the provided text that the user has input within the callback
     use :attr:`InputText.value`.
 
-    Parameters
-    ------------
     Parameters
     ----------
     style: :class:`discord.InputTextStyle`

--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from ..types.components import InputText as InputTextComponentPayload
 
 
-class InputText(Item):
+class InputText:
     """Represents a UI text input field.
 
     Parameters

--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -11,7 +11,6 @@ from .item import ItemCallbackType
 
 __all__ = (
     "InputText",
-    "input_text",
 )
 
 if TYPE_CHECKING:
@@ -180,72 +179,3 @@ class InputText:
 
     def refresh_state(self, data) -> None:
         self._input_value = data["value"]
-
-
-def input_text(
-    *,
-    style: InputTextStyle = InputTextStyle.short,
-    custom_id: str = MISSING,
-    label: Optional[str] = None,
-    placeholder: Optional[str] = None,
-    min_length: Optional[int] = None,
-    max_length: Optional[int] = None,
-    required: Optional[bool] = True,
-    value: Optional[str] = None,
-    row: Optional[int] = None,
-) -> Callable[[ItemCallbackType], ItemCallbackType]:
-    """A decorator that attaches an input text field to a component.
-
-    The function being decorated should have three parameters, ``self`` representing
-    the :class:`discord.ui.View`, the :class:`discord.ui.InputText` being pressed and
-    the :class:`discord.Interaction` you receive.
-
-    In order to get the provided text that the user has input within the callback
-    use :attr:`InputText.value`.
-
-    Parameters
-    ----------
-    style: :class:`discord.InputTextStyle`
-        The style of the input text field.
-    custom_id: Optional[:class:`str`]
-        The ID of the input text field that gets received during an interaction.
-    label: Optional[:class:`str`]
-        The label for the input text field, if any.
-    placeholder: Optional[:class:`str`]
-        The placeholder text that is shown if nothing is selected, if any.
-    min_length: Optional[:class:`int`]
-        The minimum number of characters that must be entered.
-        Defaults to 0.
-    max_length: Optional[:class:`int`]
-        The maximum number of characters that can be entered.
-    required: Optional[:class:`bool`]
-        Whether the input text field is required or not. Defaults to `True`.
-    value: Optional[:class:`str`]
-        Pre-fills the input text field with this value.
-    row: Optional[:class:`int`]
-        The relative row this button belongs to. A Discord component can only have 5
-        rows. By default, items are arranged automatically into those 5 rows. If you'd
-        like to control the relative positioning of the row then passing an index is advised.
-        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
-        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
-    """
-
-    def decorator(func: ItemCallbackType) -> ItemCallbackType:
-        if not inspect.iscoroutinefunction(func):
-            raise TypeError("input_text function must be a coroutine function")
-
-        func.__discord_ui_model_type__ = InputText
-        func.__discord_ui_model_kwargs__ = {
-            "style": style,
-            "custom_id": custom_id,
-            "label": label,
-            "placeholder": placeholder,
-            "min_length": min_length,
-            "max_length": max_length,
-            "required": required,
-            "value": value,
-            "row": row,
-        }
-        return func
-
-    return decorator

--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 from ..components import InputText as InputTextComponent
 from ..enums import ComponentType, InputTextStyle
 from ..utils import MISSING
-from .item import Item, ItemCallbackType
+from .item import ItemCallbackType
 
 __all__ = (
     "InputText",

--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import inspect
 import os
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Optional
 
 from ..components import InputText as InputTextComponent
 from ..enums import ComponentType, InputTextStyle
 from ..utils import MISSING
-from .item import ItemCallbackType
 
 __all__ = (
     "InputText",

--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -50,6 +50,7 @@ class InputText(Item):
 
     def __init__(
         self,
+        *,
         style: InputTextStyle = InputTextStyle.short,
         custom_id: str = MISSING,
         label: Optional[str] = None,

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import os
 from itertools import groupby
-from functools import partial
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, ClassVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from .item import ItemCallbackType
 from .input_text import InputText
 
 __all__ = (
@@ -24,27 +22,10 @@ class Modal:
 
     This object must be inherited to create a UI within Discord.
     """
-    __discord_ui_modal__: ClassVar[bool] = True
-    __modal_children_items__: ClassVar[List[ItemCallbackType]] = []
-
     def __init__(self, title: str, custom_id: Optional[str] = None) -> None:
         self.custom_id = custom_id or os.urandom(16).hex()
         self.title = title
         self.children: List[InputText] = []
-        for func in self.__modal_children_items__:
-            item: InputText = func.__discord_ui_model_type__(**func.__discord_ui_model_kwargs__)
-            item.callback = partial(func, self, item)
-            setattr(self, func.__name__, item)
-            self.children.append(item)
-
-    def __init_subclass__(cls) -> None:
-        children: List[ItemCallbackType] = []
-        for base in reversed(cls.__mro__):
-            for member in base.__dict__.values():
-                if hasattr(member, '__discord_ui_model_type__'):
-                    children.append(member)
-
-        cls.__modal_children_items__ = children
 
     async def callback(self, interaction: Interaction):
         """|coro|

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -60,7 +60,7 @@ class Modal:
 
     def to_components(self) -> List[Dict[str, Any]]:
         def key(item: InputText) -> int:
-            return item._rendered_row or 0
+            return item.row or 0
 
         children = sorted(self.children, key=key)
         components: List[Dict[str, Any]] = []

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -5,7 +5,7 @@ from itertools import groupby
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, ClassVar
 
-from .item import Item, ItemCallbackType
+from .item import ItemCallbackType
 from .input_text import InputText
 
 __all__ = (

--- a/examples/modal_dialogs.py
+++ b/examples/modal_dialogs.py
@@ -12,8 +12,8 @@ bot = Bot()
 
 
 class MyModal(Modal):
-    def __init__(self) -> None:
-        super().__init__("Test Modal Dialog")
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self.add_item(InputText(label="Short Input", placeholder="Placeholder Test"))
 
         self.add_item(
@@ -34,14 +34,14 @@ class MyModal(Modal):
 @bot.slash_command(name="modaltest", guild_ids=[...])
 async def modal_slash(ctx):
     """Shows an example of a modal dialog being invoked from a slash command."""
-    modal = MyModal()
+    modal = MyModal(title="Slash Command Modal")
     await ctx.interaction.response.send_modal(modal)
 
 
 @bot.message_command(name="messagemodal", guild_ids=[...])
 async def modal_message(ctx, message):
     """Shows an example of a modal dialog being invoked from a message command."""
-    modal = MyModal()
+    modal = MyModal(title="Message Command Modal")
     modal.title = f"Modal for Message ID: {message.id}"
     await ctx.interaction.response.send_modal(modal)
 
@@ -49,7 +49,7 @@ async def modal_message(ctx, message):
 @bot.user_command(name="usermodal", guild_ids=[...])
 async def modal_user(ctx, member):
     """Shows an example of a modal dialog being invoked from a user command."""
-    modal = MyModal()
+    modal = MyModal(title="User Command Modal")
     modal.title = f"Modal for User: {member.display_name}"
     await ctx.interaction.response.send_modal(modal)
 
@@ -61,7 +61,7 @@ async def modaltest(ctx):
     class MyView(discord.ui.View):
         @discord.ui.button(label="Modal Test", style=discord.ButtonStyle.primary)
         async def button_callback(self, button, interaction):
-            modal = MyModal()
+            modal = MyModal(title="Modal Triggered from Button")
             await interaction.response.send_modal(modal)
 
         @discord.ui.select(
@@ -78,7 +78,7 @@ async def modaltest(ctx):
             ],
         )
         async def select_callback(self, select, interaction):
-            modal = MyModal()
+            modal = MyModal(title="Temporary Title")
             modal.title = select.values[0]
             await interaction.response.send_modal(modal)
 


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This PR does the following:

1. Removes `Item` inheritance from `InputText` as it's not needed for the latter to work
2. Removes weights from `Modal` as it's not needed to determine whether a component will fit or not (only one input text fits per row, and only 5 rows are allowed).
3. Fixes args/kwargs usage (includes change from #984)
4. Updates examples to better reflect the above change

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
