### PR TITLE
Allow type checkers to treat cached_property as a normal property.

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
     from typing import Callable, Awaitable
 
-from ..utils import _cached_property as cached_property
+from ..utils import cached_property
 
 T = TypeVar("T")
 CogT = TypeVar("CogT", bound="Cog")

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -136,11 +136,11 @@ if TYPE_CHECKING:
     from .permissions import Permissions
     from .template import Template
 
-    cached_property = NewType('cached_property', property)
-
     class _RequestLike(Protocol):
         headers: Mapping[str, Any]
 
+    cached_property = NewType('cached_property', property)
+    
     P = ParamSpec("P")
 
 else:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -56,6 +56,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    NewType,
     Optional,
     Protocol,
     Sequence,
@@ -134,6 +135,8 @@ if TYPE_CHECKING:
     from .invite import Invite
     from .permissions import Permissions
     from .template import Template
+
+    cached_property = NewType('cached_property', property)
 
     class _RequestLike(Protocol):
         headers: Mapping[str, Any]


### PR DESCRIPTION
## Summary

Using NewType to alias `cached_property` as a subclass of property allows type checkers to actually treat it as a property instead of a function object without causing the issue that actually sub-classing property would cause.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
