### PR TITLE
Convert interaction.data["guild_id"] to int in the KeyError fallback within process_application_commands

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -813,7 +813,8 @@ class ApplicationCommandMixin(ABC):
         except KeyError:
             for cmd in self.application_commands:
                 guild_id = interaction.data.get("guild_id")
-                if guild_id: guild_id = int(guild_id)
+                if guild_id: 
+                    guild_id = int(guild_id)
                 if cmd.name == interaction.data["name"] and (
                     guild_id == cmd.guild_ids
                     or (isinstance(cmd.guild_ids, list) and guild_id in cmd.guild_ids)

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -812,9 +812,11 @@ class ApplicationCommandMixin(ABC):
             command = self._application_commands[interaction.data["id"]]
         except KeyError:
             for cmd in self.application_commands:
+                guild_id = interaction.data.get("guild_id")
+                if guild_id: guild_id = int(guild_id)
                 if cmd.name == interaction.data["name"] and (
-                    interaction.data.get("guild_id") == cmd.guild_ids
-                    or (isinstance(cmd.guild_ids, list) and interaction.data.get("guild_id") in cmd.guild_ids)
+                    guild_id == cmd.guild_ids
+                    or (isinstance(cmd.guild_ids, list) and guild_id in cmd.guild_ids)
                 ):
                     command = cmd
                     break


### PR DESCRIPTION
Fixes the KeyError fallback in process_application_commands to actually function.

## Summary

If an application command can't be found by its interaction ID, there's a fallback that attempts to find it by checking the command name and its guild_ids if they are set. However, the `guild_id` in interaction.data is a string while `SlashCommand.guild_ids` is a list of integers and so this would always fail, further resulting in commands being unregistered.

![image](https://user-images.githubusercontent.com/41271523/163513941-6a9328a1-c47e-440c-adec-abab24e116a6.png)
![image](https://user-images.githubusercontent.com/41271523/163514004-dedbf056-9be3-4718-96b6-a02a672217b7.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
