### PR TITLE
Add more forum channel/thread features

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -97,6 +97,7 @@ if TYPE_CHECKING:
     from .types.channel import PermissionOverwrite as PermissionOverwritePayload
     from .ui.view import View
     from .user import ClientUser
+    from .flags import ChannelFlags
 
     PartialMessageableChannel = Union[TextChannel, VoiceChannel, Thread, DMChannel, PartialMessageable]
     MessageableChannel = Union[PartialMessageableChannel, GroupChannel]
@@ -328,6 +329,7 @@ class GuildChannel:
     type: ChannelType
     position: int
     category_id: Optional[int]
+    flags: ChannelFlags
     _state: ConnectionState
     _overwrites: List[_Overwrites]
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1198,3 +1198,39 @@ class ApplicationFlags(BaseFlags):
         and has hit the guild limit.
         """
         return 1 << 19
+
+
+@fill_with_flags()
+class ChannelFlags(BaseFlags):
+    r"""Wraps up the Discord Channel flags.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two ChannelFlags are equal.
+        .. describe:: x != y
+
+            Checks if two ChannelFlags are not equal.
+        .. describe:: hash(x)
+
+            Return the flag's hash.
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+    .. versionadded:: 2.0
+
+    Attributes
+    -----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def pinned(self):
+        """:class:`bool`: Returns ``True`` if the thread is pinned to the top of its parent forum channel."""
+        return 1 << 1

--- a/discord/http.py
+++ b/discord/http.py
@@ -1091,9 +1091,9 @@ class HTTPClient:
             *,
             name: str,
             auto_archive_duration: threads.ThreadArchiveDuration,
+            rate_limit_per_user: int,
             invitable: bool = True,
             reason: Optional[str] = None,
-            tts: bool = False,
             embed: Optional[embed.Embed] = None,
             embeds: Optional[List[embed.Embed]] = None,
             nonce: Optional[str] = None,
@@ -1108,9 +1108,6 @@ class HTTPClient:
         }
         if content:
             payload["content"] = content
-
-        if tts:
-            payload["tts"] = True
 
         if embed:
             payload["embeds"] = [embed]
@@ -1129,6 +1126,9 @@ class HTTPClient:
 
         if stickers:
             payload["sticker_ids"] = stickers
+
+        if rate_limit_per_user:
+            payload["rate_limit_per_user"] = rate_limit_per_user
         # TODO: Once supported by API, remove has_message=true query parameter
         route = Route("POST", "/channels/{channel_id}/threads?has_message=true", channel_id=channel_id)
         return self.request(route, json=payload, reason=reason)


### PR DESCRIPTION
## Summary

Targeted towards the `forum-channels` branch (#1249)

- Implements ChannelFlags
- Updated forum channel's create_post
  - Also renamed to create_thread for consistency
- Implemented thread pinning
- Added support for slowmode when creating forum thread
- Removed TTS support when creating forum thread
  - Unsure if it is supported or not, but it isn't documented

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested. *(I have nowhere to test these changes)*
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
