### PR TITLE
Fix scheduled event payload typings

### DIFF
--- a/discord/types/scheduled_events.py
+++ b/discord/types/scheduled_events.py
@@ -24,11 +24,8 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Literal, Optional, TypedDict, Union
+from typing import Literal, Optional, TypedDict
 
-from .channel import StageChannel, VoiceChannel
-from .guild import Guild
 from .member import Member
 from .snowflake import Snowflake
 from .user import User
@@ -38,26 +35,30 @@ ScheduledEventLocationType = Literal[1, 2, 3]
 ScheduledEventPrivacyLevel = Literal[2]
 
 
-class ScheduledEventLocation(TypedDict):
-    value: Union[StageChannel, VoiceChannel, str]
-    type: ScheduledEventLocationType
-
-
 class ScheduledEvent(TypedDict):
     id: Snowflake
-    guild: Guild
+    guild_id: Snowflake
+    channel_id: Snowflake
+    creator_id: Snowflake
     name: str
     description: str
     image: Optional[str]
-    start_time: datetime
-    end_time: Optional[datetime]
-    status: ScheduledEventStatus
-    subscriber_count: Optional[int]
-    creator_id: Snowflake
-    creator: Optional[User]
-    location: ScheduledEventLocation
+    scheduled_start_time: str
+    scheduled_end_time: Optional[str]
     privacy_level: ScheduledEventPrivacyLevel
+    status: ScheduledEventStatus
+    entity_type: ScheduledEventLocationType
+    entity_id: Snowflake
+    entity_metadata: ScheduledEventEntityMetadata
+    creator: User
+    user_count: Optional[int]
 
 
-class ScheduledEventSubscriber(User):
+class ScheduledEventEntityMetadata(TypedDict):
+    location: str
+
+
+class ScheduledEventSubscriber(TypedDict):
+    guild_scheduled_event_id: Snowflake
+    user: User
     member: Optional[Member]


### PR DESCRIPTION
## Summary
`discord.types` is for api typings not library typings

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
