### PR TITLE
Update `HTTPClient.kick()` to use `reason` kwarg

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -833,11 +833,7 @@ class HTTPClient:
             guild_id=guild_id,
             user_id=user_id,
         )
-        if reason:
-            # thanks aiohttp
-            r.url = f"{r.url}?reason={_uriquote(reason)}"
-
-        return self.request(r)
+        return self.request(r, reason=reason)
 
     def ban(
         self,


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This updates `HTTPClient.kick()` to use the `reason` kwarg, which causes the API call to use the `X-Audit-Log-Reason` header required by v10 of the API.

Closes #1109 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
