### PR TITLE
Fix some keyword arguments failing

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -886,7 +886,9 @@ class SlashCommandGroup(ApplicationCommand):
         description: str,
         guild_ids: Optional[List[int]] = None,
         parent: Optional[SlashCommandGroup] = None,
-        **kwargs,
+        *,
+        default_permissions: Optional[bool] = True,
+        permissions: Optional[List[CommandPermission]] = [],
     ) -> None:
         validate_chat_input_name(name)
         validate_chat_input_description(description)
@@ -904,8 +906,8 @@ class SlashCommandGroup(ApplicationCommand):
         self.id = None
 
         # Permissions
-        self.default_permission = kwargs.get("default_permission", True)
-        self.permissions: List[CommandPermission] = kwargs.get("permissions", [])
+        self.default_permission = default_permissions
+        self.permissions: List[CommandPermission] = permissions
         if self.permissions and self.default_permission:
             self.default_permission = False
 


### PR DESCRIPTION
## Summary
Fixes some arguments, when set to keyword arguments, failing.

Reported through help channels.

### Minimal Code Reproductions

main.py
```py
import discord

bot = discord.Bot()
bot.load_extension("testing")

bot.run("token")
```

testing.py
```py
import discord

class Cog(discord.Cog):
    def __init__(self, client):
        self.client = client

    s = discord.SlashCommandGroup(name="test", description="A command", guild_ids=[...])

def setup(client):
    client.add_cog(Cog(client))
```

### Error

`Extension 'testing' raised an error: TypeError: discord.commands.core.SlashCommandGroup() got multiple values for keyword argument 'name'`

<details>
  <summary>full traceback</summary>
  <br>

  ```py
  Extension 'testing' raised an error: TypeError: discord.commands.core.SlashCommandGroup() got multiple values for keyword argument 'name'
    File "[D:\Documents\GitHub\my-pycord-fork\discord\cog.py]()", line 684, in _load_from_module_spec
      spec.loader.exec_module(lib)  # type: ignore
    File "[D:\Documents\GitHub\my-pycord-fork\testing.py]()", line 4, in <module>
      class Cog(discord.Cog):
    File "[D:\Documents\GitHub\my-pycord-fork\discord\cog.py]()", line 210, in __new__
      new_cls.__cog_commands__ = tuple(c._update_copy(cmd_attrs) for c in new_cls.__cog_commands__)  # type: ignore
    File "[D:\Documents\GitHub\my-pycord-fork\discord\cog.py]()", line 210, in <genexpr>
      new_cls.__cog_commands__ = tuple(c._update_copy(cmd_attrs) for c in new_cls.__cog_commands__)  # type: ignore
    File "[D:\Documents\GitHub\my-pycord-fork\discord\commands\core.py]()", line 1077, in _update_copy
      return self.copy()
    File "[D:\Documents\GitHub\my-pycord-fork\discord\commands\core.py]()", line 1049, in copy
      ret = self.__class__(
  
  The above exception was the direct cause of the following exception:
  
    File "[D:\Documents\GitHub\my-pycord-fork\discord\cog.py]()", line 687, in _load_from_module_spec
      raise errors.ExtensionFailed(key, e) from e
    File "[D:\Documents\GitHub\my-pycord-fork\discord\cog.py]()", line 756, in load_extension
      self._load_from_module_spec(spec, name)
    File "[D:\Documents\GitHub\my-pycord-fork\test.py]()", line 5, in <module>
      bot.load_extension("testing")
  ```
  
</details>

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
