### PR TITLE
chore: deprecate `actx.respond` for `actx.send`

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
 import discord.abc
 from discord.interactions import InteractionMessage
+from discord.utils import deprecated
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
@@ -221,13 +222,27 @@ class ApplicationContext(discord.abc.Messageable):
         return None
 
     @property
+    @deprecated('ApplicationContext.send')
     def respond(self) -> Callable[..., Awaitable[Union[Interaction, WebhookMessage]]]:
+        """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response
+        or a followup response depending if the interaction has been responded to yet or not.
+        
+        .. deprecated:: 2.0.0b5
+        """
+        if not self.interaction.response.is_done():
+            return self.interaction.response.send_message  # self.response
+        else:
+            return self.followup.send  # self.send_followup
+    
+    @property
+    def send(self) -> Callable[..., Awaitable[Union[Interaction, WebhookMessage]]]:
         """Callable[..., Union[:class:`~.Interaction`, :class:`~.Webhook`]]: Sends either a response
         or a followup response depending if the interaction has been responded to yet or not."""
         if not self.interaction.response.is_done():
             return self.interaction.response.send_message  # self.response
         else:
             return self.followup.send  # self.send_followup
+
 
     @property
     def send_response(self) -> Callable[..., Awaitable[Interaction]]:


### PR DESCRIPTION
## Summary

Deprecates ApplicationContext.respond for the new ApplicationContext.send

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
