### PR TITLE
Removed unused parameter and incorrect docstring.

### DIFF
--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -39,12 +39,6 @@ class InputText:
     value: Optional[:class:`str`]
         Pre-fills the input text field with this value.
         Must be 4000 characters or fewer.
-    row: Optional[:class:`int`]
-        The relative row this button belongs to. A Discord component can only have 5
-        rows. By default, items are arranged automatically into those 5 rows. If you'd
-        like to control the relative positioning of the row then passing an index is advised.
-        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
-        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
 
     def __init__(
@@ -58,7 +52,6 @@ class InputText:
         max_length: Optional[int] = None,
         required: Optional[bool] = True,
         value: Optional[str] = None,
-        row: Optional[int] = None,
     ):
         super().__init__()
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
@@ -77,7 +70,6 @@ class InputText:
             value=value,
         )
         self._input_value = None
-        self.row = row
         self._rendered_row: Optional[int] = None
 
     @property


### PR DESCRIPTION
I believe this was a relic of copy pasting the button template code, but no where is the row used, and the docstring description for it is incorrect and references buttons. Please ignore if I'm completely missing something. It is technically breaking because it removes the row parameter form the text input, however nobody should be using this to my knowledge? (Couldn't find it's use on the Discord Docs). Seemingly had no effect when changed, so, like I said, if I'm completely missing something, please let me know, but I believe this was a mistake

## Summary

Removes unused param from copy paste of button code.

<!-- What is this pull request for? Does it fix any issues? -->

Removes misleading docs

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
