### PR TITLE
Add missing **kwargs param to support non-explicit parameters in `SlashCommandGroup` (fixes issue introduced by #1127)

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -889,6 +889,7 @@ class SlashCommandGroup(ApplicationCommand):
         *,
         default_permissions: Optional[bool] = True,
         permissions: Optional[List[CommandPermission]] = [],
+        **kwargs,
     ) -> None:
         validate_chat_input_name(name)
         validate_chat_input_description(description)


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

#1127 fixed an issue by allowing keyword arguments to be accepted, but it also inadvertently removed the **kwargs parameter that is still needed for other variables in the class (e.g. `check`).

Specifically, this error is fixed by this PR:

`TypeError: SlashCommandGroup.__init__() got an unexpected keyword argument 'checks'`


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
