### PR TITLE
Fix #1244

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -192,7 +192,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.topic: Optional[str] = data.get("topic")
-        self.position: int = data["position"]
+        self.position: int = data.get("position")
         self.nsfw: bool = data.get("nsfw", False)
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)
@@ -816,7 +816,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
         self.video_quality_mode: VideoQualityMode = try_enum(VideoQualityMode, data.get("video_quality_mode", 1))
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.last_message_id: Optional[int] = utils._get_as_snowflake(data, 'last_message_id')
-        self.position: int = data["position"]
+        self.position: int = data.get("position")
         self.bitrate: int = data.get("bitrate")
         self.user_limit: int = data.get("user_limit")
         self._fill_overwrites(data)

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -803,7 +803,7 @@ class SlashCommand(ApplicationCommand):
                         obj_type = Role
                         kw["guild"] = ctx.guild
                     elif op.input_type is SlashCommandOptionType.channel:
-                        obj_type = _guild_channel_factory(_data["type"])
+                        obj_type, _ = _guild_channel_factory(_data["type"])
                         kw["guild"] = ctx.guild
                     elif op.input_type is SlashCommandOptionType.attachment:
                         obj_type = Attachment


### PR DESCRIPTION
## Summary

My fast fix for #1241 which prevents use of TextChannels and VoiceChannels as command options.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
