### PR TITLE
feat: asynchrounousifying the setup function in cog

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -41,6 +41,7 @@ from typing import (
     Type,
     TypeVar,
 )
+from asyncio import create_task
 
 import discord.utils
 
@@ -693,7 +694,11 @@ class CogMixin:
             raise errors.NoEntryPointError(key)
 
         try:
-            setup(self)
+            if inspect.iscoroutinefunction(setup):
+                create_task(setup(self))
+            else:
+                setup(self)
+                
         except Exception as e:
             del sys.modules[key]
             self._remove_module_references(lib.__name__)

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -10,7 +10,7 @@ There comes a time in the bot development when you want to extend the bot functi
 Primer
 --------
 
-An extension at its core is a python file with an entry point called ``setup``. This setup must be a plain Python function (not a coroutine). It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
+An extension at its core is a python file with an entry point called ``setup``.
 
 An example extension looks like this:
 


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
i had asynchrounousified the setup function in cog

code used for testing:
testcog.py
```python
from discord.ext import commands
from discord.ext.commands import Cog

class testCog(Cog):
    def __init__(self, bot):
        self.bot = bot
    
    @commands.command()
    async def test(self, ctx):
        await ctx.send("Test")

async def setup(bot):
    bot.add_cog(testCog(bot))
    print("test done")
```

main.py
```python
import random

import discord
import asyncio
from discord.ext import commands

description = """An example bot to showcase the discord.ext.commands extension
module.
There are a number of utility commands being showcased here."""

intents = discord.Intents.default()
intents.members = True
intents.message_content = True


bot = commands.Bot(command_prefix=")", description=description, intents=intents)


@bot.event
async def on_ready():
    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
    print("------")

async def setup():
    bot.load_extension("testcog")

asyncio.run(setup())
bot.run("token")
```

command used to run: `python3 main.py`
output:
```
test done
Logged in as my bot name#my bot discrim (ID: my bot id)
------
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested. 
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
