### PR TITLE
Fix for PartialMessageable TypeError in ext.pages

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -738,7 +738,7 @@ class Paginator(discord.ui.View):
                     ephemeral=ephemeral,
                 )
                 # convert from WebhookMessage to Message reference to bypass 15min webhook token timeout
-                msg = msg.channel.get_partial_message(msg.id) or await msg.channel.fetch_message(msg.id)
+                msg = await msg.channel.fetch_message(msg.id)
             else:
                 msg = await interaction.response.send_message(
                     content=page if isinstance(page, str) else None,


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This fixes the following error, which can occur if the paginator is sent after a deferred response:

`TypeError: Expected TextChannel, DMChannel or Thread not <class 'discord.channel.PartialMessageable'>`


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
