### PR TITLE
Renamed original_message of Interaction class

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -27,7 +27,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, Coroutine
 
 from . import utils
 from .channel import ChannelType, PartialMessageable
@@ -245,7 +245,18 @@ class Interaction:
         }
         return Webhook.from_state(data=payload, state=self._state)
 
-    async def original_message(self) -> InteractionMessage:
+    def original_message(self) -> Coroutine[InteractionMessage]:
+        """
+        Alias for fetch_original_message to not break existing code.
+        Maybe throw deprecation warning in future versions.
+
+        Returns
+        --------
+        coro
+        """
+        return self.fetch_original_message()
+
+    async def fetch_original_message(self) -> InteractionMessage:
         """|coro|
 
         Fetches the original interaction response message associated with the interaction.


### PR DESCRIPTION

<!-- Warning: No new features will be merged until the next stable release. -->

## Summary
`Interaction.original_message` is a weird name for a method that invokes an api call.
discord.py has a convetion to name everything that makes api calls fetch_x we should stick to it.

I reneamed the method to fetch_original_message and made an alias for the old name so we dont break.
But added a not to it.

Docs not modified.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
