### PR TITLE
Move dev requirements to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 aiohttp>=3.6.0,<3.9.0
-pre-commit


### PR DESCRIPTION
## Summary
`pre-commit` was added to requirements.txt, but isn't required outside a development environment. This PR fixes that.
