### PR TITLE
Add `wait()` method to `Modal` class

### DIFF
--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -102,7 +102,7 @@ class Modal:
             self._stopped.set_result(True)
 
     async def wait(self) -> bool:
-        """Waits for the modal dialog to be closed."""
+        """Waits for the modal dialog to be submitted."""
         return await self._stopped
 
     def to_dict(self):

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 from itertools import groupby
@@ -29,6 +30,8 @@ class Modal:
         self.title = title
         self.children: List[InputText] = []
         self.__weights = _ModalWeights(self.children)
+        loop = asyncio.get_running_loop()
+        self._stopped: asyncio.Future[bool] = loop.create_future()
 
     async def callback(self, interaction: Interaction):
         """|coro|
@@ -40,7 +43,7 @@ class Modal:
         interaction: :class:`~discord.Interaction`
             The interaction that submitted the modal dialog.
         """
-        pass
+        self.stop()
 
     def to_components(self) -> List[Dict[str, Any]]:
         def key(item: InputText) -> int:
@@ -92,6 +95,15 @@ class Modal:
             self.children.remove(item)
         except ValueError:
             pass
+
+    def stop(self) -> None:
+        """Stops listening to interaction events from the modal dialog."""
+        if not self._stopped.done():
+            self._stopped.set_result(True)
+
+    async def wait(self) -> bool:
+        """Waits for the modal dialog to be closed."""
+        return await self._stopped
 
     def to_dict(self):
         return {


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This adds a `wait()` (and supporting `stop()`) method to the `Modal` class, similar to the one used for `View`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
