### PR TITLE
Add `Guild._fetch_role()` private method to support proper handling of role mentionable in slash command options

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -50,7 +50,7 @@ from typing import (
 )
 
 from ..enums import ChannelType, SlashCommandOptionType
-from ..errors import ClientException, ValidationError
+from ..errors import ClientException, ValidationError, NotFound
 from ..member import Member
 from ..message import Attachment, Message
 from ..user import User
@@ -740,9 +740,10 @@ class SlashCommand(ApplicationCommand):
 
             elif op.input_type == SlashCommandOptionType.mentionable:
                 arg_id = int(arg)
-                arg = await get_or_fetch(ctx.guild, "member", arg_id)
-                if arg is None:
-                    arg = ctx.guild.get_role(arg_id) or arg_id
+                try:
+                    arg = await get_or_fetch(ctx.guild, "member", arg_id)
+                except NotFound:
+                    arg = await get_or_fetch(ctx.guild, "role", arg_id)
 
             elif op.input_type == SlashCommandOptionType.string and (converter := op.converter) is not None:
                 arg = await converter.convert(converter, ctx, arg)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2474,7 +2474,7 @@ class Guild(Hashable):
         data = await self._state.http.get_roles(self.id)
         return [Role(guild=self, state=self._state, data=d) for d in data]
 
-    async def fetch_role(self, role_id: int) -> Role:
+    async def _fetch_role(self, role_id: int) -> Role:
         """|coro|
 
         Retrieves a :class:`Role` that the guild has.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2483,7 +2483,7 @@ class Guild(Hashable):
 
             This method is an API call. For general usage, consider iterating over :attr:`roles` instead.
 
-        .. versionadded:: 1.3
+        .. versionadded:: 2.0
 
         Parameters
         -----------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2481,7 +2481,7 @@ class Guild(Hashable):
 
         .. note::
 
-            This method is an API call. For general usage, consider iterating over :attr:`roles` instead.
+            This method is an API call. For general usage, consider using :attr:`get_role` instead.
 
         .. versionadded:: 2.0
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2474,6 +2474,38 @@ class Guild(Hashable):
         data = await self._state.http.get_roles(self.id)
         return [Role(guild=self, state=self._state, data=d) for d in data]
 
+    async def fetch_role(self, role_id: int) -> Role:
+        """|coro|
+
+        Retrieves a :class:`Role` that the guild has.
+
+        .. note::
+
+            This method is an API call. For general usage, consider iterating over :attr:`roles` instead.
+
+        .. versionadded:: 1.3
+
+        Parameters
+        -----------
+        role_id: :class:`int`
+            The role ID to fetch from the guild.
+
+        Raises
+        -------
+        HTTPException
+            Retrieving the role failed.
+
+        Returns
+        -------
+        Optional[:class:`Role`]
+            The role in the guild with the specified ID.
+            Returns ``None`` if not found.
+        """
+        roles = await self.fetch_roles()
+        for role in roles:
+            if role.id == role_id:
+                return role
+
     @overload
     async def create_role(
         self,

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -377,7 +377,7 @@ def time_snowflake(dt: datetime.datetime, high: bool = False) -> int:
         The snowflake representing the time given.
     """
     discord_millis = int(dt.timestamp() * 1000 - DISCORD_EPOCH)
-    return (discord_millis << 22) + (2**22 - 1 if high else 0)
+    return (discord_millis << 22) + (2 ** 22 - 1 if high else 0)
 
 
 def find(predicate: Callable[[T], Any], seq: Iterable[T]) -> Optional[T]:
@@ -477,6 +477,8 @@ async def get_or_fetch(obj, attr: str, id: int, *, default: Any = MISSING):
     if getter is None:
         try:
             getter = await getattr(obj, f"fetch_{attr}")(id)
+        except AttributeError:
+            getter = await getattr(obj, f"_fetch_{attr}")(id)
         except HTTPException:
             if default is not MISSING:
                 return default


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This adds a new private method `Guild._fetch_role()` which allows `utils.get_or_fetch` to work with roles properly. Previously it did not work because there was only a `fetch_roles` method, not `fetch_role`. As part of this change, `utils.get_or_fetch` was also updated to use private `_fetch` methods if an `AttributeError` is raised for any object that does not have a `fetch_*` method. This has an added benefit of allowing us to more easily add private _fetch methods on other objects if we need to in the future.

This also fixes #906 by having the "mentionable" option type check for first a user, then a role if a user is not found. This required the above described addition of `Guild._fetch_fole()` to work properly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
