### PR TITLE
Hotfix to add debug warning to catch deprecated perms v1 usage until v2 perms are implemented

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -60,7 +60,7 @@ from .commands import (
     command,
 )
 from .enums import InteractionType
-from .errors import CheckFailure, DiscordException, Forbidden
+from .errors import CheckFailure, DiscordException, Forbidden, HTTPException
 from .interactions import Interaction
 from .shard import AutoShardedClient
 from .types import interactions
@@ -647,7 +647,7 @@ class ApplicationCommandMixin(ABC):
 
         # TODO: 2.1: Remove this and favor permissions v2
         # Global Command Permissions
-        
+
         if not _register_permissions:
             return
 
@@ -778,6 +778,10 @@ class ApplicationCommandMixin(ABC):
                     f"Failed to add command permissions to guild {guild_id}",
                     file=sys.stderr,
                 )
+            except HTTPException:
+                _log.warning(
+                    "Command Permissions V2 not yet implemented, permissions will not be set for your commands."
+                )
 
     async def process_application_commands(self, interaction: Interaction, auto_sync: bool = None) -> None:
         """|coro|
@@ -818,11 +822,10 @@ class ApplicationCommandMixin(ABC):
         except KeyError:
             for cmd in self.application_commands:
                 guild_id = interaction.data.get("guild_id")
-                if guild_id: 
+                if guild_id:
                     guild_id = int(guild_id)
                 if cmd.name == interaction.data["name"] and (
-                    guild_id == cmd.guild_ids
-                    or (isinstance(cmd.guild_ids, list) and guild_id in cmd.guild_ids)
+                    guild_id == cmd.guild_ids or (isinstance(cmd.guild_ids, list) and guild_id in cmd.guild_ids)
                 ):
                     command = cmd
                     break


### PR DESCRIPTION
## Summary

This adds logic to catch the HTTPException that occurs when the library tries to submit v1 permissions to the now-deprecated `/applications/{application.id}/guilds/{guild.id}/commands/permissions` endpoint.

The only change made is to throw a warning in the debug log instead of an unhandled exception. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
