### PR TITLE
None check for check_guilds

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -616,7 +616,7 @@ class ApplicationCommandMixin(ABC):
             Whether to delete existing commands that are not in the list of commands to register. Defaults to True.
         """
 
-        check_guilds = list(set(check_guilds + (self.debug_guilds or [])))
+        check_guilds = list(set((check_guilds or []) + (self.debug_guilds or [])))
 
         if commands is None:
             commands = self.pending_application_commands


### PR DESCRIPTION
## Summary

check_guilds has been marked as optional, but no None check was being done causing `TypeError: unsupported operand type(s) for +: 'bool' and 'list'` when passing None to check_guilds

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
