### PR TITLE
Fix `slash_autocomplete` example

### DIFF
--- a/examples/app_commands/slash_autocomplete.py
+++ b/examples/app_commands/slash_autocomplete.py
@@ -129,7 +129,9 @@ async def autocomplete_example(
     color: Option(str, "Pick a color!", autocomplete=get_colors),
     animal: Option(str, "Pick an animal!", autocomplete=get_animals),
 ):
-    """This demonstrates using the ctx.options parameter to create slash command options that are dependent on the values entered for other options."""
+    """Demonstrates using ctx.options to create options that are dependent on the values of other options.
+    For the `color` option, a callback is passed, where additional logic can be added to determine which values are returned.
+    For the `animal` option, the callback uses the input from the color option to return an iterable of animals"""
     await ctx.respond(f"You picked {color} for the color, which allowed you to choose {animal} for the animal.")
 
 


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The command description docstring for the `ac_example` command in `examples/app_commands/slash_autocomplete.py /` was to long (over 100 characters). Shortens the description and add more clarification on the next lines.
Fixes: #1084 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
