### PR TITLE
Note message content requirement in `commands.Bot`

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -409,6 +409,10 @@ class Bot(BotBase, discord.Bot):
 
     This class also subclasses :class:`.GroupMixin` to provide the functionality
     to manage commands.
+    
+    .. note::
+        
+        Using prefixed commands requires :attr:`discord.Intents.message_content` to be enabled.
 
     Attributes
     -----------

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -409,9 +409,9 @@ class Bot(BotBase, discord.Bot):
 
     This class also subclasses :class:`.GroupMixin` to provide the functionality
     to manage commands.
-    
+
     .. note::
-        
+
         Using prefixed commands requires :attr:`discord.Intents.message_content` to be enabled.
 
     Attributes


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

Notes the message content requirement in the `commands.Bot` bot while using prefixed commands.

Unsure if the attribute reference actually works, it should though.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
