### PR TITLE
Fix for `InputText.value` not being properly cleared for non-required fields

### DIFF
--- a/discord/ui/input_text.py
+++ b/discord/ui/input_text.py
@@ -76,7 +76,7 @@ class InputText:
             required=required,
             value=value,
         )
-        self._input_value = None
+        self._input_value = False
         self.row = row
         self._rendered_row: Optional[int] = None
 
@@ -164,7 +164,10 @@ class InputText:
     @property
     def value(self) -> Optional[str]:
         """Optional[:class:`str`]: The value entered in the text field."""
-        return self._input_value or self._underlying.value
+        if self._input_value is not False:
+            # only False on init, otherwise the value was either set or cleared
+            return self._input_value  # type: ignore
+        return self._underlying.value
 
     @value.setter
     def value(self, value: Optional[str]):


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This fixes the logic for the `value` property on the `ui.InputText` class to allow clearing out a pre-filled value for a non-required input text field

Fixes #1092 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
