### PR TITLE
Fix missing .channels wildcard import removed in #1012

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -45,6 +45,7 @@ from typing import (
 
 from . import abc, utils
 from .asset import Asset
+from .channel import *
 from .channel import _guild_channel_factory, _threaded_guild_channel_factory
 from .colour import Colour
 from .emoji import Emoji


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This re-adds the wildcard .channels import that was removed in #1012. Removing this resulted in many references to TextChannel, VoiceChannel, and others not working outside of typing contexts.

Closes #1034

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
