### PR TITLE
Fix of app command example (slash_options)

### DIFF
--- a/examples/app_commands/slash_options.py
+++ b/examples/app_commands/slash_options.py
@@ -22,7 +22,7 @@ async def hello(
 @bot.slash_command(guild_ids=[...])
 async def channel(
     ctx: discord.ApplicationContext,
-    channel: Option([discord.TextChannel, discord.VoiceChannel], "Select a channel")
+    channel: Option((discord.TextChannel, discord.VoiceChannel), "Select a channel")
     # you can specify allowed channel types by passing a list of them like: [discord.TextChannel, discord.VoiceChannel]
 ):
     await ctx.respond(f"Hi! You selected {channel.mention} channel.")

--- a/examples/app_commands/slash_options.py
+++ b/examples/app_commands/slash_options.py
@@ -23,7 +23,7 @@ async def hello(
 async def channel(
     ctx: discord.ApplicationContext,
     channel: Option((discord.TextChannel, discord.VoiceChannel), "Select a channel")
-    # you can specify allowed channel types by passing a list of them like: [discord.TextChannel, discord.VoiceChannel]
+    # you can specify allowed channel types by passing a list of them like: (discord.TextChannel, discord.VoiceChannel)
 ):
     await ctx.respond(f"Hi! You selected {channel.mention} channel.")
 


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

Fix for the app command example (slash_options).
When creating a slash command option for being able to select different channel types like discord.Textchannel and discord.Voice channel the current example raises this error or similar:
```py
Extension 'cogs.info' raised an error: AttributeError: 'list' object has no attribute '__name__'
```
I replaced these brackets [] to these one: () in order to fix that issue.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
