### PR TITLE
Add `client` property to `Interaction` class

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         TextChannel,
         VoiceChannel,
     )
+    from .client import Client
     from .commands import OptionChoice
     from .embeds import Embed
     from .guild import Guild
@@ -80,7 +81,6 @@ if TYPE_CHECKING:
         Thread,
         PartialMessageable,
     ]
-
 
 MISSING: Any = utils.MISSING
 
@@ -188,6 +188,11 @@ class Interaction:
                 self.user = User(state=self._state, data=data["user"])
             except KeyError:
                 pass
+
+    @property
+    def client(self) -> Client:
+        """Returns the client that sent the interaction."""
+        return self._state._get_client()
 
     @property
     def guild(self) -> Optional[Guild]:


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This adds a new property, `client` to the `Interaction` class. This allows retrieving the `Client` instance that sent the interaction.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
