### PR TITLE
Ability to set guild_ids for all commands in a cog

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -138,6 +138,7 @@ class CogMeta(type):
     __cog_settings__: Dict[str, Any]
     __cog_commands__: List[ApplicationCommand]
     __cog_listeners__: List[Tuple[str, str]]
+    __cog_guild_ids__: List[int]
 
     def __new__(cls: Type[CogMeta], *args: Any, **kwargs: Any) -> CogMeta:
         name, bases, attrs = args
@@ -220,8 +221,8 @@ class CogMeta(type):
 
         # Update the Command instances dynamically as well
         for command in new_cls.__cog_commands__:
-            if isinstance(command, ApplicationCommand) and command.guild_ids is None and len(new_cls.guild_ids) != 0:
-                command.guild_ids = new_cls.guild_ids
+            if isinstance(command, ApplicationCommand) and command.guild_ids is None and len(new_cls.__cog_guild_ids__) != 0:
+                command.guild_ids = new_cls.__cog_guild_ids__
             if not isinstance(command, SlashCommandGroup):
                 setattr(new_cls, command.callback.__name__, command)
                 parent = command.parent
@@ -263,6 +264,7 @@ class Cog(metaclass=CogMeta):
     __cog_settings__: ClassVar[Dict[str, Any]]
     __cog_commands__: ClassVar[List[ApplicationCommand]]
     __cog_listeners__: ClassVar[List[Tuple[str, str]]]
+    __cog_guild_ids__: ClassVar[List[int]]
 
     def __new__(cls: Type[CogT], *args: Any, **kwargs: Any) -> CogT:
         # For issue 426, we need to store a copy of the command objects

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -135,6 +135,7 @@ class CogMeta(type):
 
     def __new__(cls: Type[CogMeta], *args: Any, **kwargs: Any) -> CogMeta:
         name, bases, attrs = args
+        guild_ids = kwargs.pop("guild_ids", [])
         attrs["__cog_name__"] = kwargs.pop("name", name)
         attrs["__cog_settings__"] = kwargs.pop("command_attrs", {})
 
@@ -213,6 +214,8 @@ class CogMeta(type):
 
         # Update the Command instances dynamically as well
         for command in new_cls.__cog_commands__:
+            if isinstance(command, ApplicationCommand) and command.guild_ids is None and len(guild_ids) != 0:
+                command.guild_ids = guild_ids
             if not isinstance(command, SlashCommandGroup):
                 setattr(new_cls, command.callback.__name__, command)
                 parent = command.parent

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -126,6 +126,12 @@ class CogMeta(type):
                 @commands.command(hidden=False)
                 async def bar(self, ctx):
                     pass # hidden -> False
+
+    guild_ids: Optional[List[:class:`int`]]
+        A shortcut to command_attrs, what guild_ids should all application commands have
+        in the cog. You can override this by setting guild_ids per command.
+
+        .. versionadded:: 2.0
     """
 
     __cog_name__: str

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -141,9 +141,9 @@ class CogMeta(type):
 
     def __new__(cls: Type[CogMeta], *args: Any, **kwargs: Any) -> CogMeta:
         name, bases, attrs = args
-        guild_ids = kwargs.pop("guild_ids", [])
         attrs["__cog_name__"] = kwargs.pop("name", name)
         attrs["__cog_settings__"] = kwargs.pop("command_attrs", {})
+        attrs["__cog_guild_ids__"] = kwargs.pop("guild_ids", [])
 
         description = kwargs.pop("description", None)
         if description is None:
@@ -220,8 +220,8 @@ class CogMeta(type):
 
         # Update the Command instances dynamically as well
         for command in new_cls.__cog_commands__:
-            if isinstance(command, ApplicationCommand) and command.guild_ids is None and len(guild_ids) != 0:
-                command.guild_ids = guild_ids
+            if isinstance(command, ApplicationCommand) and command.guild_ids is None and len(new_cls.guild_ids) != 0:
+                command.guild_ids = new_cls.guild_ids
             if not isinstance(command, SlashCommandGroup):
                 setattr(new_cls, command.callback.__name__, command)
                 parent = command.parent


### PR DESCRIPTION
## Summary
```python
class SomeCog(commands.Cog, guild_ids=[...]):
    def __init__(self, client):
        self.client = client

    @discord.slash_command(name="locale")
    async def n(self, ctx):
        await ctx.respond(ctx.interaction.locale)

    @discord.slash_command(name="guild-locale")
    async def h(self, ctx):
        await ctx.respond(ctx.interaction.guild_locale)
```
Would be a convenient alternative to putting `guild_ids` in each command or using `command_attrs`

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
