### PR TITLE
Run parent checks in `can_run`

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -320,7 +320,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         if self.parent is not None:
             # parent checks should be ran first
             predicates = self.parent.checks + predicates
-            
+
         if not predicates:
             # since we have no checks, then we just return True.
             return True

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -317,6 +317,10 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             raise CheckFailure(f"The global check functions for command {self.name} failed.")
 
         predicates = self.checks
+        if self.parent is not None:
+            # parent checks should be ran first
+            predicates = self.parent.checks + predicates
+            
         if not predicates:
             # since we have no checks, then we just return True.
             return True

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -900,7 +900,7 @@ class SlashCommandGroup(ApplicationCommand):
         self.subcommands: List[Union[SlashCommand, SlashCommandGroup]] = self.__initial_commands__
         self.guild_ids = guild_ids
         self.parent = parent
-        self.checks = []
+        self.checks = kwargs.get("checks", [])
 
         self._before_invoke = None
         self._after_invoke = None


### PR DESCRIPTION
## Summary

Adds the parent checks to the list of checks to run in `can_run`.
Fixes #943

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
