### PR TITLE
Fix PartialMessage.edit

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1869,7 +1869,7 @@ class PartialMessage(Hashable):
 
         content = fields.pop("content", MISSING)
         if content is not MISSING:
-            fields["content"] = str(content)
+            fields["content"] = str(content) if content is not None else None
 
         embed = fields.pop("embed", MISSING)
         embeds = fields.pop("embeds", MISSING)


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

Fixes the behavior of `PartialMessage.edit` when the content passed is `None`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
