### PR TITLE
[ext.pages] Hotfix to remove custom_id parameter from being passed to default PaginatorMenu

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -578,7 +578,7 @@ class Paginator(discord.ui.View):
 
     def add_menu(self):
         """Adds the default :class:`PaginatorMenu` instance to the paginator."""
-        self.menu = PaginatorMenu(self.page_groups, placeholder=self.menu_placeholder, custom_id="pages_group_menu")
+        self.menu = PaginatorMenu(self.page_groups, placeholder=self.menu_placeholder)
         self.menu.paginator = self
         self.add_item(self.menu)
 


### PR DESCRIPTION
<!-- Warning: No new features will be merged until the next stable release. -->

## Summary

This removes the `custom_id` parameter being passed to the default `PaginatorMenu` used when `Paginator.add_menu()` is called.

Fixes #1269 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
