### PR TITLE
Update `Message.edit` type hinting overload and remove resulting redundant overloads

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1198,37 +1198,9 @@ class Message(Hashable):
         *,
         content: Optional[str] = ...,
         embed: Optional[Embed] = ...,
-        file: Optional[File] = ...,
-        attachments: List[Attachment] = ...,
-        suppress: bool = ...,
-        delete_after: Optional[float] = ...,
-        allowed_mentions: Optional[AllowedMentions] = ...,
-        view: Optional[View] = ...,
-    ) -> Message:
-        ...
-
-    @overload
-    async def edit(
-        self,
-        *,
-        content: Optional[str] = ...,
-        embed: Optional[Embed] = ...,
-        files: Optional[List[File]] = ...,
-        attachments: List[Attachment] = ...,
-        suppress: bool = ...,
-        delete_after: Optional[float] = ...,
-        allowed_mentions: Optional[AllowedMentions] = ...,
-        view: Optional[View] = ...,
-    ) -> Message:
-        ...
-
-    @overload
-    async def edit(
-        self,
-        *,
-        content: Optional[str] = ...,
         embeds: List[Embed] = ...,
-        file: File = ...,
+        file: Optional[File] = ...,
+        files: Optional[List[File]] = ...,
         attachments: List[Attachment] = ...,
         suppress: bool = ...,
         delete_after: Optional[float] = ...,


### PR DESCRIPTION
## Summary

This updates the `Message.edit` overload to use the full method signature. As a result, the other two overloads for the method are made redundant and were removed.

Without this change, the following typing error occurs:

![image](https://user-images.githubusercontent.com/935885/165619944-3eafd08d-a1bc-4149-bbb7-5479c1f5e157.png)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
