### PR TITLE
Fix #982

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1063,7 +1063,9 @@ class SlashCommandGroup(ApplicationCommand):
 
     async def _invoke(self, ctx: ApplicationContext) -> None:
         option = ctx.interaction.data["options"][0]
+        resolved = ctx.interaction.data.get("resolved", None)
         command = find(lambda x: x.name == option["name"], self.subcommands)
+        option["resolved"] = resolved
         ctx.interaction.data = option
         await command.invoke(ctx)
 


### PR DESCRIPTION
## Summary

Fixes attachments not working in subcommands

<details>
    <summary>I tested this with the code in #1004</summary>
    <br>

```py
import discord

bot = discord.Bot()

cmd = bot.create_group("cmd", "a group")
sub = cmd.create_subgroup("sub", "another sub")

@sub.command(name="subest")
async def cmd_sub_subest(ctx, image: discord.Option(discord.Attachment, description="Your image")):
    await ctx.respond(image.url)

bot.run("token")
```

</details>

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
