### PR TITLE
Fix attribute error with deprecated stage discovery

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -615,7 +615,7 @@ class ApplicationType(Enum):
 
 
 class StagePrivacyLevel(Enum):
-    # public = 1 Deprecated
+    # public = 1 (deprecated)
     closed = 2
     guild_only = 2
 

--- a/discord/stage_instance.py
+++ b/discord/stage_instance.py
@@ -109,7 +109,7 @@ class StageInstance(Hashable):
         return self._state.get_channel(self.channel_id)  # type: ignore
 
     def is_public(self) -> bool:
-        return StagePrivacyLevel.guild_only
+        return False
 
     async def edit(
         self,

--- a/discord/stage_instance.py
+++ b/discord/stage_instance.py
@@ -109,7 +109,7 @@ class StageInstance(Hashable):
         return self._state.get_channel(self.channel_id)  # type: ignore
 
     def is_public(self) -> bool:
-        return self.privacy_level is StagePrivacyLevel.public
+        return StagePrivacyLevel.guild_only
 
     async def edit(
         self,


### PR DESCRIPTION
## Summary
StagePrivacyLevel.public was removed, so stage_instance.is_public will raise an attribute error

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
