### PR TITLE
Context.me returning ClientUser when guilds intent is absent

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -301,10 +301,11 @@ class Context(discord.abc.Messageable, Generic[BotT]):
     @discord.utils.cached_property
     def me(self) -> Union[Member, ClientUser]:
         """Union[:class:`.Member`, :class:`.ClientUser`]:
-        Similar to :attr:`.Guild.me` except it may return the :class:`.ClientUser` in private message contexts.
+        Similar to :attr:`.Guild.me` except it may return the :class:`.ClientUser` in private message
+        message contexts, or when :meth:`Intents.guilds` is absent.
         """
         # bot.user will never be None at this point.
-        return self.guild.me if self.guild is not None else self.bot.user  # type: ignore
+        return self.guild.me if self.guild is not None and self.guild.me is not None else self.bot.user  # type: ignore
 
     @property
     def voice_client(self) -> Optional[VoiceProtocol]:


### PR DESCRIPTION
## Summary

In discord.ext.commands.Context, when the guilds intent is absent, self.guild will but self.guild.me will be None. Adding that to the cases where self.me() falls back on returning self.bot user instead.

I don't know of any open issues relevant to this change; the simple test was invoking the default help command with and without the guilds intent.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
