### PR TITLE
Change __title__ to pycord

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -9,7 +9,7 @@ A basic wrapper for the Discord API.
 
 """
 
-__title__ = 'discord'
+__title__ = 'pycord'
 __author__ = 'Pycord Development'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2021 Rapptz & Copyright 2021-present Pycord Development'


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary
Changes the dunder title attribute to "pycord".