### PR TITLE
Remove deprecated mention syntax

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -524,8 +524,6 @@ class Member(discord.abc.Messageable, _UserTag):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the member."""
-        if self.nick:
-            return f"<@!{self._user.id}>"
         return f"<@{self._user.id}>"
 
     @property


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

Removes deprecated mention syntax for users with nicknames. See discord/discord-api-docs#4734 for more info.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
