### PR TITLE
Allows passing in thread.id directly to the send function for Webhook objects

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1371,6 +1371,7 @@ class Webhook(BaseWebhook):
         allowed_mentions: AllowedMentions = MISSING,
         view: View = MISSING,
         thread: Snowflake = MISSING,
+        thread_id: Optional[int] = None,
         wait: Literal[True],
     ) -> WebhookMessage:
         ...
@@ -1391,6 +1392,7 @@ class Webhook(BaseWebhook):
         allowed_mentions: AllowedMentions = MISSING,
         view: View = MISSING,
         thread: Snowflake = MISSING,
+        thread_id: Optional[int] = None,
         wait: Literal[False] = ...,
     ) -> None:
         ...
@@ -1410,6 +1412,7 @@ class Webhook(BaseWebhook):
         allowed_mentions: AllowedMentions = MISSING,
         view: View = MISSING,
         thread: Snowflake = MISSING,
+        thread_id: Optional[int] = None,
         wait: bool = False,
         delete_after: float = None,
     ) -> Optional[WebhookMessage]:
@@ -1539,9 +1542,9 @@ class Webhook(BaseWebhook):
             previous_allowed_mentions=previous_mentions,
         )
         adapter = async_context.get()
-        thread_id: Optional[int] = None
-        if thread is not MISSING:
-            thread_id = thread.id
+        if not thread_id:
+            if thread is not MISSING:
+                thread_id = thread.id
 
         data = await adapter.execute_webhook(
             self.id,

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1480,6 +1480,12 @@ class Webhook(BaseWebhook):
             The thread to send this webhook to.
 
             .. versionadded:: 2.0
+        thread_id: :class:`int`
+            The thread_id to send this webhook to. Can be used in lieu of 
+            creating a Thread or Snowflake object. The thread should be in
+            the channel(s) that the webhook has access to.
+
+            .. versionadded:: 2.1
         delete_after: :class:`float`
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent.

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -927,6 +927,7 @@ class SyncWebhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         thread: Snowflake = MISSING,
+        thread_id: Optional[int] = None,
         wait: Literal[False] = ...,
     ) -> None:
         ...
@@ -944,6 +945,7 @@ class SyncWebhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         thread: Snowflake = MISSING,
+        thread_id: Optional[int] = None,
         wait: bool = False,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
@@ -1035,9 +1037,9 @@ class SyncWebhook(BaseWebhook):
             previous_allowed_mentions=previous_mentions,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
-        thread_id: Optional[int] = None
-        if thread is not MISSING:
-            thread_id = thread.id
+        if not thread_id:
+            if thread is not MISSING:
+                thread_id = thread.id
 
         data = adapter.execute_webhook(
             self.id,


### PR DESCRIPTION
## Summary

This PR allows passing in thread.id directly to the send function for Webhook objects.
Webhooks created from URL's have access to a specific channel via the Discord settings > integration page. Currently, developers need to create a Thread object that is then passed into the Webhook.send() function, only for the send function to extract the thread.id attribute.

Motivating:
After fetching a webhook, most of its attributes are null making it incredibly difficult to create a Thread object, often you'll have to initialize objects or clients that have the scope to fetch a thread. Allowing the send function to take the thread.id directly reduces boilerplate if the thread_id is already known since we no longer need to fetch the thread object in the first place.

Overall, this makes it easier for webhooks to connect to a thread directly and simplifies integrating an external channel to a Discord thread (only the webhook object and it's scopes are needed)!

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)