### PR TITLE
[ext.pages] Add `Paginator.edit()` method

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -881,7 +881,6 @@ class Paginator(discord.ui.View):
             raise TypeError(f"expected Message not {message.__class__!r}")
 
         self.update_buttons()
-        self.update_buttons()
 
         page: Union[Page, str, discord.Embed, List[discord.Embed]] = self.pages[self.current_page]
         page_content: Page = self.get_page_content(page)

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -901,6 +901,8 @@ class Paginator(discord.ui.View):
             )
         except discord.NotFound:
             pass
+        except discord.Forbidden:
+            pass
 
         return message
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -839,6 +839,61 @@ class Paginator(discord.ui.View):
 
         return self.message
 
+    async def edit(
+        self,
+        message: discord.Message,
+        suppress: Optional[bool] = None,
+        allowed_mentions: Optional[discord.AllowedMentions] = None,
+        delete_after: Optional[float] = None,
+    ) -> discord.Message:
+        """Edits an existing message to replace it with the paginator contents.
+
+        Parameters
+        -----------
+        message: :class:`discord.Message`
+            The message to edit with the paginator.
+        suppress: :class:`bool`
+            Whether to suppress embeds for the message. This removes
+            all the embeds if set to ``True``. If set to ``False``
+            this brings the embeds back if they were suppressed.
+            Using this parameter requires :attr:`~.Permissions.manage_messages`.
+        allowed_mentions: Optional[:class:`~discord.AllowedMentions`]
+            Controls the mentions being processed in this message. If this is
+            passed, then the object is merged with :attr:`~discord.Client.allowed_mentions`.
+            The merging behaviour only overrides attributes that have been explicitly passed
+            to the object, otherwise it uses the attributes set in :attr:`~discord.Client.allowed_mentions`.
+            If no object is passed at all then the defaults given by :attr:`~discord.Client.allowed_mentions`
+            are used instead.
+        delete_after: Optional[:class:`float`]
+            If set, deletes the paginator after the specified time.
+        Returns
+        --------
+        :class:`discord.Message`
+            The message that was edited.
+        """
+        if not isinstance(message, discord.Message):
+            raise TypeError(f"expected Message not {message.__class__!r}")
+
+        self.update_buttons()
+        self.update_buttons()
+
+        page: Union[Page, str, discord.Embed, List[discord.Embed]] = self.pages[self.current_page]
+        page_content: Page = self.get_page_content(page)
+
+        if page_content.custom_view:
+            self.update_custom_view(page_content.custom_view)
+
+        self.user = message.author
+
+        return await message.edit(
+            content=page_content.content,
+            embeds=page_content.embeds,
+            view=self,
+            suppress=suppress,
+            allowed_mentions=allowed_mentions,
+            delete_after=delete_after,
+        )
+
     async def respond(
         self,
         interaction: discord.Interaction,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -874,8 +874,8 @@ class Paginator(discord.ui.View):
 
         Returns
         --------
-        :class:`discord.Message`
-            The message that was edited.
+        Optional[:class:`discord.Message`]
+            The message that was edited. Returns ``None`` if the operation failed.
         """
         if not isinstance(message, discord.Message):
             raise TypeError(f"expected Message not {message.__class__!r}")

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -848,6 +848,11 @@ class Paginator(discord.ui.View):
     ) -> discord.Message:
         """Edits an existing message to replace it with the paginator contents.
 
+        .. note::
+
+            If invoked from an interaction, you will still need to respond to the interaction.
+
+
         Parameters
         -----------
         message: :class:`discord.Message`
@@ -866,6 +871,7 @@ class Paginator(discord.ui.View):
             are used instead.
         delete_after: Optional[:class:`float`]
             If set, deletes the paginator after the specified time.
+
         Returns
         --------
         :class:`discord.Message`
@@ -884,15 +890,20 @@ class Paginator(discord.ui.View):
             self.update_custom_view(page_content.custom_view)
 
         self.user = message.author
+        self.message = message
+        try:
+            await message.edit(
+                content=page_content.content,
+                embeds=page_content.embeds,
+                view=self,
+                suppress=suppress,
+                allowed_mentions=allowed_mentions,
+                delete_after=delete_after,
+            )
+        except discord.NotFound:
+            pass
 
-        return await message.edit(
-            content=page_content.content,
-            embeds=page_content.embeds,
-            view=self,
-            suppress=suppress,
-            allowed_mentions=allowed_mentions,
-            delete_after=delete_after,
-        )
+        return message
 
     async def respond(
         self,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -899,9 +899,7 @@ class Paginator(discord.ui.View):
                 allowed_mentions=allowed_mentions,
                 delete_after=delete_after,
             )
-        except discord.NotFound:
-            pass
-        except discord.Forbidden:
+        except (discord.NotFound, discord.Forbidden):
             pass
 
         return message

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -845,7 +845,7 @@ class Paginator(discord.ui.View):
         suppress: Optional[bool] = None,
         allowed_mentions: Optional[discord.AllowedMentions] = None,
         delete_after: Optional[float] = None,
-    ) -> discord.Message:
+    ) -> Optional[discord.Message]:
         """Edits an existing message to replace it with the paginator contents.
 
         .. note::
@@ -889,9 +889,8 @@ class Paginator(discord.ui.View):
             self.update_custom_view(page_content.custom_view)
 
         self.user = message.author
-        self.message = message
         try:
-            await message.edit(
+            self.message = await message.edit(
                 content=page_content.content,
                 embeds=page_content.embeds,
                 view=self,
@@ -902,7 +901,7 @@ class Paginator(discord.ui.View):
         except (discord.NotFound, discord.Forbidden):
             pass
 
-        return message
+        return self.message
 
     async def respond(
         self,


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This adds a new `edit` method to the `Paginator` class, allowing users to more easily edit an existing message with the paginator contents.

Properly fixes #1093 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
