### PR TITLE
[ext.pages] Fix logic for `page_count` calculation

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -358,7 +358,7 @@ class Paginator(discord.ui.View):
                 List[str], List[Page], List[Union[List[discord.Embed], discord.Embed]]
             ] = self.page_groups[0].pages
 
-        self.page_count = max(len(self.pages), 0)
+        self.page_count = max(len(self.pages) - 1, 0)
         self.buttons = {}
         self.custom_buttons: List = custom_buttons
         self.show_disabled = show_disabled
@@ -438,7 +438,7 @@ class Paginator(discord.ui.View):
         self.pages: Union[List[PageGroup], List[str], List[Page], List[Union[List[discord.Embed], discord.Embed]]] = (
             pages if pages is not None else self.pages
         )
-        self.page_count = len(self.pages) - 1
+        self.page_count = max(len(self.pages) - 1, 0)
         self.current_page = 0
         # Apply config changes, if specified
         self.show_disabled = show_disabled if show_disabled is not None else self.show_disabled


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This fixes an issue introduced in #1227 with the logic for determining the value for `page_count` in `Paginator.__init__()`. It also adds the same fix to `Paginator.update()`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
