### PR TITLE
Add `Page` class to `ext.pages` to allow for greater flexibility with page contents

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -106,7 +106,9 @@ class PaginatorButton(discord.ui.Button):
 
 
 class Page:
-    """Represents a page shown in the paginator. Allows for directly referencing and modifying each page as a class instance.
+    """Represents a page shown in the paginator.
+
+    Allows for directly referencing and modifying each page as a class instance.
 
     Parameters
     ----------

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -31,6 +31,7 @@ __all__ = (
     "Paginator",
     "PageGroup",
     "PaginatorMenu",
+    "Page",
 )
 
 
@@ -102,6 +103,44 @@ class PaginatorButton(discord.ui.Button):
         elif self.button_type == "last":
             self.paginator.current_page = self.paginator.page_count
         await self.paginator.goto_page(page_number=self.paginator.current_page)
+
+
+class Page:
+    """Represents a page shown in the paginator. Allows for directly referencing and modifying each page as a class instance.
+
+    Parameters
+    ----------
+    content: :class:`str`
+        The content of the page. Corresponds to the :class:`discord.Message.content` attribute.
+    embeds: Optional[List[Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
+        The embeds of the page. Corresponds to the :class:`discord.Message.embeds` attribute.
+    """
+
+    def __init__(
+        self, content: Optional[str] = None, embeds: Optional[List[Union[List[discord.Embed], discord.Embed]]] = None
+    ):
+        self._content = content
+        self._embeds = embeds
+
+    @property
+    def content(self) -> Optional[str]:
+        """Gets the content for the page."""
+        return self._content
+
+    @content.setter
+    def content(self, value: Optional[str]):
+        """Sets the content for the page."""
+        self._content = value
+
+    @property
+    def embeds(self) -> Optional[List[Union[List[discord.Embed], discord.Embed]]]:
+        """Gets the embeds for the page."""
+        return self._embeds
+
+    @embeds.setter
+    def embeds(self, value: Optional[List[Union[List[discord.Embed], discord.Embed]]]):
+        """Sets the embeds for the page."""
+        self._embeds = value
 
 
 class PageGroup:

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -738,7 +738,7 @@ class Paginator(discord.ui.View):
                     ephemeral=ephemeral,
                 )
                 # convert from WebhookMessage to Message reference to bypass 15min webhook token timeout
-                msg = msg.channel.get_partial_message(msg.id) or await msg.channel.fetch_message(msg.id)
+                msg = await msg.channel.fetch_message(msg.id)
             else:
                 msg = await interaction.response.send_message(
                     content=page if isinstance(page, str) else None,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -121,6 +121,8 @@ class Page:
     def __init__(
         self, content: Optional[str] = None, embeds: Optional[List[Union[List[discord.Embed], discord.Embed]]] = None
     ):
+        if content is None and embeds is None:
+            raise discord.InvalidArgument("A page cannot have both content and embeds equal to None.")
         self._content = content
         self._embeds = embeds
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import discord
 from discord.ext.commands import Context

--- a/docs/ext/pages/index.rst
+++ b/docs/ext/pages/index.rst
@@ -291,6 +291,14 @@ Example usage in a cog:
 API Reference
 -------------
 
+Page
+~~~~
+
+.. attributetable:: discord.ext.pages.Page
+
+.. autoclass:: discord.ext.pages.Page
+    :members:
+
 Paginator
 ~~~~~~~~~
 

--- a/examples/views/paginator.py
+++ b/examples/views/paginator.py
@@ -36,6 +36,23 @@ class PageTest(commands.Cog):
 
         self.even_more_pages = ["11111", "22222", "33333"]
 
+        self.new_pages = [
+            pages.Page(
+                content="Page 1 Title!",
+                embeds=[
+                    discord.Embed(title="New Page 1 Embed Title 1!"),
+                    discord.Embed(title="New Page 1 Embed Title 2!"),
+                ],
+            ),
+            pages.Page(
+                content="Page 2 Title!",
+                embeds=[
+                    discord.Embed(title="New Page 2 Embed Title 1!"),
+                    discord.Embed(title="New Page 2 Embed Title 2!"),
+                ],
+            ),
+        ]
+
     def get_pages(self):
         return self.pages
 
@@ -46,6 +63,12 @@ class PageTest(commands.Cog):
     async def pagetest_default(self, ctx: discord.ApplicationContext):
         """Demonstrates using the paginator with the default options."""
         paginator = pages.Paginator(pages=self.get_pages())
+        await paginator.respond(ctx.interaction, ephemeral=False)
+
+    @pagetest.command(name="new")
+    async def pagetest_new(self, ctx: discord.ApplicationContext):
+        """Demonstrates using the paginator with the Page class."""
+        paginator = pages.Paginator(pages=self.new_pages)
         await paginator.respond(ctx.interaction, ephemeral=False)
 
     @pagetest.command(name="hidden")


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This adds a new class, `Page` to `ext.pages`, which allows users to specify both the `content` and `embeds` attributes. This allows the paginator to display pages with both `content` and `embeds`, where previously it only allowed one or the other on each page.

Existing usage of passing lists of strings or embeds still works as it did before.

This is being added as part of 2.0 to allow for a much easier guide to be written for end users rather than trying to have them understand the nuances of passing a list of embeds, list of list of embeds, or list of strings. Now they can just define their `Page` objects and pass a list of those.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
