### PR TITLE
Localization Fixes

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1593,7 +1593,6 @@ valid_locales = [
 # Validation
 def validate_chat_input_name(name: Any, locale: str = None):
     # Must meet the regex ^[\w-]{1,32}$
-    print(locale)
     if locale not in valid_locales and locale is not None:
         raise ValidationError(
             f"Locale {locale} is not a valid locale, in command names, "

--- a/discord/http.py
+++ b/discord/http.py
@@ -251,6 +251,9 @@ class HTTPClient:
             if reason:
                 headers["X-Audit-Log-Reason"] = _uriquote(reason, safe="/ ")
 
+        if locale := kwargs.pop('locale', None):
+            headers["X-Discord-Locale"] = locale
+
         kwargs["headers"] = headers
         # Proxy support
         if self.proxy is not None:
@@ -2063,17 +2066,25 @@ class HTTPClient:
 
     # Application commands (global)
 
-    def get_global_commands(self, application_id: Snowflake) -> Response[List[interactions.ApplicationCommand]]:
+    def get_global_commands(
+        self, application_id: Snowflake, *, with_localizations: bool = True, locale: str = None,
+    ) -> Response[List[interactions.ApplicationCommand]]:
+        params = {
+            "with_localizations": int(with_localizations)
+        }
+
         return self.request(
             Route(
                 "GET",
                 "/applications/{application_id}/commands",
                 application_id=application_id,
-            )
+            ),
+            params=params,
+            locale=locale,
         )
 
     def get_global_command(
-        self, application_id: Snowflake, command_id: Snowflake
+        self, application_id: Snowflake, command_id: Snowflake, locale: str = None,
     ) -> Response[interactions.ApplicationCommand]:
         r = Route(
             "GET",
@@ -2081,7 +2092,7 @@ class HTTPClient:
             application_id=application_id,
             command_id=command_id,
         )
-        return self.request(r)
+        return self.request(r, locale=locale)
 
     def upsert_global_command(self, application_id: Snowflake, payload) -> Response[interactions.ApplicationCommand]:
         r = Route(

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -77,7 +77,7 @@ class ApplicationCommandOption(_ApplicationCommandOptionOptional):
 
 
 class _ApplicationCommandOptionChoiceOptional(TypedDict, total=False):
-    name_localization: Dict[str, str]
+    name_localizations: Dict[str, str]
 
 
 class ApplicationCommandOptionChoice(_ApplicationCommandOptionChoiceOptional):

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -46,6 +46,10 @@ ApplicationCommandType = Literal[1, 2, 3]
 class _ApplicationCommandOptional(TypedDict, total=False):
     options: List[ApplicationCommandOption]
     type: ApplicationCommandType
+    name_localized: str
+    name_localizations: Dict[str, str]
+    description_localized: str
+    description_localizations: Dict[str, str]
 
 
 class ApplicationCommand(_ApplicationCommandOptional):
@@ -58,6 +62,8 @@ class ApplicationCommand(_ApplicationCommandOptional):
 class _ApplicationCommandOptionOptional(TypedDict, total=False):
     choices: List[ApplicationCommandOptionChoice]
     options: List[ApplicationCommandOption]
+    name_localizations: Dict[str, str]
+    description_localizations: Dict[str, str]
 
 
 ApplicationCommandOptionType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -70,7 +76,11 @@ class ApplicationCommandOption(_ApplicationCommandOptionOptional):
     required: bool
 
 
-class ApplicationCommandOptionChoice(TypedDict):
+class _ApplicationCommandOptionChoiceOptional(TypedDict, total=False):
+    name_localization: Dict[str, str]
+
+
+class ApplicationCommandOptionChoice(_ApplicationCommandOptionChoiceOptional):
     name: str
     value: Union[str, int]
 


### PR DESCRIPTION
## Summary

Context menu support name localizations, validation of localized names/descriptions, and fetching localization data.
The new regex wasn't implemented because it doesn't seem to work (in python at least):

![image](https://user-images.githubusercontent.com/78228142/161971101-638d6437-ff22-4d86-9520-b2157079169c.png)

testing needed

## Checklist

- [x] If code changes were made then they have been tested. (more testing should be done)
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
