### PR TITLE
Add Message Content Intent

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -533,11 +533,12 @@ class Intents(BaseFlags):
     @classmethod
     def default(cls: Type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled
-        except :attr:`presences` and :attr:`members`.
+        except :attr:`presences`, :attr:`members`, and :attr:`message_content`.
         """
         self = cls.all()
         self.presences = False
         self.members = False
+        self.message_content = False
         return self
 
     @flag_value
@@ -757,9 +758,7 @@ class Intents(BaseFlags):
 
         .. note::
 
-            As of April 2022 requires opting in explicitly via the developer portal to receive the actual content of the guild messages.
-            Bots in over 100 guilds will need to apply to Discord for verification.
-            See https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Access-Deprecation-for-Verified-Bots for more information.
+            :attr:`message_content` is required to recieve the actual content of guild messages.
         """
         return (1 << 9) | (1 << 12)
 
@@ -799,9 +798,7 @@ class Intents(BaseFlags):
 
         .. note::
 
-            As of April 2022 requires opting in explicitly via the developer portal to receive the actual content of the messages.
-            Bots in over 100 guilds will need to apply to Discord for verification.
-            See https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Access-Deprecation-for-Verified-Bots for more information.
+            :attr:`message_content` is required to recieve the actual content of guild messages.
         """
         return 1 << 9
 
@@ -937,6 +934,31 @@ class Intents(BaseFlags):
         """
         return 1 << 14
 
+    @flag_value
+    def message_content(self):
+        """:class:`bool`: Whether the bot will recieve message content in guild messages.
+
+        This corresponds to the following attributes:
+
+        - :attr:`Message.content`
+        - :attr:`Message.embeds`
+        - :attr:`Message.attachments`
+        - :attr:`Message.components`
+        
+        These attributes will still be available for messages recieved from interactions, 
+        the bot's own messages, messages the bot was mentioned in, and DMs.
+        
+        .. versionadded:: 2.0
+        
+        .. note::
+
+            As of April 2022 requires opting in explicitly via the developer portal to receive the actual content of the guild messages.
+            Bots in over 100 guilds will need to apply to Discord for verification.
+            See https://support-dev.discord.com/hc/en-us/articles/4404772028055 for more information.
+            
+        """
+        return 1 << 15
+    
     @flag_value
     def scheduled_events(self):
         """:class:`bool`: Whether "scheduled event" related events are enabled.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -787,7 +787,7 @@ class Intents(BaseFlags):
         - :func:`on_reaction_remove` (only for guilds)
         - :func:`on_reaction_clear` (only for guilds)
 
-        Without the :attr:`ApplicationFlags.gateway_message_content` intent enabled, the following fields are either an empty string or empty array:
+        Without the :attr:`message_content` intent enabled, the following fields are either an empty string or empty array:
 
         - :attr:`Message.content`
         - :attr:`Message.embeds`
@@ -795,10 +795,6 @@ class Intents(BaseFlags):
         - :attr:`Message.components`
 
         For more information go to the :ref:`message content intent documentation <need_message_content_intent>`.
-
-        .. note::
-
-            :attr:`message_content` is required to receive the actual content of guild messages.
         """
         return 1 << 9
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -932,21 +932,21 @@ class Intents(BaseFlags):
         - :attr:`Message.embeds`
         - :attr:`Message.attachments`
         - :attr:`Message.components`
-        
-        These attributes will still be available for messages received from interactions, 
+
+        These attributes will still be available for messages received from interactions,
         the bot's own messages, messages the bot was mentioned in, and DMs.
-        
+
         .. versionadded:: 2.0
-        
+
         .. note::
 
             As of April 2022 requires opting in explicitly via the developer portal to receive the actual content of the guild messages.
             Bots in over 100 guilds will need to apply to Discord for verification.
             See https://support-dev.discord.com/hc/en-us/articles/4404772028055 for more information.
-            
+
         """
         return 1 << 15
-    
+
     @flag_value
     def scheduled_events(self):
         """:class:`bool`: Whether "scheduled event" related events are enabled.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -758,7 +758,7 @@ class Intents(BaseFlags):
 
         .. note::
 
-            :attr:`message_content` is required to recieve the actual content of guild messages.
+            :attr:`message_content` is required to receive the actual content of guild messages.
         """
         return (1 << 9) | (1 << 12)
 
@@ -798,7 +798,7 @@ class Intents(BaseFlags):
 
         .. note::
 
-            :attr:`message_content` is required to recieve the actual content of guild messages.
+            :attr:`message_content` is required to receive the actual content of guild messages.
         """
         return 1 << 9
 
@@ -936,7 +936,7 @@ class Intents(BaseFlags):
 
     @flag_value
     def message_content(self):
-        """:class:`bool`: Whether the bot will recieve message content in guild messages.
+        """:class:`bool`: Whether the bot will receive message content in guild messages.
 
         This corresponds to the following attributes:
 
@@ -945,7 +945,7 @@ class Intents(BaseFlags):
         - :attr:`Message.attachments`
         - :attr:`Message.components`
         
-        These attributes will still be available for messages recieved from interactions, 
+        These attributes will still be available for messages received from interactions, 
         the bot's own messages, messages the bot was mentioned in, and DMs.
         
         .. versionadded:: 2.0


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

Adds the message content intent flag as described in https://github.com/discord/discord-api-docs/discussions/4510, as well as their [support article](https://support-dev.discord.com/hc/en-us/articles/4404772028055).
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
