### PR TITLE
Rewrite options

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -696,7 +696,7 @@ class SlashCommand(ApplicationCommand):
 
             if option.name is None:
                 option.name = p_name
-            if option.name != p_name:
+            if option.name != p_name or option._parameter_name is None:
                 option._parameter_name = p_name
 
             _validate_names(option)
@@ -744,6 +744,12 @@ class SlashCommand(ApplicationCommand):
 
     def _is_typing_optional(self, annotation):
         return self._is_typing_union(annotation) and type(None) in annotation.__args__  # type: ignore
+
+    def _set_cog(self, cog):
+        prev = self.cog
+        super()._set_cog(cog)
+        if (prev is None and cog is not None) or (prev is not None and cog is None):
+            self.options = self._parse_options(self._get_signature_parameters())  # parse again to leave out self
 
     @property
     def is_subcommand(self) -> bool:
@@ -1155,7 +1161,7 @@ class SlashCommandGroup(ApplicationCommand):
             return self.copy()
 
     def _set_cog(self, cog):
-        self.cog = cog
+        super()._set_cog(cog)
         for subcommand in self.subcommands:
             subcommand._set_cog(cog)
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -141,7 +141,10 @@ class Option:
                 else:
                     if _type == SlashCommandOptionType.channel:
                         if not isinstance(input_type, tuple):
-                            input_type = (input_type,)
+                            if hasattr(input_type, "__args__"):  # Union
+                                input_type = input_type.__args__
+                            else:
+                                input_type = (input_type,)
                         for i in input_type:
                             if i.__name__ == "GuildChannel":
                                 continue

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -80,12 +80,12 @@ class Option:
     ----------
     input_type: :class:`Any`
         The type of input that is expected for this option.
-    description: :class:`str`
-        The description of this option.
-        Must be 100 characters or fewer.
     name: :class:`str`
         The name of this option visible in the UI.
         Inherits from the variable name if not provided as a parameter.
+    description: Optional[:class:`str`]
+        The description of this option.
+        Must be 100 characters or fewer.
     choices: Optional[List[Union[:class:`Any`, :class:`OptionChoice`]]]
         The list of available choices for this option.
         Can be a list of values or :class:`OptionChoice` objects (which represent a name:value pair).
@@ -115,10 +115,11 @@ class Option:
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
     """
 
-    def __init__(self, input_type: Any, /, description: str = None, **kwargs) -> None:
+    def __init__(self, input_type: Any = str, /, description: Optional[str] = None, **kwargs) -> None:
         self.name: Optional[str] = kwargs.pop("name", None)
         if self.name is not None:
             self.name = str(self.name)
+        self._parameter_name = self.name  # default
         self.description = description or "No description provided"
         self.converter = None
         self._raw_type = input_type

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -695,8 +695,9 @@ class SlashCommandOptionType(Enum):
         if issubclass(datatype, float):
             return cls.number
 
-        # TODO: Improve the error message
-        raise TypeError(f"Invalid class {datatype} used as an input type for an Option")
+        from .commands.context import ApplicationContext
+        if not issubclass(datatype, ApplicationContext):  # TODO: prevent ctx being passed here in cog commands
+            raise TypeError(f"Invalid class {datatype} used as an input type for an Option")  # TODO: Improve the error message
 
 
 class EmbeddedActivity(Enum):


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary
This modifies methods of slash commands related to option parsing and validation in order to optimize them and fix as many issues as possible.
Also allows a new design for creating options:
```py
async def command(
    ctx,
    parameter: type = Option(**other_values),
)
```

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
