### PR TITLE
Add slash_error to app_examples

### DIFF
--- a/examples/app_commands/slash_error.py
+++ b/examples/app_commands/slash_error.py
@@ -2,7 +2,7 @@ import discord
 
 bot = discord.Bot()
 
-
+# note - You can use this in a cog using @commands.Cog.listiner(), but it will only see application errors also in that cog, unlike on_command_error
 
 # for more permissions, check slash_perms.py
 @bot.slash_command(guild_ids=[...])  # create a slash command that requires ban_members permission

--- a/examples/app_commands/slash_error.py
+++ b/examples/app_commands/slash_error.py
@@ -1,0 +1,21 @@
+import discord
+
+bot = discord.Bot()
+
+
+
+# for more permissions, check slash_perms.py
+@bot.slash_command(guild_ids=[...])  # create a slash command that requires ban_members permission
+@bot.has_permissions(ban_members = True) # command decorator for user permissions
+async def hello(ctx):
+    """Say hello to the bot"""  
+    await ctx.respond(f"Hello {ctx.author}!")
+
+
+@bot.event # the event that runs when you dont have the ban members permission and run the `hello` command
+async def on_application_command_error(ctx, error): # the `error` argument shows the error that happened
+    await ctx.send(error) # Send the error to the user
+    return # Return so that it doesn't clog up our terminal
+
+# To learn how to add more and use commands, check slash_basic.py
+bot.run("TOKEN")

--- a/examples/app_commands/slash_error.py
+++ b/examples/app_commands/slash_error.py
@@ -2,7 +2,6 @@ import discord
 
 bot = discord.Bot()
 
-# note - You can use this in a cog using @commands.Cog.listiner(), but it will only see application errors also in that cog, unlike on_command_error
 
 # for more permissions, check slash_perms.py
 @bot.slash_command(guild_ids=[...])  # create a slash command that requires ban_members permission


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This pull request is to address some peoples questions on how to use the `on_application_command_error`. People do not realize that you must either put it in the main python file or every cog file, you can't put it in a error cog because it only see's errors of commands in that cog

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
