### PR TITLE
Revert "Run parent checks in `can_run`"

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -317,10 +317,6 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             raise CheckFailure(f"The global check functions for command {self.name} failed.")
 
         predicates = self.checks
-        if self.parent is not None:
-            # parent checks should be ran first
-            predicates = self.parent.checks + predicates
-
         if not predicates:
             # since we have no checks, then we just return True.
             return True
@@ -902,7 +898,7 @@ class SlashCommandGroup(ApplicationCommand):
         self.subcommands: List[Union[SlashCommand, SlashCommandGroup]] = self.__initial_commands__
         self.guild_ids = guild_ids
         self.parent = parent
-        self.checks = kwargs.get("checks", [])
+        self.checks = []
 
         self._before_invoke = None
         self._after_invoke = None


### PR DESCRIPTION
Reverts Pycord-Development/pycord#1027

line 912 in core.py has a NameError