### PR TITLE
fix some kwargs failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ build/
 test.py
 build/
 node_modules/*
-test.py

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -892,9 +892,6 @@ class SlashCommandGroup(ApplicationCommand):
         description: str,
         guild_ids: Optional[List[int]] = None,
         parent: Optional[SlashCommandGroup] = None,
-        *,
-        default_permissions: Optional[bool] = True,
-        permissions: Optional[List[CommandPermission]] = [],
         **kwargs,
     ) -> None:
         validate_chat_input_name(name)
@@ -913,8 +910,8 @@ class SlashCommandGroup(ApplicationCommand):
         self.id = None
 
         # Permissions
-        self.default_permission = default_permissions
-        self.permissions: List[CommandPermission] = permissions
+        self.default_permission = kwargs.get("default_permission", True)
+        self.permissions: List[CommandPermission] = kwargs.get("permissions", [])
         if self.permissions and self.default_permission:
             self.default_permission = False
 
@@ -1058,7 +1055,10 @@ class SlashCommandGroup(ApplicationCommand):
         ret = self.__class__(
             name=self.name,
             description=self.description,
-            **self.__original_kwargs__,
+            **{
+                param: value for param, value in self.__original_kwargs__.items()
+                if param not in ('name', 'description')
+            },
         )
         return self._ensure_assignment_on_copy(ret)
 


### PR DESCRIPTION
## Summary
Actually fixes #1127, #1150
No missing argument or multiple argument errors

Another solution would to create something like `__original_args__` and pass that in instead of `name` and `description` separately

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
