### PR TITLE
Slash Command Channel Parsing Bug Fixes

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -130,9 +130,9 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         The category channel ID this channel belongs to, if applicable.
     topic: Optional[:class:`str`]
         The channel's topic. ``None`` if it doesn't exist.
-    position: :class:`int`
+    position: Optional[:class:`int`]
         The position in the channel list. This is a number that starts at 0. e.g. the
-        top channel is position 0.
+        top channel is position 0. Can be ``None`` if the channel was recieved in an interaction.
     last_message_id: Optional[:class:`int`]
         The last message ID of the message sent to this channel. It may
         *not* point to an existing or valid message.
@@ -192,7 +192,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.topic: Optional[str] = data.get("topic")
-        self.position: int = data["position"]
+        self.position: int = data.get("position", None)
         self.nsfw: bool = data.get("nsfw", False)
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)
@@ -816,7 +816,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
         self.video_quality_mode: VideoQualityMode = try_enum(VideoQualityMode, data.get("video_quality_mode", 1))
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.last_message_id: Optional[int] = utils._get_as_snowflake(data, 'last_message_id')
-        self.position: int = data["position"]
+        self.position: int = data.get("position", None)
         self.bitrate: int = data.get("bitrate")
         self.user_limit: int = data.get("user_limit")
         self._fill_overwrites(data)
@@ -902,9 +902,9 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         The channel ID.
     category_id: Optional[:class:`int`]
         The category channel ID this channel belongs to, if applicable.
-    position: :class:`int`
+    position: Optional[:class:`int`]
         The position in the channel list. This is a number that starts at 0. e.g. the
-        top channel is position 0.
+        top channel is position 0. Can be ``None`` if the channel was recieved in an interaction.
     bitrate: :class:`int`
         The channel's preferred audio bitrate in bits per second.
     user_limit: :class:`int`
@@ -1374,9 +1374,9 @@ class StageChannel(VocalGuildChannel):
         The channel's topic. ``None`` if it isn't set.
     category_id: Optional[:class:`int`]
         The category channel ID this channel belongs to, if applicable.
-    position: :class:`int`
+    position: Optional[:class:`int`]
         The position in the channel list. This is a number that starts at 0. e.g. the
-        top channel is position 0.
+        top channel is position 0. Can be ``None`` if the channel was recieved in an interaction.
     bitrate: :class:`int`
         The channel's preferred audio bitrate in bits per second.
     user_limit: :class:`int`
@@ -1651,9 +1651,9 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         The guild the category belongs to.
     id: :class:`int`
         The category channel ID.
-    position: :class:`int`
+    position: Optional[:class:`int`]
         The position in the category list. This is a number that starts at 0. e.g. the
-        top category is position 0.
+        top category is position 0. Can be ``None`` if the channel was recieved in an interaction.
     nsfw: :class:`bool`
         If the channel is marked as "not safe for work".
 
@@ -1686,7 +1686,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.nsfw: bool = data.get("nsfw", False)
-        self.position: int = data["position"]
+        self.position: int = data.get("position", None)
         self._fill_overwrites(data)
 
     @property

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -192,7 +192,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.topic: Optional[str] = data.get("topic")
-        self.position: int = data.get("position", )
+        self.position: int = data.get("position")
         self.nsfw: bool = data.get("nsfw", False)
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -192,7 +192,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.topic: Optional[str] = data.get("topic")
-        self.position: int = data.get("position", None)
+        self.position: int = data.get("position", )
         self.nsfw: bool = data.get("nsfw", False)
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)
@@ -816,7 +816,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
         self.video_quality_mode: VideoQualityMode = try_enum(VideoQualityMode, data.get("video_quality_mode", 1))
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.last_message_id: Optional[int] = utils._get_as_snowflake(data, 'last_message_id')
-        self.position: int = data.get("position", None)
+        self.position: int = data.get("position")
         self.bitrate: int = data.get("bitrate")
         self.user_limit: int = data.get("user_limit")
         self._fill_overwrites(data)
@@ -1686,7 +1686,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self.nsfw: bool = data.get("nsfw", False)
-        self.position: int = data.get("position", None)
+        self.position: int = data.get("position")
         self._fill_overwrites(data)
 
     @property

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -803,7 +803,7 @@ class SlashCommand(ApplicationCommand):
                         obj_type = Role
                         kw["guild"] = ctx.guild
                     elif op.input_type is SlashCommandOptionType.channel:
-                        obj_type = _guild_channel_factory(_data["type"])
+                        obj_type = _guild_channel_factory(_data["type"])[0]
                         kw["guild"] = ctx.guild
                     elif op.input_type is SlashCommandOptionType.attachment:
                         obj_type = Attachment


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
- Fixes parsing of channels in slash command invocations:
```py
Traceback (most recent call last):
  File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\commands\core.py", line 122, in wrapped
    ret = await coro(arg)
  File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\commands\core.py", line 811, in _invoke
    arg = obj_type(state=ctx.interaction._state, data=_data, **kw)
TypeError: 'tuple' object is not callable
```
- Makes the `position` attribute optional because Discord wasn't sending it:
```py
Traceback (most recent call last):
  File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\commands\core.py", line 122, in wrapped
    ret = await coro(arg)
  File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\commands\core.py", line 810, in _invoke
    arg = obj_type(state=ctx.interaction._state, data=_data, **kw)
  File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\channel.py", line 176, in __init__
    self._update(guild, data)
  File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\channel.py", line 195, in _update
    self.position: int = data["position"]
KeyError: 'position'
```

There was apparently a PR for this (#1246) but it was closed

Fixes #1241

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
