### PR TITLE
Add `custom_id` attribute to `PaginatorMenu` to fix bug with persistent views that include page groups

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -776,6 +776,7 @@ class PaginatorMenu(discord.ui.Select):
         self,
         page_groups: List[PageGroup],
         placeholder: str = "Select Page Group",
+        custom_id: Optional[str] = None,
     ):
         self.page_groups = page_groups
         self.paginator: Optional[Paginator] = None
@@ -788,7 +789,7 @@ class PaginatorMenu(discord.ui.Select):
             )
             for page_group in self.page_groups
         ]
-        super().__init__(placeholder=placeholder, max_values=1, min_values=1, options=opts)
+        super().__init__(placeholder=placeholder, max_values=1, min_values=1, options=opts, custom_id=custom_id)
 
     async def callback(self, interaction: discord.Interaction):
         selection = self.values[0]


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This fixes persistent paginators that include the use of page groups (`PageGroup`), by allowing the `custom_id` parameter to be passed to `PaginatorMenu` when overriding `Paginator.add_menu()`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
