### PR TITLE
Fix for `InputText.label` being required

### DIFF
--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -22,8 +22,8 @@ class InputText:
         The style of the input text field.
     custom_id: Optional[:class:`str`]
         The ID of the input text field that gets received during an interaction.
-    label: Optional[:class:`str`]
-        The label for the input text field, if any.
+    label: :class:`str`
+        The label for the input text field.
         Must be 45 characters or fewer.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
@@ -40,7 +40,7 @@ class InputText:
         Pre-fills the input text field with this value.
         Must be 4000 characters or fewer.
     row: Optional[:class:`int`]
-        The relative row this button belongs to. A Discord component can only have 5
+        The relative row this input text field belongs to. A modal dialog can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
         like to control the relative positioning of the row then passing an index is advised.
         For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
@@ -52,7 +52,7 @@ class InputText:
         *,
         style: InputTextStyle = InputTextStyle.short,
         custom_id: str = MISSING,
-        label: Optional[str] = None,
+        label: str,
         placeholder: Optional[str] = None,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
@@ -114,7 +114,7 @@ class InputText:
     @label.setter
     def label(self, value: str):
         if not isinstance(value, str):
-            raise TypeError(f"label should be None or str not {value.__class__}")
+            raise TypeError(f"label should be str not {value.__class__}")
         self._underlying.label = value
 
     @property


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This makes the `label` parameter for `InputText` required, to match the API.

Also updates docstring for the `row` parameter.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
