### PR TITLE
Revert API version back to v9 until April 

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -112,7 +112,7 @@ async def json_or_text(response: aiohttp.ClientResponse) -> Union[Dict[str, Any]
 
 
 class Route:
-    BASE: ClassVar[str] = "https://discord.com/api/v10"
+    BASE: ClassVar[str] = "https://discord.com/api/v9"
 
     def __init__(self, method: str, path: str, **parameters: Any) -> None:
         self.path: str = path
@@ -2454,9 +2454,9 @@ class HTTPClient:
         except HTTPException as exc:
             raise GatewayNotFound() from exc
         if zlib:
-            value = "{0}?encoding={1}&v=10&compress=zlib-stream"
+            value = "{0}?encoding={1}&v=9&compress=zlib-stream"
         else:
-            value = "{0}?encoding={1}&v=10"
+            value = "{0}?encoding={1}&v=9"
         return value.format(data["url"], encoding)
 
     async def get_bot_gateway(self, *, encoding: str = "json", zlib: bool = True) -> Tuple[int, str]:
@@ -2466,9 +2466,9 @@ class HTTPClient:
             raise GatewayNotFound() from exc
 
         if zlib:
-            value = "{0}?encoding={1}&v=10&compress=zlib-stream"
+            value = "{0}?encoding={1}&v=9&compress=zlib-stream"
         else:
-            value = "{0}?encoding={1}&v=10"
+            value = "{0}?encoding={1}&v=9"
         return data["shards"], value.format(data["url"], encoding)
 
     def get_user(self, user_id: Snowflake) -> Response[user.User]:


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This reverts the change made in #1012 in order to prevent prematurely breaking verified bots that do not have the message content intent granted. We should instead create a separate branch to test v10 until the enforcement of message content intent actually begins in April.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
