### PR TITLE
Add docs for `InputTextStyle` enum values.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1810,7 +1810,6 @@ of :class:`enum.Enum`.
 
         Represents an input_text component.
 
-
 .. class:: ButtonStyle
 
     Represents the style of the button component.
@@ -1873,7 +1872,6 @@ of :class:`enum.Enum`.
     .. attribute:: paragraph
 
         An alias for :attr:`long`.
-
 
 .. class:: VoiceRegion
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1849,6 +1849,26 @@ of :class:`enum.Enum`.
 
         An alias for :attr:`link`.
 
+.. class:: InputTextStyle
+    .. versionadded:: 2.0
+
+    .. attribute:: short
+
+        Represents a single-line input text field.
+    .. attribute:: long
+
+        Represents a multi-line input text field.
+    .. attribute:: singleline
+
+        An alias for :attr:`short`.
+    .. attribute:: multiline
+
+        An alias for :attr:`long`.
+    .. attribute:: paragraph
+
+        An alias for :attr:`long`.
+
+
 .. class:: VoiceRegion
 
     Specifies the region a voice server belongs to.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1806,6 +1806,9 @@ of :class:`enum.Enum`.
     .. attribute:: select
 
         Represents a select component.
+    .. attribute:: input_text
+
+        Represents an input_text component.
 
 
 .. class:: ButtonStyle
@@ -1850,6 +1853,9 @@ of :class:`enum.Enum`.
         An alias for :attr:`link`.
 
 .. class:: InputTextStyle
+
+    Represents the style of the input text component.
+
     .. versionadded:: 2.0
 
     .. attribute:: short


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This adds missing doc entries for `InputTextStyle` under the `Enumerations` category.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
