### PR TITLE
[ext.pages] Compatibility patch for ext.bridge

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -736,6 +736,8 @@ class Paginator(discord.ui.View):
                 return Page(content=None, embeds=page)
             else:
                 raise TypeError("All list items must be embeds.")
+        else:
+            raise TypeError("Page content must be a Page object, string, an embed, or a list of embeds.")
 
     async def page_action(self, interaction: Optional[discord.Interaction] = None) -> None:
         """Triggers the callback associated with the current page, if any.


### PR DESCRIPTION
## Summary

This adds compatibility for `ext.pages` when used with `ext.bridge` by allowing a `BridgeContext` object to be passed instead of an `Interaction` in `Paginator.respond().` 
If a `BridgeContext` object is passed, `Paginator.respond()` uses the `ext.bridge` methods to send the paginated message instead of the `Interaction` methods.

Due to `BridgeContext.respond()` not recognizing the `ephemeral` keyword, paginators passing a `BridgeContext` object cannot be ephemeral and that parameter will be ignored.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
