### PR TITLE
Change the example of /channel

### DIFF
--- a/examples/app_commands/slash_options.py
+++ b/examples/app_commands/slash_options.py
@@ -22,7 +22,7 @@ async def hello(
 @bot.slash_command(guild_ids=[...])
 async def channel(
     ctx: discord.ApplicationContext,
-    channel: Option([discord.TextChannel, discord.VoiceChannel], "Select a channel")
+    channel: Option((discord.TextChannel, discord.VoiceChannel) "Select a channel")
     # you can specify allowed channel types by passing a list of them like: [discord.TextChannel, discord.VoiceChannel]
 ):
     await ctx.respond(f"Hi! You selected {channel.mention} channel.")


### PR DESCRIPTION


<!-- Warning: No new features will be merged until the next stable release. -->

## Summary
When using squared bracket in discord.Option, you get an error because you can't use a list since in the source it is checking for a tuple. So to reflect this, I changed the example to round brackets.

<!-- What is this pull request for? Does it fix any issues? -->

It fixes an unclear piece of code in the examples. No effect on the library code itself. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested. 
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
