### PR TITLE
Rename all "pycord" references to address trademark violation concerns from PSF

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to Pycord
+## Contributing to Pogcord
 
 First off, thanks for taking the time to contribute. It makes the library substantially better. :+1:
 
@@ -8,9 +8,9 @@ The following is a set of guidelines for contributing to the repository. These a
 
 Generally speaking questions are better suited in our resources below.
 
-- The official support server: https://pycord.dev/discord
-- [The FAQ in the documentation](https://docs.pycord.dev/en/master/faq.html)
-- [StackOverflow's `pycord` tag](https://stackoverflow.com/questions/tagged/pycord)
+- The official support server: https://pogcord.dev/discord
+- [The FAQ in the documentation](https://docs.pogcord.dev/en/master/faq.html)
+- [StackOverflow's `pogcord` tag](https://stackoverflow.com/questions/tagged/pogcord)
 
 Please try your best not to ask questions in our issue tracker. Most of them don't belong there unless they provide value to a larger audience.
 
@@ -25,7 +25,7 @@ Please be aware of the following things when filing bug reports.
     - Guidance on **how to reproduce the issue**. Ideally, this should have a small code sample that allows us to run and see the issue for ourselves to debug. **Please make sure that the token is not displayed**. If you cannot provide a code snippet, then let us know what the steps were, how often it happens, etc.
     - Tell us **what you expected to happen**. That way we can meet that expectation.
     - Tell us **what actually happens**. What ends up happening in reality? It's not helpful to say "it fails" or "it doesn't work". Say *how* it failed, do you get an exception? Does it hang? How are the expectations different from reality?
-    - Tell us **information about your environment**. What version of Pycord are you using? How was it installed? What operating system are you running on? These are valuable questions and information that we use.
+    - Tell us **information about your environment**. What version of Pogcord are you using? How was it installed? What operating system are you running on? These are valuable questions and information that we use.
 
 If the bug report is missing this information then it'll take us longer to fix the issue. We will probably ask for clarification, and barring that if no response was given then the issue will be closed.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out a bug.
-        If you want real-time support, consider joining our Discord at https://pycord.dev/discord instead.
+        If you want real-time support, consider joining our Discord at https://pogcord.dev/discord instead.
 
         Please note that this form is for bugs only!
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Ask a question
     about: Ask questions and discuss with other users of the library.
-    url: https://github.com/Pycord-Development/pycord/discussions
+    url: https://github.com/Pogcord-Development/pogcord/discussions
   - name: Discord Server
     about: Use our official Discord server to ask for help and questions as well.
-    url: https://pycord.dev/discord
+    url: https://pogcord.dev/discord

--- a/.github/ISSUE_TEMPLATE/vulnerability_report.yml
+++ b/.github/ISSUE_TEMPLATE/vulnerability_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out a vulnerability report.
-        If you want real-time support, consider joining our Discord at https://pycord.dev/discord instead.
+        If you want real-time support, consider joining our Discord at https://pogcord.dev/discord instead.
 
         Please note that this form is for vulnerability reports only!
   - type: textarea

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,5 +10,5 @@
 ## Reporting a Vulnerability
 
 If you find a vulnerability you have two ways to report it:
-- Write us on https://pycord.dev/discord
-- Open an [issue](https://github.com/Pycord-Development/pycord/issues/new/choose)
+- Write us on https://pogcord.dev/discord
+- Open an [issue](https://github.com/Pogcord-Development/pogcord/issues/new/choose)

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,1 @@
-patreon: pycord
+patreon: pogcord

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,20 @@
-Pycord
+Pogcord
 ======
 
 .. image:: https://img.shields.io/discord/881207955029110855?color=blue&label=discord&style=for-the-badge&logo=discord&color=success
-   :target: https://pycord.dev/discord
+   :target: https://pogcord.dev/discord
    :alt: Discord server invite
-.. image:: https://img.shields.io/pypi/v/py-cord.svg?style=for-the-badge&logo=semantic-release&color=yellowgreen
-   :target: https://pypi.python.org/pypi/py-cord
+.. image:: https://img.shields.io/pypi/v/pog-cord.svg?style=for-the-badge&logo=semantic-release&color=yellowgreen
+   :target: https://pypi.python.org/pypi/pog-cord
    :alt: PyPI version info
-.. image:: https://img.shields.io/pypi/pyversions/py-cord.svg?style=for-the-badge&logo=python
-   :target: https://pypi.python.org/pypi/py-cord
+.. image:: https://img.shields.io/pypi/pyversions/pog-cord.svg?style=for-the-badge&logo=python
+   :target: https://pypi.python.org/pypi/pog-cord
    :alt: PyPI supported Python versions
-.. image:: https://img.shields.io/pypi/dm/py-cord?color=blueviolet&logo=pypi&logoColor=blue&style=for-the-badge
-   :target: https://pypi.python.org/pypi/py-cord
+.. image:: https://img.shields.io/pypi/dm/pog-cord?color=blueviolet&logo=pypi&logoColor=blue&style=for-the-badge
+   :target: https://pypi.python.org/pypi/pog-cord
    :alt: PyPI downloads
 
-A fork of discord.py. Pycord is a modern, easy to use, feature-rich, and async ready API wrapper for Discord written in Python.
+A fork of discord.py. Pogcord is a modern, easy to use, feature-rich, and async ready API wrapper for Discord written in Python.
 
 Key Features
 ------------
@@ -34,37 +34,37 @@ To install the library without full voice support, you can just run the followin
 .. code:: sh
 
     # Linux/macOS
-    python3 -m pip install -U py-cord
+    python3 -m pip install -U pog-cord
 
     # Windows
-    py -3 -m pip install -U py-cord
+    py -3 -m pip install -U pog-cord
 
 Otherwise to get voice support you should run the following command:
 
 .. code:: sh
 
     # Linux/macOS
-    python3 -m pip install -U "py-cord[voice]"
+    python3 -m pip install -U "pog-cord[voice]"
 
     # Windows
-    py -3 -m pip install -U py-cord[voice]
+    py -3 -m pip install -U pog-cord[voice]
 
 To install additional packages for speedup, run the following command:
 
 .. code:: sh
 
     # Linux/macOS
-    python3 -m pip install -U "py-cord[speed]"
+    python3 -m pip install -U "pog-cord[speed]"
     # Windows
-    py -3 -m pip install -U py-cord[speed]
+    py -3 -m pip install -U pog-cord[speed]
 
 
 To install the development version, do the following:
 
 .. code:: sh
 
-    $ git clone https://github.com/Pycord-Development/pycord
-    $ cd pycord
+    $ git clone https://github.com/Pogcord-Development/pogcord
+    $ cd pogcord
     $ python3 -m pip install -U .[voice]
 
 
@@ -125,8 +125,8 @@ Note: Make sure you do not reveal your bot token to anyone, it can grant access 
 Useful Links
 ------------
 
-- `Documentation <https://docs.pycord.dev/en/master/index.html>`_
-- `Learn how to create Discord bots with Pycord <https://guide.pycord.dev>`_
-- `Our Official Discord Server <https://pycord.dev/discord>`_
+- `Documentation <https://docs.pogcord.dev/en/master/index.html>`_
+- `Learn how to create Discord bots with Pogcord <https://guide.pogcord.dev>`_
+- `Our Official Discord Server <https://pogcord.dev/discord>`_
 - `Official Discord Developers Server <https://discord.gg/discord-developers>`_
 - `Unofficial Discord API Server <https://discord.gg/discord-api>`_

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -4,15 +4,15 @@ Discord API Wrapper
 
 A basic wrapper for the Discord API.
 
-:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pycord Development
+:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pogcord Development
 :license: MIT, see LICENSE for more details.
 
 """
 
-__title__ = "pycord"
-__author__ = "Pycord Development"
+__title__ = "pogcord"
+__author__ = "Pogcord Development"
 __license__ = "MIT"
-__copyright__ = "Copyright 2015-2021 Rapptz & Copyright 2021-present Pycord Development"
+__copyright__ = "Copyright 2015-2021 Rapptz & Copyright 2021-present Pogcord Development"
 __version__ = "2.0.0b5"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -39,11 +39,11 @@ def show_version() -> None:
     entries = ["- Python v{0.major}.{0.minor}.{0.micro}-{0.releaselevel}".format(sys.version_info)]
 
     version_info = discord.version_info
-    entries.append("- py-cord v{0.major}.{0.minor}.{0.micro}-{0.releaselevel}".format(version_info))
+    entries.append("- pog-cord v{0.major}.{0.minor}.{0.micro}-{0.releaselevel}".format(version_info))
     if version_info.releaselevel != "final":
-        pkg = pkg_resources.get_distribution("py-cord")
+        pkg = pkg_resources.get_distribution("pog-cord")
         if pkg:
-            entries.append(f"    - py-cord pkg_resources: v{pkg.version}")
+            entries.append(f"    - pog-cord pkg_resources: v{pkg.version}")
 
     entries.append(f"- aiohttp v{aiohttp.__version__}")
     uname = platform.uname()
@@ -339,7 +339,7 @@ def add_newcog_args(subparser: argparse._SubParsersAction) -> None:
 
 
 def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
-    parser = argparse.ArgumentParser(prog="discord", description="Tools for helping with Pycord")
+    parser = argparse.ArgumentParser(prog="discord", description="Tools for helping with Pogcord")
     parser.add_argument("-v", "--version", action="store_true", help="shows the library version")
     parser.set_defaults(func=core)
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/backoff.py
+++ b/discord/backoff.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -61,7 +61,7 @@ class ExponentialBackoff(Generic[T]):
 
         self._exp: int = 0
         self._max: int = 10
-        self._reset_time: int = base * 2**11
+        self._reset_time: int = base * 2 ** 11
         self._last_invocation: float = time.monotonic()
 
         # Use our own random instance to avoid messing with global one
@@ -101,4 +101,4 @@ class ExponentialBackoff(Generic[T]):
             self._exp = 0
 
         self._exp = min(self._exp + 1, self._max)
-        return self._randfunc(0, self._base * 2**self._exp)
+        return self._randfunc(0, self._base * 2 ** self._exp)

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/client.py
+++ b/discord/client.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -397,7 +397,7 @@ class Client:
     ) -> asyncio.Task:
         wrapped = self._run_event(coro, event_name, *args, **kwargs)
         # Schedules the task
-        return asyncio.create_task(wrapped, name=f"pycord: {event_name}")
+        return asyncio.create_task(wrapped, name=f"pogcord: {event_name}")
 
     def dispatch(self, event: str, *args: Any, **kwargs: Any) -> None:
         _log.debug("Dispatching event %s", event)

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/commands/__init__.py
+++ b/discord/commands/__init__.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -50,7 +50,7 @@ from typing import (
 )
 
 from ..enums import ChannelType, SlashCommandOptionType
-from ..errors import ClientException, ValidationError, NotFound
+from ..errors import ClientException, NotFound, ValidationError
 from ..member import Member
 from ..message import Attachment, Message
 from ..user import User
@@ -388,15 +388,15 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         A pre-invoke hook is called directly before the command is
         called. This makes it a useful function to set up database
         connections or any type of set up required.
-        
+
         This pre-invoke hook takes a sole parameter, a :class:`.ApplicationContext`.
         See :meth:`.Bot.before_invoke` for more info.
-        
+
         Parameters
         -----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the pre-invoke hook.
-            
+
         Raises
         -------
         TypeError
@@ -413,15 +413,15 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         A post-invoke hook is called directly after the command is
         called. This makes it a useful function to clean-up database
         connections or any type of clean up required.
-        
+
         This post-invoke hook takes a sole parameter, a :class:`.ApplicationContext`.
         See :meth:`.Bot.after_invoke` for more info.
-        
+
         Parameters
         -----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the post-invoke hook.
-            
+
         Raises
         -------
         TypeError
@@ -1073,8 +1073,9 @@ class SlashCommandGroup(ApplicationCommand):
             name=self.name,
             description=self.description,
             **{
-                param: value for param, value in self.__original_kwargs__.items()
-                if param not in ('name', 'description')
+                param: value
+                for param, value in self.__original_kwargs__.items()
+                if param not in ("name", "description")
             },
         )
         return self._ensure_assignment_on_copy(ret)
@@ -1420,9 +1421,9 @@ class MessageCommand(ContextMenuCommand):
 
 def slash_command(**kwargs):
     """Decorator for slash commands that invokes :func:`application_command`.
-    
+
     .. versionadded:: 2.0
-    
+
     Returns
     --------
     Callable[..., :class:`SlashCommand`]
@@ -1433,9 +1434,9 @@ def slash_command(**kwargs):
 
 def user_command(**kwargs):
     """Decorator for user commands that invokes :func:`application_command`.
-    
+
     .. versionadded:: 2.0
-    
+
     Returns
     --------
     Callable[..., :class:`UserCommand`]
@@ -1446,9 +1447,9 @@ def user_command(**kwargs):
 
 def message_command(**kwargs):
     """Decorator for message commands that invokes :func:`application_command`.
-    
+
     .. versionadded:: 2.0
-    
+
     Returns
     --------
     Callable[..., :class:`MessageCommand`]
@@ -1466,9 +1467,9 @@ def application_command(cls=SlashCommand, **attrs):
     ``inspect.cleandoc``. If the docstring is ``bytes``, then it is decoded
     into :class:`str` using utf-8 encoding.
     The ``name`` attribute also defaults to the function name unchanged.
-    
+
     .. versionadded:: 2.0
-    
+
     Parameters
     -----------
     cls: :class:`.ApplicationCommand`
@@ -1477,7 +1478,7 @@ def application_command(cls=SlashCommand, **attrs):
     attrs
         Keyword arguments to pass into the construction of the class denoted
         by ``cls``.
-        
+
     Raises
     -------
     TypeError
@@ -1496,12 +1497,12 @@ def application_command(cls=SlashCommand, **attrs):
 
 def command(**kwargs):
     """An alias for :meth:`application_command`.
-    
+
     .. note::
         This decorator is overridden by :func:`commands.command`.
-        
+
     .. versionadded:: 2.0
-    
+
     Returns
     --------
     Callable[..., :class:`ApplicationCommand`]

--- a/discord/commands/errors.py
+++ b/discord/commands/errors.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -218,8 +218,12 @@ class OptionChoice:
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
     """
 
-    def __init__(self, name: str, value: Optional[Union[str, int, float]] = None,
-                 name_localizations: Optional[Dict[str, str]] = None):
+    def __init__(
+        self,
+        name: str,
+        value: Optional[Union[str, int, float]] = None,
+        name_localizations: Optional[Dict[str, str]] = None,
+    ):
         self.name = name
         self.value = value if value is not None else name
         self.name_localizations = name_localizations

--- a/discord/commands/permissions.py
+++ b/discord/commands/permissions.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/components.py
+++ b/discord/components.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/errors.py
+++ b/discord/errors.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -65,7 +65,7 @@ __all__ = (
 
 
 class DiscordException(Exception):
-    """Base exception class for pycord
+    """Base exception class for pogcord
 
     Ideally speaking, this could be caught to handle any exceptions raised from this library.
     """

--- a/discord/ext/commands/__init__.py
+++ b/discord/ext/commands/__init__.py
@@ -4,7 +4,7 @@ discord.ext.commands
 
 An extension module to facilitate creation of bot commands.
 
-:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pycord Development
+:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pogcord Development
 :license: MIT, see LICENSE for more details.
 """
 

--- a/discord/ext/commands/_types.py
+++ b/discord/ext/commands/_types.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/commands/view.py
+++ b/discord/ext/commands/view.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/pages/__init__.py
+++ b/discord/ext/pages/__init__.py
@@ -3,7 +3,7 @@ discord.ext.pages
 ~~~~~~~~~~~~~~~~~~~~~
 An extension module to provide useful menu options.
 
-:copyright: 2021-present Pycord-Development
+:copyright: 2021-present Pogcord-Development
 :license: MIT, see LICENSE for more details.
 """
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/file.py
+++ b/discord/file.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -89,7 +89,7 @@ def fill_with_flags(*, inverted: bool = False):
 
         if inverted:
             max_bits = max(cls.VALID_FLAGS.values()).bit_length()
-            cls.DEFAULT_VALUE = -1 + (2**max_bits)
+            cls.DEFAULT_VALUE = -1 + (2 ** max_bits)
         else:
             cls.DEFAULT_VALUE = 0
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -396,8 +396,8 @@ class DiscordWebSocket:
                 "token": self.token,
                 "properties": {
                     "$os": sys.platform,
-                    "$browser": "pycord",
-                    "$device": "pycord",
+                    "$browser": "pogcord",
+                    "$device": "pogcord",
                     "$referrer": "",
                     "$referring_domain": "",
                 },

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -67,7 +67,7 @@ from .file import File
 from .flags import SystemChannelFlags
 from .integrations import Integration, _integration_factory
 from .invite import Invite
-from .iterators import AuditLogIterator, MemberIterator, BanIterator
+from .iterators import AuditLogIterator, BanIterator, MemberIterator
 from .member import Member, VoiceState
 from .mixins import Hashable
 from .permissions import PermissionOverwrite
@@ -1886,8 +1886,9 @@ class Guild(Hashable):
         channel: GuildChannel = factory(guild=self, state=self._state, data=data)  # type: ignore
         return channel
 
-    def bans(self, limit: Optional[int] = None, before: Optional[SnowflakeTime] = None,
-             after: Optional[SnowflakeTime] = None) -> BanIterator:
+    def bans(
+        self, limit: Optional[int] = None, before: Optional[SnowflakeTime] = None, after: Optional[SnowflakeTime] = None
+    ) -> BanIterator:
         """|coro|
 
         Retrieves an :class:`.AsyncIterator` that enables receiving the guild's bans. In order to use this, you must

--- a/discord/http.py
+++ b/discord/http.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -188,7 +188,7 @@ class HTTPClient:
         self.proxy_auth: Optional[aiohttp.BasicAuth] = proxy_auth
         self.use_clock: bool = not unsync_clock
 
-        user_agent = "DiscordBot (https://github.com/Pycord-Development/pycord {0}) Python/{1[0]}.{1[1]} aiohttp/{2}"
+        user_agent = "DiscordBot (https://github.com/Pogcord-Development/pogcord {0}) Python/{1[0]}.{1[1]} aiohttp/{2}"
         self.user_agent: str = user_agent.format(__version__, sys.version_info, aiohttp.__version__)
 
     def recreate(self) -> None:
@@ -1343,11 +1343,11 @@ class HTTPClient:
         return self.request(Route("POST", "/guilds/templates/{code}", code=code), json=payload)
 
     def get_bans(
-            self,
-            guild_id: Snowflake,
-            limit: Optional[int] = None,
-            before: Optional[Snowflake] = None,
-            after: Optional[Snowflake] = None,
+        self,
+        guild_id: Snowflake,
+        limit: Optional[int] = None,
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
     ) -> Response[List[guild.Ban]]:
         params: Dict[str, Union[int, Snowflake]] = {}
 

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -4,7 +4,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -56,7 +56,7 @@ __all__ = (
 if TYPE_CHECKING:
     from .abc import Snowflake
     from .audit_logs import AuditLogEntry
-    from .guild import Guild, BanEntry
+    from .guild import BanEntry, Guild
     from .member import Member
     from .message import Message
     from .scheduled_events import ScheduledEvent
@@ -740,12 +740,12 @@ class BanIterator(_AsyncIterator["BanEntry"]):
 
 class ArchivedThreadIterator(_AsyncIterator["Thread"]):
     def __init__(
-            self,
-            channel_id: int,
-            guild: Guild,
-            limit: Optional[int],
-            joined: bool,
-            private: bool,
+        self,
+        channel_id: int,
+        guild: Guild,
+        limit: Optional[int],
+        joined: bool,
+        private: bool,
         before: Optional[Union[Snowflake, datetime.datetime]] = None,
     ):
         self.channel_id = channel_id

--- a/discord/member.py
+++ b/discord/member.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/mentions.py
+++ b/discord/mentions.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/message.py
+++ b/discord/message.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/mixins.py
+++ b/discord/mixins.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/object.py
+++ b/discord/object.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/oggparse.py
+++ b/discord/oggparse.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/partial_emoji.py
+++ b/discord/partial_emoji.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/player.py
+++ b/discord/player.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/role.py
+++ b/discord/role.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/sinks/__init__.py
+++ b/discord/sinks/__init__.py
@@ -4,7 +4,7 @@ discord.sinks
 
 A place to store all officially given voice sinks.
 
-:copyright: 2021-present Pycord Development
+:copyright: 2021-present Pogcord Development
 :license: MIT, see LICENSE for more details.
 """
 from .core import *

--- a/discord/sinks/core.py
+++ b/discord/sinks/core.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -127,7 +127,7 @@ class AudioData:
 
     def write(self, data):
         """Writes audio data.
-        
+
         Raises
         ------
         ClientException
@@ -142,7 +142,7 @@ class AudioData:
 
     def cleanup(self):
         """Finishes and cleans up the audio data.
-        
+
         Raises
         ------
         ClientException
@@ -155,7 +155,7 @@ class AudioData:
 
     def on_format(self, encoding):
         """Called when audio data is formatted.
-        
+
         Raises
         ------
         ClientException
@@ -176,7 +176,7 @@ class Sink(Filters):
         such as :class:`~discord.sinks.WaveSink`.
 
     just replace the following like so: ::
-    
+
         vc.start_recording(
             MySubClassedSink(),
             finished_callback,

--- a/discord/sinks/errors.py
+++ b/discord/sinks/errors.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/sinks/m4a.py
+++ b/discord/sinks/m4a.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -48,7 +48,7 @@ class M4ASink(Sink):
 
     def format_audio(self, audio):
         """Formats the recorded audio.
-        
+
         Raises
         ------
         M4ASinkError

--- a/discord/sinks/mka.py
+++ b/discord/sinks/mka.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,7 @@ class MKASink(Sink):
 
     def format_audio(self, audio):
         """Formats the recorded audio.
-        
+
         Raises
         ------
         MKASinkError

--- a/discord/sinks/mkv.py
+++ b/discord/sinks/mkv.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,7 @@ class MKVSink(Sink):
 
     def format_audio(self, audio):
         """Formats the recorded audio.
-        
+
         Raises
         ------
         MKVSinkError

--- a/discord/sinks/mp3.py
+++ b/discord/sinks/mp3.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -49,7 +49,7 @@ class MP3Sink(Sink):
 
     def format_audio(self, audio):
         """Formats the recorded audio.
-        
+
         Raises
         ------
         MP3SinkError

--- a/discord/sinks/mp4.py
+++ b/discord/sinks/mp4.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -48,7 +48,7 @@ class MP4Sink(Sink):
 
     def format_audio(self, audio):
         """Formats the recorded audio.
-        
+
         Raises
         ------
         MP4SinkError

--- a/discord/sinks/ogg.py
+++ b/discord/sinks/ogg.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,7 @@ class OGGSink(Sink):
 
     def format_audio(self, audio):
         """Formats the recorded audio.
-        
+
         Raises
         ------
         OGGSinkError

--- a/discord/sinks/pcm.py
+++ b/discord/sinks/pcm.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/sinks/wave.py
+++ b/discord/sinks/wave.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,7 @@ class WaveSink(Sink):
 
     def format_audio(self, audio):
         """Formats the recorded audio.
-        
+
         Raises
         ------
         WaveSinkError

--- a/discord/stage_instance.py
+++ b/discord/stage_instance.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/state.py
+++ b/discord/state.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/team.py
+++ b/discord/team.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/template.py
+++ b/discord/template.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/__init__.py
+++ b/discord/types/__init__.py
@@ -4,6 +4,6 @@ discord.types
 
 Typings for the Discord API
 
-:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pycord Development
+:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pogcord Development
 :license: MIT, see LICENSE for more details.
 """

--- a/discord/types/activity.py
+++ b/discord/types/activity.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/embed.py
+++ b/discord/types/embed.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/emoji.py
+++ b/discord/types/emoji.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/gateway.py
+++ b/discord/types/gateway.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/guild.py
+++ b/discord/types/guild.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/integration.py
+++ b/discord/types/integration.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/invite.py
+++ b/discord/types/invite.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/member.py
+++ b/discord/types/member.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/role.py
+++ b/discord/types/role.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/scheduled_events.py
+++ b/discord/types/scheduled_events.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/snowflake.py
+++ b/discord/types/snowflake.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/sticker.py
+++ b/discord/types/sticker.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/team.py
+++ b/discord/types/team.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/template.py
+++ b/discord/types/template.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/threads.py
+++ b/discord/types/threads.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/user.py
+++ b/discord/types/user.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/voice.py
+++ b/discord/types/voice.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/webhook.py
+++ b/discord/types/webhook.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/welcome_screen.py
+++ b/discord/types/welcome_screen.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/types/widget.py
+++ b/discord/types/widget.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ui/__init__.py
+++ b/discord/ui/__init__.py
@@ -4,7 +4,7 @@ discord.ui
 
 UI Kit helper for the Discord API
 
-:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pycord Development
+:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pogcord Development
 :license: MIT, see LICENSE for more details.
 
 """

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ui/item.py
+++ b/discord/ui/item.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/user.py
+++ b/discord/user.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -139,8 +139,8 @@ if TYPE_CHECKING:
     class _RequestLike(Protocol):
         headers: Mapping[str, Any]
 
-    cached_property = NewType('cached_property', property)
-    
+    cached_property = NewType("cached_property", property)
+
     P = ParamSpec("P")
 
 else:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -699,7 +699,7 @@ class VoiceClient(VoiceProtocol):
             A function which is called after the bot has stopped recording.
         *args:
             Args which will be passed to the callback function.
-            
+
         Raises
         ------
         RecordingException

--- a/discord/webhook/__init__.py
+++ b/discord/webhook/__init__.py
@@ -4,7 +4,7 @@ discord.webhook
 
 Webhook support for the Discord API
 
-:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pycord Development
+:copyright: (c) 2015-2021 Rapptz & (c) 2021-present Pogcord Development
 :license: MIT, see LICENSE for more details.
 
 """

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -1267,37 +1267,37 @@ class Webhook(BaseWebhook):
     ) -> Webhook:
         """|coro|
 
-          Edits this Webhook.
+        Edits this Webhook.
 
-          Parameters
-          -----------
-          name: Optional[:class:`str`]
-              The webhook's new default name.
-          avatar: Optional[:class:`bytes`]
-              A :term:`py:bytes-like object` representing the webhook's new default avatar.
-          channel: Optional[:class:`abc.Snowflake`]
-              The webhook's new channel. This requires an authenticated webhook.
+        Parameters
+        -----------
+        name: Optional[:class:`str`]
+            The webhook's new default name.
+        avatar: Optional[:class:`bytes`]
+            A :term:`py:bytes-like object` representing the webhook's new default avatar.
+        channel: Optional[:class:`abc.Snowflake`]
+            The webhook's new channel. This requires an authenticated webhook.
 
-              .. versionadded:: 2.0
-          reason: Optional[:class:`str`]
-              The reason for editing this webhook. Shows up on the audit log.
+            .. versionadded:: 2.0
+        reason: Optional[:class:`str`]
+            The reason for editing this webhook. Shows up on the audit log.
 
-              .. versionadded:: 1.4
-          prefer_auth: :class:`bool`
-              Whether to use the bot token over the webhook token
-              if available. Defaults to ``True``.
+            .. versionadded:: 1.4
+        prefer_auth: :class:`bool`
+            Whether to use the bot token over the webhook token
+            if available. Defaults to ``True``.
 
-              .. versionadded:: 2.0
+            .. versionadded:: 2.0
 
-          Raises
-          ------
-          HTTPException
-              Editing the webhook failed.
-          NotFound
-              This webhook does not exist.
-          InvalidArgument
-              This webhook does not have a token associated with it
-              or it tried editing a channel without authentication.
+        Raises
+        ------
+        HTTPException
+            Editing the webhook failed.
+        NotFound
+            This webhook does not exist.
+        InvalidArgument
+            This webhook does not have a token associated with it
+            or it tried editing a channel without authentication.
         """
         if self.token is None and self.auth_token is None:
             raise InvalidArgument("This webhook does not have a token associated with it")

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -2,7 +2,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2021-present Pogcord Development
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -86,17 +86,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/pycord.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/pogcord.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/pycord.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/pogcord.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/pycord"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/pycord"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/pogcord"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/pogcord"
 	@echo "# devhelp"
 
 epub:

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -58,8 +58,8 @@
     {#- The main navigation header #}
     <header class="grid-item">
       <nav>
-        <a href="{{ pathto(master_doc)|e }}" class="main-heading">Pycord</a>
-        <a href="https://github.com/Pycord-Development/pycord" title="GitHub"><span class="material-icons custom-icons">github</span></a>
+        <a href="{{ pathto(master_doc)|e }}" class="main-heading">Pogcord</a>
+        <a href="https://github.com/Pogcord-Development/pogcord" title="GitHub"><span class="material-icons custom-icons">github</span></a>
         <a href="{{ discord_invite }}" title="{{ _('Discord') }}"><span class="material-icons custom-icons">discord</span></a>
         <a href="{{ pathto('faq') }}" title="FAQ"><span class="material-icons">help_center</span></a>
         {#- If we have more links we can put them here #}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,7 +3,7 @@
 API Reference
 ===============
 
-The following section outlines the API of Pycord.
+The following section outlines the API of Pogcord.
 
 .. note::
 
@@ -11,7 +11,7 @@ The following section outlines the API of Pycord.
     in an output independent way.  If the logging module is not configured,
     these logs will not be output anywhere.  See :ref:`logging_setup` for
     more information on how to set up and use the logging module with
-    Pycord.
+    Pogcord.
 
 Version Related Info
 ---------------------
@@ -3921,7 +3921,7 @@ AuditLogDiff
 Webhook Support
 ------------------
 
-Pycord offers support for creating, editing, and executing webhooks through the :class:`Webhook` class.
+Pogcord offers support for creating, editing, and executing webhooks through the :class:`Webhook` class.
 
 Webhook
 ~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 #
-# pycord documentation build configuration file, created by
+# pogcord documentation build configuration file, created by
 # sphinx-quickstart on Fri Aug 21 05:43:30 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -50,7 +50,7 @@ autodoc_typehints = "none"
 # napoleon_attr_annotations = False
 
 extlinks = {
-    "issue": ("https://github.com/Pycord-Development/pycord/issues/%s", "GH-"),
+    "issue": ("https://github.com/Pogcord-Development/pogcord/issues/%s", "GH-"),
 }
 
 # Links used for cross-referencing stuff in other documentation
@@ -83,8 +83,8 @@ source_suffix = {
 master_doc = "index"
 
 # General information about the project.
-project = "Pycord"
-copyright = "2015-2021, Rapptz & 2021-present, Pycord Development"
+project = "Pogcord"
+copyright = "2015-2021, Rapptz & 2021-present, Pogcord Development"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -161,7 +161,7 @@ html_experimental_html5_writer = True
 html_theme = "basic"
 
 html_context = {
-    "discord_invite": "https://pycord.dev/discord",
+    "discord_invite": "https://pogcord.dev/discord",
     "discord_extensions": [
         ("discord.ext.commands", "ext/commands"),
         ("discord.ext.tasks", "ext/tasks"),
@@ -170,11 +170,11 @@ html_context = {
 }
 
 resource_links = {
-    "discord": "https://pycord.dev/discord",
-    "issues": "https://github.com/Pycord-Development/pycord/issues",
-    "discussions": "https://github.com/Pycord-Development/pycord/discussions",
-    "examples": f"https://github.com/Pycord-Development/pycord/tree/{branch}/examples",
-    "guide": "https://guide.pycord.dev/",
+    "discord": "https://pogcord.dev/discord",
+    "issues": "https://github.com/Pogcord-Development/pogcord/issues",
+    "discussions": "https://github.com/Pogcord-Development/pogcord/discussions",
+    "examples": f"https://github.com/Pogcord-Development/pogcord/tree/{branch}/examples",
+    "guide": "https://guide.pogcord.dev/",
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -200,7 +200,7 @@ resource_links = {
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = "./images/pycord.ico"
+html_favicon = "./images/pogcord.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -270,7 +270,7 @@ html_search_scorer = "_static/scorer.js"
 html_js_files = ["custom.js", "settings.js", "copy.js", "sidebar.js"]
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "pycorddoc"
+htmlhelp_basename = "pogcorddoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -289,7 +289,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ("index", "Pycord.tex", "Pycord Documentation", "Pycord Development", "manual"),
+    ("index", "Pogcord.tex", "Pogcord Documentation", "Pogcord Development", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -317,7 +317,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "Pycord", "Pycord Documentation", ["Pycord Development"], 1)]
+man_pages = [("index", "Pogcord", "Pogcord Documentation", ["Pogcord Development"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -331,10 +331,10 @@ man_pages = [("index", "Pycord", "Pycord Documentation", ["Pycord Development"],
 texinfo_documents = [
     (
         "index",
-        "Pycord",
-        "Pycord Documentation",
-        "Pycord Development",
-        "Pycord",
+        "Pogcord",
+        "Pogcord Documentation",
+        "Pogcord Development",
+        "Pogcord",
         "One line description of project.",
         "Miscellaneous",
     ),

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -3,7 +3,7 @@
 API Reference
 ===============
 
-The following section outlines the API of Pycord's prefixed command extension module.
+The following section outlines the API of Pogcord's prefixed command extension module.
 
 .. note::
 

--- a/docs/ext/commands/index.rst
+++ b/docs/ext/commands/index.rst
@@ -3,9 +3,9 @@
 ``discord.ext.commands`` -- Bot commands framework
 ====================================================
 
-``Pycord`` offers a lower level aspect on interacting with Discord. Often times, the library is used for the creation of
+``Pogcord`` offers a lower level aspect on interacting with Discord. Often times, the library is used for the creation of
 bots. However this task can be daunting and confusing to get correctly the first time. Many times there comes a repetition in
-creating a bot command framework that is extensible, flexible, and powerful. For this reason, ``Pycord`` comes with an
+creating a bot command framework that is extensible, flexible, and powerful. For this reason, ``Pogcord`` comes with an
 extension library that handles this for you.
 
 

--- a/docs/ext/tasks/index.rst
+++ b/docs/ext/tasks/index.rst
@@ -11,7 +11,7 @@ One of the most common operations when making a bot is having a loop run in the 
 - What do I do if the internet goes out?
 - What is the maximum number of seconds I can sleep anyway?
 
-The goal of this Pycord extension is to abstract all these worries away from you.
+The goal of this Pogcord extension is to abstract all these worries away from you.
 
 Recipes
 ---------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,7 +6,7 @@
 Frequently Asked Questions
 ===========================
 
-This is a list of Frequently Asked Questions regarding using ``Pycord`` and its extension modules. Feel free to suggest a
+This is a list of Frequently Asked Questions regarding using ``Pogcord`` and its extension modules. Feel free to suggest a
 new question or submit one via pull requests.
 
 .. contents:: Questions
@@ -81,7 +81,7 @@ General questions regarding library usage belong here.
 Where can I find usage examples?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Example code can be found in the `examples folder <https://github.com/Pycord-Development/pycord/tree/master/examples>`_
+Example code can be found in the `examples folder <https://github.com/Pogcord-Development/pogcord/tree/master/examples>`_
 in the repository.
 
 How do I set the "Playing" status?
@@ -253,7 +253,7 @@ this together we can do the following: ::
 How do I run something in the background?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`Check the background_task.py example. <https://github.com/Pycord-Development/pycord/blob/master/examples/background_task.py>`_
+`Check the background_task.py example. <https://github.com/Pogcord-Development/pogcord/blob/master/examples/background_task.py>`_
 
 How do I get a specific model?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,15 @@
-.. pycord documentation master file, created by
+.. pogcord documentation master file, created by
    sphinx-quickstart on Fri Aug 21 05:43:30 2015.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Pycord
+Welcome to Pogcord
 =================
 
 .. image:: /images/snake.svg
 .. image:: /images/snake_dark.svg
 
-Pycord is a modern, easy to use, feature-rich, and async ready API wrapper
+Pogcord is a modern, easy to use, feature-rich, and async ready API wrapper
 for Discord.
 
 **Features:**

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -4,16 +4,16 @@
 
 .. _intro:
 
-Installing Pycord
+Installing Pogcord
 =================
 
-This is the documentation for Pycord, a library for Python to aid
+This is the documentation for Pogcord, a library for Python to aid
 in creating applications that utilise the Discord API.
 
 Prerequisites
 -------------
 
-Pycord works with Python 3.8 or higher. Support for earlier versions of Python
+Pogcord works with Python 3.8 or higher. Support for earlier versions of Python
 is not provided. Python 2.7 or lower is not supported. Python 3.7 or lower is not supported.
 
 
@@ -26,35 +26,35 @@ Installing
 
     For new features like slash commands, buttons, modals, and threads, you will need to install the pre-release a stable v2.0 is released. ::
 
-        python3 -m pip install -U py-cord --pre
+        python3 -m pip install -U pog-cord --pre
 
     For Windows users, this command should be used to install the pre-release: ::
 
-        py -3 -m pip install -U py-cord --pre
+        py -3 -m pip install -U pog-cord --pre
 
 You can get the library directly from PyPI: ::
 
-    python3 -m pip install -U py-cord
+    python3 -m pip install -U pog-cord
 
 If you are using Windows, then the following should be used instead: ::
 
-    py -3 -m pip install -U py-cord
+    py -3 -m pip install -U pog-cord
 
 
-To install additional packages for speedup,  you should use ``py-cord[speed]`` instead of ``py-cord``, e.g.
+To install additional packages for speedup,  you should use ``pog-cord[speed]`` instead of ``pog-cord``, e.g.
 
 .. code:: sh
 
     # Linux/macOS
-    python3 -m pip install -U "py-cord[speed]"
+    python3 -m pip install -U "pog-cord[speed]"
 
     # Windows
-    py -3 -m pip install -U py-cord[speed]
+    py -3 -m pip install -U pog-cord[speed]
 
 
-To get voice support, you should use ``py-cord[voice]`` instead of ``py-cord``, e.g. ::
+To get voice support, you should use ``pog-cord[voice]`` instead of ``pog-cord``, e.g. ::
 
-    python3 -m pip install -U py-cord[voice]
+    python3 -m pip install -U pog-cord[voice]
 
 On Linux environments, installing voice requires getting the following dependencies:
 
@@ -105,14 +105,14 @@ However, for the quick and dirty:
 
     .. code-block:: shell
 
-        $ pip install -U py-cord
+        $ pip install -U pog-cord
 
 Congratulations. You now have a virtual environment all set up.
 
 Basic Concepts
 --------------
 
-Pycord revolves around the concept of :ref:`events <discord-api-events>`.
+Pogcord revolves around the concept of :ref:`events <discord-api-events>`.
 An event is something you listen to and then respond to. For example, when a message
 happens, you will receive an event about it that you can respond to.
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -6,7 +6,7 @@
 Setting Up Logging
 ==================
 
-*Pycord* logs errors and debug information via the :mod:`logging` python
+*Pogcord* logs errors and debug information via the :mod:`logging` python
 module. It is strongly recommended that the logging module is
 configured, as no errors or warnings will be output if it is not set up.
 Configuration of the ``logging`` module can be as simple as::

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -127,9 +127,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\pycord.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\pogcord.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\pycord.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\pogcord.ghc
 	goto end
 )
 

--- a/examples/converters.py
+++ b/examples/converters.py
@@ -92,7 +92,7 @@ async def ignore(ctx: commands.Context, target: typing.Union[discord.Member, dis
     # The `commands` framework attempts a conversion of each type in this Union *in order*.
     # So, it will attempt to convert whatever is passed to `target` to a `discord.Member` instance.
     # If that fails, it will attempt to convert it to a `discord.TextChannel` instance.
-    # See: https://docs.pycord.dev/en/latest/ext/commands/commands.html#typing-union
+    # See: https://docs.pogcord.dev/en/latest/ext/commands/commands.html#typing-union
     # NOTE: If a Union typehint converter fails it will raise `commands.BadUnionArgument`
     # Instead of `commands.BadArgument`.
 
@@ -108,7 +108,7 @@ async def ignore(ctx: commands.Context, target: typing.Union[discord.Member, dis
 async def multiply(ctx: commands.Context, number: int, maybe: bool):
     # We want an `int` and a `bool` parameter here.
     # `bool` is a slightly special case, as shown here:
-    # See: https://docs.pycord.dev/en/latest/ext/commands/commands.html#bool
+    # See: https://docs.pogcord.dev/en/latest/ext/commands/commands.html#bool
 
     if maybe:
         return await ctx.send(number * 2)

--- a/examples/views/button_roles.py
+++ b/examples/views/button_roles.py
@@ -7,7 +7,7 @@ Let users assign themselves roles by clicking on Buttons.
 The view made is persistent, so it will work even when the bot restarts.
 
 See this example for more information about persistent views
-https://github.com/Pycord-Development/pycord/blob/master/examples/views/persistent.py
+https://github.com/Pogcord-Development/pogcord/blob/master/examples/views/persistent.py
 Make sure to load this cog when your bot starts!
 """
 

--- a/examples/views/paginator.py
+++ b/examples/views/paginator.py
@@ -1,4 +1,4 @@
-# Docs: https://docs.pycord.dev/en/master/ext/pages/index.html
+# Docs: https://docs.pogcord.dev/en/master/ext/pages/index.html
 # Note that the below examples use a Slash Command Group in a cog for better organization - it's not required for using ext.pages.
 import asyncio
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ with open("README.rst") as f:
     readme = f.read()
 
 # Extra Requirements
-# Ex: pip install py-cord[voice] or [speed]
+# Ex: pip install pog-cord[voice] or [speed]
 extras_require = {
     "voice": ["PyNaCl>=1.3.0,<1.6"],
     "docs": [
@@ -84,13 +84,13 @@ packages = [
 
 
 setup(
-    name="py-cord",
-    author="Pycord Development",
-    url="https://pycord.dev/github",
+    name="pog-cord",
+    author="Pogcord Development",
+    url="https://pogcord.dev/github",
     project_urls={
-        "Website": "https://pycord.dev",
-        "Documentation": "https://docs.pycord.dev/en/master/",
-        "Issue tracker": "https://github.com/Pycord-Development/pycord/issues",
+        "Website": "https://pogcord.dev",
+        "Documentation": "https://docs.pogcord.dev/en/master/",
+        "Issue tracker": "https://github.com/Pogcord-Development/pogcord/issues",
     },
     version=version,
     packages=packages,


### PR DESCRIPTION
<!-- Warning: AF 2022 -->

## Summary

This replaces all references to "pycord", "Pycord", and "py-cord" with "pogcord", "Pogcord", and "pog-cord", in order to comply with the cease-and-desist letter we recently received from the Python Software Foundation regarding our chosen branding.

Closes #4122

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
