### PR TITLE
Properly set Black to use 120 characters for line length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     -   id: black
         args: # arguments to configure black
-          - --line-length=88
+          - --line-length=120
 -   repo: https://github.com/ikamensh/flynt/
     rev: '0.76'
     hooks:


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

Updates Black arguments in pre-commit workflow to use 120 characters for line length. Was inadvertently left out of 429dadce242bcdd8cfc224a072a5558497d0618b

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
