### PR TITLE
Fixed example not displaying at `Using Cogs`.

### DIFF
--- a/docs/cogs.rst
+++ b/docs/cogs.rst
@@ -67,7 +67,6 @@ Using Cogs
 Just as we remove a cog by its name, we can also retrieve it by its name as well. This allows us to use a cog as an inter-command communication protocol to share data. For example:
 
 .. code-block:: python3
-    :emphasize-lines: 22,24
 
     class Economy(discord.Cog):
         ...

--- a/docs/ext/commands/cogs.rst
+++ b/docs/ext/commands/cogs.rst
@@ -74,7 +74,6 @@ Using Cogs
 Just as we remove a cog by its name, we can also retrieve it by its name as well. This allows us to use a cog as an inter-command communication protocol to share data. For example:
 
 .. code-block:: python3
-    :emphasize-lines: 22,24
 
     class Economy(commands.Cog):
         ...


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixed about example of `Using Cogs` in [cogs.rst](https://github.com/Pycord-Development/pycord/blob/master/docs/cogs.rst#using-cogs) cannot see.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
