### PR TITLE
[ext.pages] General fixes and enhancements

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -358,7 +358,7 @@ class Paginator(discord.ui.View):
                 List[str], List[Page], List[Union[List[discord.Embed], discord.Embed]]
             ] = self.page_groups[0].pages
 
-        self.page_count = len(self.pages) - 1
+        self.page_count = max(len(self.pages), 0)
         self.buttons = {}
         self.custom_buttons: List = custom_buttons
         self.show_disabled = show_disabled

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -134,12 +134,20 @@ class Page:
         content: Optional[str] = None,
         embeds: Optional[List[Union[List[discord.Embed], discord.Embed]]] = None,
         custom_view: Optional[discord.ui.View] = None,
+        **kwargs,
     ):
         if content is None and embeds is None:
             raise discord.InvalidArgument("A page cannot have both content and embeds equal to None.")
         self._content = content
         self._embeds = embeds or []
         self._custom_view = custom_view
+
+    async def callback(self):
+        """|coro|
+
+        The coroutine associated to a specific page. If `Paginator.page_action()` is used, this coroutine is called.
+        """
+        pass
 
     @property
     def content(self) -> Optional[str]:
@@ -709,6 +717,11 @@ class Paginator(discord.ui.View):
                 return Page(content=None, embeds=page)
             else:
                 raise TypeError("All list items must be embeds.")
+
+    async def page_action(self) -> None:
+        """Triggers the callback associated with the current page, if any."""
+        if self.get_page_content(self.pages[self.current_page]).callback:
+            await self.get_page_content(self.pages[self.current_page]).callback()
 
     async def send(
         self,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -744,7 +744,7 @@ class Paginator(discord.ui.View):
         Parameters
         ----------
         interaction: Optional[:class:`discord.Interaction`]
-            The interaction used to trigger the page action.
+            The interaction that was used to trigger the page action.
         """
         if self.get_page_content(self.pages[self.current_page]).callback:
             await self.get_page_content(self.pages[self.current_page]).callback(interaction=interaction)

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -738,7 +738,7 @@ class Paginator(discord.ui.View):
             else:
                 raise TypeError("All list items must be embeds.")
 
-    async def page_action(self, interaction: Optional[discord.Interaction]) -> None:
+    async def page_action(self, interaction: Optional[discord.Interaction] = None) -> None:
         """Triggers the callback associated with the current page, if any.
 
         Parameters

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -228,7 +228,8 @@ class PageGroup:
         A list of PaginatorButtons to initialize the Paginator with.
         If ``use_default_buttons`` is ``True``, this parameter is ignored.
     trigger_on_display: :class:`bool`
-        Whether to automatically trigger the callback associated with a `Page` whenever it is displayed. Has no effect if no callback exists for a `Page`.
+        Whether to automatically trigger the callback associated with a `Page` whenever it is displayed.
+        Has no effect if no callback exists for a `Page`.
     """
 
     def __init__(
@@ -302,7 +303,8 @@ class Paginator(discord.ui.View):
         A list of PaginatorButtons to initialize the Paginator with.
         If ``use_default_buttons`` is ``True``, this parameter is ignored.
     trigger_on_display: :class:`bool`
-        Whether to automatically trigger the callback associated with a `Page` whenever it is displayed. Has no effect if no callback exists for a `Page`.
+        Whether to automatically trigger the callback associated with a `Page` whenever it is displayed.
+        Has no effect if no callback exists for a `Page`.
 
     Attributes
     ----------
@@ -395,6 +397,7 @@ class Paginator(discord.ui.View):
         custom_view: Optional[discord.ui.View] = None,
         timeout: Optional[float] = None,
         custom_buttons: Optional[List[PaginatorButton]] = None,
+        trigger_on_display: Optional[bool] = None,
     ):
         """Updates the existing :class:`Paginator` instance with the provided options.
 
@@ -426,6 +429,9 @@ class Paginator(discord.ui.View):
         custom_buttons: Optional[List[:class:`PaginatorButton`]]
             A list of PaginatorButtons to initialize the Paginator with.
             If ``use_default_buttons`` is ``True``, this parameter is ignored.
+        trigger_on_display: :class:`bool`
+            Whether to automatically trigger the callback associated with a `Page` whenever it is displayed.
+            Has no effect if no callback exists for a `Page`.
         """
 
         # Update pages and reset current_page to 0 (default)
@@ -445,6 +451,7 @@ class Paginator(discord.ui.View):
         self.loop_pages = loop_pages if loop_pages is not None else self.loop_pages
         self.custom_view: discord.ui.View = None if custom_view is None else custom_view
         self.timeout: float = timeout if timeout is not None else self.timeout
+        self.trigger_on_display = trigger_on_display if trigger_on_display is not None else self.trigger_on_display
         if custom_buttons and not self.use_default_buttons:
             self.buttons = {}
             for button in custom_buttons:

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -689,7 +689,8 @@ class Paginator(discord.ui.View):
     def update_custom_view(self, custom_view: discord.ui.View):
         """Updates the custom view shown on the paginator."""
         if isinstance(self.custom_view, discord.ui.View):
-            self.custom_view.clear_items()
+            for item in self.custom_view.children:
+                self.remove_item(item)
         for item in custom_view.children:
             self.add_item(item)
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -278,6 +278,7 @@ class Paginator(discord.ui.View):
         Whether to loop the pages when clicking prev/next while at the first/last page in the list.
     custom_view: Optional[:class:`discord.ui.View`]
         A custom view whose items are appended below the pagination components.
+        If the currently displayed page has a `custom_view` assigned, it will replace these view components when that page is displayed.
     timeout: Optional[:class:`float`]
         Timeout in seconds from last interaction with the paginator before no longer accepting input.
     custom_buttons: Optional[List[:class:`PaginatorButton`]]

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -138,7 +138,7 @@ class Page:
         if content is None and embeds is None:
             raise discord.InvalidArgument("A page cannot have both content and embeds equal to None.")
         self._content = content
-        self._embeds = embeds
+        self._embeds = embeds or []
         self._custom_view = custom_view
 
     @property
@@ -688,9 +688,10 @@ class Paginator(discord.ui.View):
 
     def update_custom_view(self, custom_view: discord.ui.View):
         """Updates the custom view shown on the paginator."""
-        self.custom_view.clear_items()
+        if isinstance(self.custom_view, discord.ui.View):
+            self.custom_view.clear_items()
         for item in custom_view.children:
-            self.custom_view.add_item(item)
+            self.add_item(item)
 
     @staticmethod
     def get_page_content(page: Union[Page, str, discord.Embed, List[discord.Embed]]) -> Page:
@@ -767,6 +768,9 @@ class Paginator(discord.ui.View):
         page = self.pages[self.current_page]
         page_content = self.get_page_content(page)
 
+        if page_content.custom_view:
+            self.update_custom_view(page_content.custom_view)
+
         self.user = ctx.author
 
         if target:
@@ -837,6 +841,9 @@ class Paginator(discord.ui.View):
 
         page: Union[Page, str, discord.Embed, List[discord.Embed]] = self.pages[self.current_page]
         page_content: Page = self.get_page_content(page)
+
+        if page_content.custom_view:
+            self.update_custom_view(page_content.custom_view)
 
         self.user = interaction.user
         if target:

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -758,6 +758,11 @@ class Paginator(discord.ui.View):
         ephemeral: :class:`bool`
             Whether the paginator message and its components are ephemeral.
             If ``target`` is specified, the ephemeral message content will be ``target_message`` instead.
+
+            .. warning::
+
+                If your paginator is ephemeral, it cannot have a timeout longer than 15 minutes (and cannot be persistent).
+
         target: Optional[:class:`~discord.abc.Messageable`]
             A target where the paginated message should be sent, if different from the original :class:`discord.Interaction`
         target_message: :class:`str`
@@ -775,7 +780,7 @@ class Paginator(discord.ui.View):
         if target is not None and not isinstance(target, discord.abc.Messageable):
             raise TypeError(f"expected abc.Messageable not {target.__class__!r}")
 
-        if ephemeral and self.timeout >= 900 or self.timeout is None:
+        if ephemeral and (self.timeout >= 900 or self.timeout is None):
             raise ValueError(
                 "paginator responses cannot be ephemeral if the paginator timeout is 15 minutes or greater"
             )
@@ -801,8 +806,9 @@ class Paginator(discord.ui.View):
                     view=self,
                     ephemeral=ephemeral,
                 )
-                # convert from WebhookMessage to Message reference to bypass 15min webhook token timeout
-                msg = await msg.channel.fetch_message(msg.id)
+                # convert from WebhookMessage to Message reference to bypass 15min webhook token timeout (non-ephemeral messages only)
+                if not ephemeral:
+                    msg = await msg.channel.fetch_message(msg.id)
             else:
                 msg = await interaction.response.send_message(
                     content=page_content.content,
@@ -810,9 +816,7 @@ class Paginator(discord.ui.View):
                     view=self,
                     ephemeral=ephemeral,
                 )
-            if isinstance(msg, discord.WebhookMessage):
-                self.message = await msg.channel.fetch_message(msg.id)
-            elif isinstance(msg, discord.Message):
+            if isinstance(msg, (discord.Message, discord.WebhookMessage)):
                 self.message = msg
             elif isinstance(msg, discord.Interaction):
                 self.message = await msg.original_message()


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This PR makes the following changes:

- `Paginator.update_custom_view()` - New method used to easily change the custom view shown with the paginator without needing to use `Paginator.update()` to do so. 
- `Page.custom_view` - New parameter, represents a custom view assigned to a `Page` object, which will be displayed when that page is being displayed. Overrides any defined `Paginator.custom_view` while the page is being displayed. 
  - Closes #955
- `Paginator.goto_page()` now accepts a keyword argument `interaction`. If provided, the message associated to the paginator will be edited via that interaction's response path. If not, the `discord.Message` object assigned to `Paginator.message` will be used to edit the message instead. 
  - Closes #1093 
  - Closes #1189 
  - The callback method for `PaginatorButton` now passes its `interaction` automatically to its `Paginator.goto_page()` call by default.
- Added `Page.callback()` method, which can be used to assign a callback to a specific page.
  - Added `Paginator.page_action()` method which triggers the callback of the currently displayed page, if one is defined.
  - Added `Paginator.trigger_on_display` parameter which makes `goto_page` automatically call `Paginator.page_action()` whenever a `Page` with a defined callback is displayed.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
