### PR TITLE
Set force to default true (registration rewrite 2)

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -347,7 +347,7 @@ class ApplicationCommandMixin:
         self,
         commands: Optional[List[ApplicationCommand]] = None,
         guild_id: Optional[int] = None,
-        force: bool = False,
+        force: bool = True,
     ) -> List[interactions.ApplicationCommand]:
         """|coro|
 
@@ -363,9 +363,10 @@ class ApplicationCommandMixin:
             If this is set, the commands will be registered as a guild command for the respective guild. If it is not
             set, the commands will be registered according to their :attr:`~.ApplicationCommand.guild_ids` attribute.
         force: :class:`bool`
-            Registers the commands regardless of the state of the command on discord, this can take up more API calls
-            but is sometimes a more foolproof method of registering commands. This also sometimes causes minor bugs
-            where the command can temporarily appear as an invalid command on the user's side. Defaults to False.
+            Registers the commands regardless of the state of the command on discord, this can sometimes cause commands
+            to be re-registred without changes (The command can temporarily appear as an invalid command on the user's
+            side) due to a bug in the API, but is a more foolproof method of registering
+            commands. Defaults to True.
         """
         if commands is None:
             commands = self.pending_application_commands
@@ -491,7 +492,7 @@ class ApplicationCommandMixin:
     async def sync_commands(
         self,
         commands: Optional[List[ApplicationCommand]] = None,
-        force: bool = False,
+        force: bool = True,
         guild_ids: Optional[List[int]] = None,
         register_guild_commands: bool = True,
         unregister_guilds: Optional[List[int]] = None,
@@ -518,9 +519,9 @@ class ApplicationCommandMixin:
         commands: Optional[List[:class:`~.ApplicationCommand`]]
             A list of commands to register. If this is not set (None), then all commands will be registered.
         force: :class:`bool`
-            Registers the commands regardless of the state of the command on discord, this can take up more API calls
-            but is sometimes a more foolproof method of registering commands. This also allows the bot to dynamically
-            remove stale commands. Defaults to False.
+            Registers the commands regardless of the state of the command on discord, this can sometimes cause commands
+            to be re-registred without changes due to a bug in the API, but is sometimes a more foolproof method of
+            registering commands. Defaults to True.
         guild_ids: Optional[List[:class:`int`]]
             A list of guild ids to register the commands for. If this is not set, the commands'
             :attr:`~.ApplicationCommand.guild_ids` attribute will be used.

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -363,7 +363,7 @@ class ApplicationCommandMixin:
             If this is set, the commands will be registered as a guild command for the respective guild. If it is not
             set, the commands will be registered according to their :attr:`~.ApplicationCommand.guild_ids` attribute.
         force: :class:`bool`
-            Registers the commands regardless of the state of the command on discord, this can sometimes cause commands
+            Registers the commands regardless of the state of the command on Discord. This can sometimes cause commands
             to be re-registered without changes (The command can temporarily appear as an invalid command on the user's
             side) due to a bug in the API, but is a more foolproof method of registering
             commands. Defaults to True.

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -364,7 +364,7 @@ class ApplicationCommandMixin:
             set, the commands will be registered according to their :attr:`~.ApplicationCommand.guild_ids` attribute.
         force: :class:`bool`
             Registers the commands regardless of the state of the command on discord, this can sometimes cause commands
-            to be re-registred without changes (The command can temporarily appear as an invalid command on the user's
+            to be re-registered without changes (The command can temporarily appear as an invalid command on the user's
             side) due to a bug in the API, but is a more foolproof method of registering
             commands. Defaults to True.
         """

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -520,7 +520,7 @@ class ApplicationCommandMixin:
             A list of commands to register. If this is not set (None), then all commands will be registered.
         force: :class:`bool`
             Registers the commands regardless of the state of the command on discord, this can sometimes cause commands
-            to be re-registred without changes due to a bug in the API, but is sometimes a more foolproof method of
+            to be re-registered without changes due to a bug in the API, but is sometimes a more foolproof method of
             registering commands. Defaults to True.
         guild_ids: Optional[List[:class:`int`]]
             A list of guild ids to register the commands for. If this is not set, the commands'

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -519,7 +519,7 @@ class ApplicationCommandMixin:
         commands: Optional[List[:class:`~.ApplicationCommand`]]
             A list of commands to register. If this is not set (None), then all commands will be registered.
         force: :class:`bool`
-            Registers the commands regardless of the state of the command on discord, this can sometimes cause commands
+            Registers the commands regardless of the state of the command on Discord. This can sometimes cause commands
             to be re-registered without changes due to a bug in the API, but is sometimes a more foolproof method of
             registering commands. Defaults to True.
         guild_ids: Optional[List[:class:`int`]]


### PR DESCRIPTION
## Summary

Defaults force kwarg in command registration to true, using a bulk update by default.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
