### PR TITLE
Fix embeds not getting edited in with partial messages

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1434,11 +1434,11 @@ class Messageable:
 
         if allowed_mentions is None:
             allowed_mentions = state.allowed_mentions and state.allowed_mentions.to_dict()
-
         elif state.allowed_mentions is not None:
             allowed_mentions = state.allowed_mentions.merge(allowed_mentions).to_dict()
         else:
             allowed_mentions = allowed_mentions.to_dict()
+
         if mention_author is not None:
             allowed_mentions = allowed_mentions or AllowedMentions().to_dict()
             allowed_mentions["replied_user"] = bool(mention_author)

--- a/discord/message.py
+++ b/discord/message.py
@@ -1814,8 +1814,6 @@ class PartialMessage(Hashable):
 
         Edits the message.
 
-        The content must be able to be transformed into a string via ``str(content)``.
-
         .. versionchanged:: 1.7
             :class:`discord.Message` is returned instead of ``None`` if an edit took place.
 
@@ -1824,9 +1822,13 @@ class PartialMessage(Hashable):
         content: Optional[:class:`str`]
             The new content to replace the message with.
             Could be ``None`` to remove the content.
-        embed: Optional[:class:`Embed`]
+        embed: Optional[:class:`~discord.Embed`]
             The new embed to replace the original with.
             Could be ``None`` to remove the embed.
+        embeds: Optional[List[:class:`~discord.Embed`]]
+            A list of embeds to upload. Must be a maximum of 10.
+
+            .. versionadded:: 2.0
         suppress: :class:`bool`
             Whether to suppress embeds for the message. This removes
             all the embeds if set to ``True``. If set to ``False``
@@ -1865,53 +1867,43 @@ class PartialMessage(Hashable):
             The message that was edited.
         """
 
-        try:
-            content = fields["content"]
-        except KeyError:
-            pass
-        else:
-            if content is not None:
-                fields["content"] = str(content)
+        content = fields.pop("content", MISSING)
+        if content is not MISSING:
+            fields["content"] = str(content)
 
-        try:
-            embed = fields["embed"]
-        except KeyError:
-            pass
-        else:
-            if embed is not None:
-                fields["embed"] = embed.to_dict()
+        embed = fields.pop("embed", MISSING)
+        embeds = fields.pop("embeds", MISSING)
 
-        try:
-            suppress: bool = fields.pop("suppress")
-        except KeyError:
-            pass
-        else:
-            flags = MessageFlags._from_value(0)
-            flags.suppress_embeds = suppress
-            fields["flags"] = flags.value
+        if embed is not MISSING and embeds is not MISSING:
+            raise InvalidArgument("Cannot pass both embed and embeds parameters.")
+
+        if embed is not MISSING:
+            fields["embeds"] = [embed.to_dict()]
+
+        if embeds is not MISSING:
+            fields["embeds"] = [embed.to_dict() for embed in embeds]
+
+        suppress = fields.pop("suppress", False)
+        flags = MessageFlags._from_value(0)
+        flags.suppress_embeds = suppress
+        fields["flags"] = flags.value
 
         delete_after = fields.pop("delete_after", None)
 
-        try:
-            allowed_mentions = fields.pop("allowed_mentions")
-        except KeyError:
-            pass
+        allowed_mentions = fields.get("allowed_mentions", MISSING)
+        if allowed_mentions is not MISSING:
+            if self._state.allowed_mentions is not None:
+                allowed_mentions = self._state.allowed_mentions.merge(allowed_mentions).to_dict()
+            else:
+                allowed_mentions = allowed_mentions.to_dict()
+            fields["allowed_mentions"] = allowed_mentions
         else:
-            if allowed_mentions is not None:
-                if self._state.allowed_mentions is not None:
-                    allowed_mentions = self._state.allowed_mentions.merge(allowed_mentions).to_dict()
-                else:
-                    allowed_mentions = allowed_mentions.to_dict()
-                fields["allowed_mentions"] = allowed_mentions
+            fields["allowed_mentions"] = self._state.allowed_mentions.to_dict() if self._state.allowed_mentions else None
 
-        try:
-            view = fields.pop("view")
-        except KeyError:
-            # To check for the view afterwards
-            view = None
-        else:
-            self._state.prevent_view_updates_for(self.id)
-            fields["components"] = view.to_components() if view else []
+        view = fields.pop("view", None)
+        self._state.prevent_view_updates_for(self.id)
+        fields["components"] = view.to_components() if view else []
+
         if fields:
             data = await self._state.http.edit_message(self.channel.id, self.id, **fields)
 


### PR DESCRIPTION
## Summary
The issue was that .edit was using the deprecated embed field which seems to have been removed in API v10.

Fixes #1182

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)