### PR TITLE
Fix cog slash commands when using ctx.invoke()

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -213,16 +213,15 @@ class CogMeta(type):
 
         # Update the Command instances dynamically as well
         for command in new_cls.__cog_commands__:
-            if not isinstance(command, ApplicationCommand):
-                setattr(new_cls, command.callback.__name__, command)
-                parent = command.parent
-                if parent is not None:
-                    # Get the latest parent reference
-                    parent = lookup[parent.qualified_name]  # type: ignore
+            setattr(new_cls, command.callback.__name__, command)
+            parent = command.parent
+            if parent is not None:
+                # Get the latest parent reference
+                parent = lookup[parent.qualified_name]  # type: ignore
 
-                    # Update our parent's reference to our self
-                    parent.remove_command(command.name)  # type: ignore
-                    parent.add_command(command)  # type: ignore
+                # Update our parent's reference to our self
+                parent.remove_command(command.name)  # type: ignore
+                parent.add_command(command)  # type: ignore
 
         return new_cls
 

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -213,15 +213,16 @@ class CogMeta(type):
 
         # Update the Command instances dynamically as well
         for command in new_cls.__cog_commands__:
-            setattr(new_cls, command.callback.__name__, command)
-            parent = command.parent
-            if parent is not None:
-                # Get the latest parent reference
-                parent = lookup[parent.qualified_name]  # type: ignore
+            if not isinstance(command, SlashCommandGroup):
+                setattr(new_cls, command.callback.__name__, command)
+                parent = command.parent
+                if parent is not None:
+                    # Get the latest parent reference
+                    parent = lookup[parent.qualified_name]  # type: ignore
 
-                # Update our parent's reference to our self
-                parent.remove_command(command.name)  # type: ignore
-                parent.add_command(command)  # type: ignore
+                    # Update our parent's reference to our self
+                    parent.remove_command(command.name)  # type: ignore
+                    parent.add_command(command)  # type: ignore
 
         return new_cls
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -188,6 +188,8 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         convert the arguments beforehand, so take care to pass the correct
         arguments in.
         """
+        if self.cog is not None:
+            return await self.callback(self.cog, ctx, *args, **kwargs)
         return await self.callback(ctx, *args, **kwargs)
 
     @property


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR fixes two simple things:
1. Application Commands in Cogs not having their cog set (see [this Issue](https://github.com/Pycord-Development/pycord/issues/1144)).
2. Checking if an Application Command is in a cog and calling its callback accordingly.

This means you can use ctx.invoke() for slash commands again like so:

```python
class TestCog(commands.Cog):
    def __init__(self, bot: discord.Bot) -> None:
        self.bot = bot

    @slash_command(guild_ids=gids)
    async def other_command(self, ctx, greet) -> None:
        await ctx.respond(f"{greet} I should run now!")

    @slash_command(guild_ids=gids)
    async def invoke_test(self, ctx) -> None:
        await ctx.invoke(self.other_command, "Hi!")
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
