### PR TITLE
Fix custom_id field in interactions

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -162,7 +162,7 @@ class Interaction:
         self.application_id: int = int(data["application_id"])
         self.locale: Optional[str] = data.get("locale")
         self.guild_locale: Optional[str] = data.get("guild_locale")
-        self.custom_id: Optional[str] = data.get("custom_id")
+        self.custom_id: Optional[str] = self.data.get("custom_id") if self.data is not None else None
 
         self.message: Optional[Message]
         try:


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary
https://github.com/Pycord-Development/pycord/pull/1040 added a custom_id field to interactions, however it is accessed wrongly causing it to always be None.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
