### PR TITLE
Add `menu_placeholder` parameter to allow specifying placeholder text for the PageGroup menu

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -240,6 +240,7 @@ class Paginator(discord.ui.View):
         Whether to show a select menu that allows the user to switch between groups of pages.
     menu_placeholder: :class:`str`
         The placeholder text to show in the page group menu when no page group has been selected yet.
+        Defaults to "Select Page Group" if not provided.
     author_check: :class:`bool`
         Whether only the original user of the command can change pages.
     disable_on_timeout: :class:`bool`
@@ -362,6 +363,7 @@ class Paginator(discord.ui.View):
             Whether only the original user of the command can change pages.
         menu_placeholder: :class:`str`
             The placeholder text to show in the page group menu when no page group has been selected yet.
+            Defaults to "Select Page Group" if not provided.
         disable_on_timeout: :class:`bool`
             Whether the buttons get disabled when the paginator view times out.
         use_default_buttons: :class:`bool`

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -238,6 +238,8 @@ class Paginator(discord.ui.View):
         Whether to show the page indicator when using the default buttons.
     show_menu: :class:`bool`
         Whether to show a select menu that allows the user to switch between groups of pages.
+    menu_placeholder: :class:`str`
+        The placeholder text to show in the page group menu when no page group has been selected yet.
     author_check: :class:`bool`
         Whether only the original user of the command can change pages.
     disable_on_timeout: :class:`bool`
@@ -280,6 +282,7 @@ class Paginator(discord.ui.View):
         show_disabled: bool = True,
         show_indicator=True,
         show_menu=False,
+        menu_placeholder: str = "Select Page Group",
         author_check=True,
         disable_on_timeout=True,
         use_default_buttons=True,
@@ -297,6 +300,7 @@ class Paginator(discord.ui.View):
         self.current_page = 0
         self.menu: Optional[PaginatorMenu] = None
         self.show_menu = show_menu
+        self.menu_placeholder = menu_placeholder
         self.page_groups: Optional[List[PageGroup]] = None
 
         if all(isinstance(pg, PageGroup) for pg in pages):
@@ -335,6 +339,7 @@ class Paginator(discord.ui.View):
         show_disabled: Optional[bool] = None,
         show_indicator: Optional[bool] = None,
         author_check: Optional[bool] = None,
+        menu_placeholder: Optional[str] = None,
         disable_on_timeout: Optional[bool] = None,
         use_default_buttons: Optional[bool] = None,
         default_button_row: Optional[int] = None,
@@ -355,6 +360,8 @@ class Paginator(discord.ui.View):
             Whether to show the page indicator when using the default buttons.
         author_check: :class:`bool`
             Whether only the original user of the command can change pages.
+        menu_placeholder: :class:`str`
+            The placeholder text to show in the page group menu when no page group has been selected yet.
         disable_on_timeout: :class:`bool`
             Whether the buttons get disabled when the paginator view times out.
         use_default_buttons: :class:`bool`
@@ -382,6 +389,7 @@ class Paginator(discord.ui.View):
         self.show_disabled = show_disabled if show_disabled is not None else self.show_disabled
         self.show_indicator = show_indicator if show_indicator is not None else self.show_indicator
         self.usercheck = author_check if author_check is not None else self.usercheck
+        self.menu_placeholder = menu_placeholder if menu_placeholder is not None else self.menu_placeholder
         self.disable_on_timeout = disable_on_timeout if disable_on_timeout is not None else self.disable_on_timeout
         self.use_default_buttons = use_default_buttons if use_default_buttons is not None else self.use_default_buttons
         self.default_button_row = default_button_row if default_button_row is not None else self.default_button_row
@@ -498,7 +506,7 @@ class Paginator(discord.ui.View):
 
     def add_menu(self):
         """Adds the default :class:`PaginatorMenu` instance to the paginator."""
-        self.menu = PaginatorMenu(self.page_groups)
+        self.menu = PaginatorMenu(self.page_groups, placeholder=self.menu_placeholder)
         self.menu.paginator = self
         self.add_item(self.menu)
 
@@ -828,7 +836,7 @@ class PaginatorMenu(discord.ui.Select):
     def __init__(
         self,
         page_groups: List[PageGroup],
-        placeholder: str = "Select Page Group",
+        placeholder: Optional[str] = None,
         custom_id: Optional[str] = None,
     ):
         self.page_groups = page_groups


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This adds a new parameter `menu_placeholder` to the `Paginator` class, which allows users to specify the text shown in the `PaginatorMenu` instance used with page groups. Previously this required subclassing `Paginator` and overriding `add_menu()` to accomplish.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
