### PR TITLE
Enum options

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -680,7 +680,7 @@ class SlashCommand(ApplicationCommand):
                 if self._is_typing_optional(option):
                     option = Option(option.__args__[0], None, required=False)
                 else:
-                    option = Option(option.__args__, None)
+                    option = Option(option.__args__)
 
             if not isinstance(option, Option):
                 option = Option(option, None)

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -669,12 +669,12 @@ class SlashCommand(ApplicationCommand):
 
             if self._is_typing_union(option):
                 if self._is_typing_optional(option):
-                    option = Option(option.__args__[0], "No description provided", required=False)
+                    option = Option(option.__args__[0], None, required=False)
                 else:
-                    option = Option(option.__args__, "No description provided")
+                    option = Option(option.__args__, None)
 
             if not isinstance(option, Option):
-                option = Option(option, "No description provided")
+                option = Option(option, None)
 
             if option.default is None:
                 if p_obj.default == inspect.Parameter.empty:

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -32,6 +32,7 @@ import inspect
 import re
 import types
 from collections import OrderedDict
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -815,6 +816,15 @@ class SlashCommand(ApplicationCommand):
 
             elif op.input_type == SlashCommandOptionType.string and (converter := op.converter) is not None:
                 arg = await converter.convert(converter, ctx, arg)
+
+            elif issubclass(op._raw_type, Enum):
+                if isinstance(arg, str) and arg.isdigit():
+                    try:
+                        arg = op._raw_type(int(arg))
+                    except ValueError:
+                        arg = op._raw_type(arg)
+                else:
+                    arg = op._raw_type(arg)
 
             kwargs[op._parameter_name] = arg
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -678,7 +678,7 @@ class SlashCommand(ApplicationCommand):
 
             if self._is_typing_union(option):
                 if self._is_typing_optional(option):
-                    option = Option(option.__args__[0], None, required=False)
+                    option = Option(option.__args__[0], required=False)
                 else:
                     option = Option(option.__args__)
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -683,7 +683,7 @@ class SlashCommand(ApplicationCommand):
                     option = Option(option.__args__)
 
             if not isinstance(option, Option):
-                option = Option(option, None)
+                option = Option(option)
 
             if option.default is None:
                 if p_obj.default == inspect.Parameter.empty:

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -22,7 +22,9 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+import inspect
 from typing import Any, Dict, List, Literal, Optional, Union
+from enum import Enum
 
 from ..enums import ChannelType, SlashCommandOptionType
 
@@ -119,14 +121,21 @@ class Option:
         self.name: Optional[str] = kwargs.pop("name", None)
         if self.name is not None:
             self.name = str(self.name)
-        self.description = description or "No description provided"
         self.converter = None
         self._raw_type = input_type
         self.channel_types: List[ChannelType] = kwargs.pop("channel_types", [])
+        enum_choices = []
         if not isinstance(input_type, SlashCommandOptionType):
             if hasattr(input_type, "convert"):
                 self.converter = input_type
                 input_type = SlashCommandOptionType.string
+            elif issubclass(input_type, Enum):
+                enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
+                if len(enum_choices) != len([elem for elem in enum_choices if elem.value.__class__ == enum_choices[0].value.__class__]):
+                    enum_choices = [OptionChoice(e.name, str(e.value)) for e in input_type]
+                    input_type = SlashCommandOptionType.string
+                else:
+                    input_type = SlashCommandOptionType.from_datatype(enum_choices[0].value.__class__)
             else:
                 try:
                     _type = SlashCommandOptionType.from_datatype(input_type)
@@ -154,9 +163,16 @@ class Option:
         self.input_type = input_type
         self.required: bool = kwargs.pop("required", True) if "default" not in kwargs else False
         self.default = kwargs.pop("default", None)
-        self.choices: List[OptionChoice] = [
+        self.choices: List[OptionChoice] = enum_choices or [
             o if isinstance(o, OptionChoice) else OptionChoice(o) for o in kwargs.pop("choices", list())
         ]
+
+        if description is not None:
+            self.description = description
+        elif issubclass(self._raw_type, Enum) and (doc := inspect.getdoc(self._raw_type)) is not None:
+            self.description = doc
+        else:
+            self.description = "No description provided"
 
         if self.input_type == SlashCommandOptionType.integer:
             minmax_types = (int, type(None))

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -26,7 +26,7 @@ import inspect
 from typing import Any, Dict, List, Literal, Optional, Union
 from enum import Enum
 
-from ..enums import ChannelType, SlashCommandOptionType
+from ..enums import ChannelType, SlashCommandOptionType, Enum as DiscordEnum
 
 __all__ = (
     "ThreadOption",
@@ -129,7 +129,7 @@ class Option:
             if hasattr(input_type, "convert"):
                 self.converter = input_type
                 input_type = SlashCommandOptionType.string
-            elif issubclass(input_type, Enum):
+            elif issubclass(input_type, (Enum, DiscordEnum)):
                 enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
                 if len(enum_choices) != len([elem for elem in enum_choices if elem.value.__class__ == enum_choices[0].value.__class__]):
                     enum_choices = [OptionChoice(e.name, str(e.value)) for e in input_type]


### PR DESCRIPTION
## Summary
Add support for Enums to be used for options as an alternative to listing options choices.

example:
```py
class Perms(enums.Enum):
    """Choose permission"""
    admin = 0
    mod = 1
    member = 2

@bot.slash_command()
async def perms(ctx, option: Perms):
    await ctx.respond(option)  # gives an enum object
```

before:
```py
@bot.slash_command()
async def perms(ctx, option: discord.Option(int, description="Choose permission", choices=[discord.OptionChoice("admin", 0), ...])):
    await ctx.respond(option)  # gives an interger
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
