### PR TITLE
[ext.pages] Fix for "Unknown Message" errors when using ephemeral paginators

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -761,7 +761,7 @@ class Paginator(discord.ui.View):
 
             .. warning::
 
-                If your paginator is ephemeral, it cannot have a timeout longer than 15 minutes (and cannot be peristent).
+                If your paginator is ephemeral, it cannot have a timeout longer than 15 minutes (and cannot be persistent).
 
         target: Optional[:class:`~discord.abc.Messageable`]
             A target where the paginated message should be sent, if different from the original :class:`discord.Interaction`


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This fixes the "Unknown Message" error that occurs when sending an ephemeral paginator after using an ephemeral defer.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
