### PR TITLE
Add url property to scheduled events

### DIFF
--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -102,7 +102,7 @@ class ScheduledEventLocation:
         return f"<ScheduledEventLocation value={self.value} type={self.type}>"
 
     def __str__(self) -> str:
-        return self.value
+        return str(self.value)
 
     @property
     def type(self) -> ScheduledEventLocationType:
@@ -232,7 +232,7 @@ class ScheduledEvent(Hashable):
             f"description={self.description} "
             f"start_time={self.start_time} "
             f"end_time={self.end_time} "
-            f"location={self.location} "
+            f"location={self.location!r} "
             f"status={self.status.name} "
             f"subscriber_count={self.subscriber_count} "
             f"creator_id={self.creator_id}>"
@@ -247,6 +247,11 @@ class ScheduledEvent(Hashable):
     def interested(self) -> Optional[int]:
         """An alias to :attr:`.subscriber_count`"""
         return self.subscriber_count
+
+    @property
+    def url(self) -> str:
+        """:class:`str`: The url to reference the scheduled event."""
+        return f"https://discord.com/events/{self.guild.id}/{self.id}"
 
     @property
     def cover(self) -> Optional[Asset]:


### PR DESCRIPTION
## Summary
Better alternative to getting an invite url.
Also fixed an issue where repr wasn't giving a proper string for jishaku

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
