### PR TITLE
[Perms v2] Additional implementations

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -424,6 +424,8 @@ class AuditLogEntry(Hashable):
         self.reason = data.get("reason")
         self.extra = data.get("options")
 
+        # TODO: there's some new fields with perms V2
+
         if isinstance(self.action, enums.AuditLogAction) and self.extra:
             if self.action is enums.AuditLogAction.member_prune:
                 # member prune has two keys with useful information

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -238,6 +238,7 @@ class AuditLogChanges:
             "location_type",
             _enum_transformer(enums.ScheduledEventLocationType),
         ),
+        "command_id": ("command_id", _transform_snowflake),
     }
 
     def __init__(
@@ -423,8 +424,6 @@ class AuditLogEntry(Hashable):
         # this key is technically not usually present
         self.reason = data.get("reason")
         self.extra = data.get("options")
-
-        # TODO: there's some new fields with perms V2
 
         if isinstance(self.action, enums.AuditLogAction) and self.extra:
             if self.action is enums.AuditLogAction.member_prune:

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -573,7 +573,6 @@ class ApplicationCommandMixin(ABC):
         register_guild_commands: bool = True,
         check_guilds: Optional[List[int]] = [],
         delete_exiting: bool = True,
-        _register_permissions: bool = True,  # TODO: Remove for perms v2
     ) -> None:
         """|coro|
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -659,12 +659,7 @@ class ApplicationCommandMixin(ABC):
                 cmd.id = i["id"]
                 self._application_commands[cmd.id] = cmd
 
-                # Permissions (Roles will be converted to IDs just before Upsert for Global Commands)
-                global_permissions.append({"id": i["id"], "permissions": cmd.permissions})
-
         for guild_id, commands in registered_guild_commands.items():
-            guild_permissions: List = []
-
             for i in commands:
                 cmd = find(
                     lambda cmd: cmd.name == i["name"]
@@ -678,105 +673,6 @@ class ApplicationCommandMixin(ABC):
                     continue
                 cmd.id = i["id"]
                 self._application_commands[cmd.id] = cmd
-
-                # Permissions
-                permissions = [
-                    perm.to_dict()
-                    for perm in cmd.permissions
-                    if perm.guild_id is None
-                    or (perm.guild_id == guild_id and cmd.guild_ids is not None and perm.guild_id in cmd.guild_ids)
-                ]
-                guild_permissions.append({"id": i["id"], "permissions": permissions})
-
-            for global_command in global_permissions:
-                permissions = [
-                    perm.to_dict()
-                    for perm in global_command["permissions"]
-                    if perm.guild_id is None
-                    or (perm.guild_id == guild_id and cmd.guild_ids is not None and perm.guild_id in cmd.guild_ids)
-                ]
-                guild_permissions.append({"id": global_command["id"], "permissions": permissions})
-
-            # Collect & Upsert Permissions for Each Guild
-            # Command Permissions for this Guild
-            guild_cmd_perms: List = []
-
-            # Loop through Commands Permissions available for this Guild
-            for item in guild_permissions:
-                new_cmd_perm = {"id": item["id"], "permissions": []}
-
-                # Replace Role / Owner Names with IDs
-                for permission in item["permissions"]:
-                    if isinstance(permission["id"], str):
-                        # Replace Role Names
-                        if permission["type"] == 1:
-                            role = get(
-                                self._bot.get_guild(guild_id).roles,
-                                name=permission["id"],
-                            )
-
-                            # If not missing
-                            if role is not None:
-                                new_cmd_perm["permissions"].append(
-                                    {
-                                        "id": role.id,
-                                        "type": 1,
-                                        "permission": permission["permission"],
-                                    }
-                                )
-                            else:
-                                raise RuntimeError(
-                                    "No Role ID found in Guild ({guild_id}) for Role ({role})".format(
-                                        guild_id=guild_id, role=permission["id"]
-                                    )
-                                )
-                        # Add owner IDs
-                        elif permission["type"] == 2 and permission["id"] == "owner":
-                            app = await self.application_info()  # type: ignore
-                            if app.team:
-                                for m in app.team.members:
-                                    new_cmd_perm["permissions"].append(
-                                        {
-                                            "id": m.id,
-                                            "type": 2,
-                                            "permission": permission["permission"],
-                                        }
-                                    )
-                            else:
-                                new_cmd_perm["permissions"].append(
-                                    {
-                                        "id": app.owner.id,
-                                        "type": 2,
-                                        "permission": permission["permission"],
-                                    }
-                                )
-                    # Add the rest
-                    else:
-                        new_cmd_perm["permissions"].append(permission)
-
-                # Make sure we don't have over 10 overwrites
-                if len(new_cmd_perm["permissions"]) > 10:
-                    raise RuntimeError(
-                        "Command '{name}' has more than 10 permission overrides in guild ({guild_id}).".format(
-                            name=self._application_commands[new_cmd_perm["id"]].name,
-                            guild_id=guild_id,
-                        )
-                    )
-                # Append to guild_cmd_perms
-                guild_cmd_perms.append(new_cmd_perm)
-
-            # Upsert
-            try:
-                await self._bot.http.bulk_upsert_command_permissions(self._bot.user.id, guild_id, guild_cmd_perms)
-            except Forbidden:
-                raise RuntimeError(
-                    f"Failed to add command permissions to guild {guild_id}",
-                    file=sys.stderr,
-                )
-            except HTTPException:
-                _log.warning(
-                    "Command Permissions V2 not yet implemented, permissions will not be set for your commands."
-                )
 
     async def process_application_commands(self, interaction: Interaction, auto_sync: bool = None) -> None:
         """|coro|

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -380,6 +380,7 @@ class AuditLogAction(Enum):
     thread_create = 110
     thread_update = 111
     thread_delete = 112
+    application_command_permission_update = 121
 
     @property
     def category(self) -> Optional[AuditLogActionCategory]:
@@ -431,6 +432,7 @@ class AuditLogAction(Enum):
             AuditLogAction.thread_create: AuditLogActionCategory.create,
             AuditLogAction.thread_update: AuditLogActionCategory.update,
             AuditLogAction.thread_delete: AuditLogActionCategory.delete,
+            AuditLogAction.application_command_permission_update: AuditLogActionCategory.update,
         }
         return lookup[self]
 
@@ -467,6 +469,8 @@ class AuditLogAction(Enum):
             return "scheduled_event"
         elif v < 113:
             return "thread"
+        elif v < 121:
+            return "application_command_permission"
 
 
 class UserFlags(Enum):

--- a/discord/http.py
+++ b/discord/http.py
@@ -2246,7 +2246,7 @@ class HTTPClient:
         application_id: Snowflake,
         guild_id: Snowflake,
         command_id: Snowflake,
-    ) -> Response:  # TODO: Typing
+    ) -> Response[interactions.GuildApplicationCommandPermissions]:
         r = Route(
             "GET",
             "/applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions",
@@ -2259,7 +2259,7 @@ class HTTPClient:
         self,
         application_id: Snowflake,
         guild_id: Snowflake,
-    ) -> Response:  # TODO: Typing
+    ) -> Response[List[interactions.GuildApplicationCommandPermissions]]:
         r = Route(
             "GET",
             "/applications/{application_id}/guilds/{guild_id}/commands/permissions",

--- a/discord/http.py
+++ b/discord/http.py
@@ -2239,20 +2239,35 @@ class HTTPClient:
         )
         return self.request(r, json=payload)
 
-    def bulk_upsert_command_permissions(
+    # Application commands (permissions)
+    
+    def get_command_permissions(
         self,
         application_id: Snowflake,
         guild_id: Snowflake,
-        payload: List[interactions.EditApplicationCommand],
-    ) -> Response[List[interactions.ApplicationCommand]]:
+        command_id: Snowflake,
+    ) -> Response:  # TODO: Typing
         r = Route(
-            "PUT",
+            "GET",
+            "/applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions",
+            application_id=application_id,
+            guild_id=guild_id,
+        )
+        return self.request(r)
+    
+    def get_guild_command_permissions(
+        self,
+        application_id: Snowflake,
+        guild_id: Snowflake,
+    ) -> Response:  # TODO: Typing
+        r = Route(
+            "GET",
             "/applications/{application_id}/guilds/{guild_id}/commands/permissions",
             application_id=application_id,
             guild_id=guild_id,
         )
-        return self.request(r, json=payload)
-
+        return self.request(r)
+    
     # Interaction responses
 
     def _edit_webhook_helper(

--- a/discord/state.py
+++ b/discord/state.py
@@ -613,6 +613,10 @@ class ConnectionState:
     def parse_resumed(self, data) -> None:
         self.dispatch("resumed")
 
+    def parse_application_command_permissions_update(self, data) -> None:
+        # unsure what the implementation would be like
+        pass
+
     def parse_message_create(self, data) -> None:
         channel, _ = self._get_guild_channel(data)
         # channel would be the correct type here

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -85,7 +85,7 @@ class ApplicationCommandOptionChoice(_ApplicationCommandOptionChoiceOptional):
     value: Union[str, int]
 
 
-ApplicationCommandPermissionType = Literal[1, 2]
+ApplicationCommandPermissionType = Literal[1, 2, 3]
 
 
 class ApplicationCommandPermissions(TypedDict):


### PR DESCRIPTION
## Summary

Targets the permissions-v2 branch

- Implements the audit log event
- Removes permission v1 code
- New audit log change fields
- Implements HTTP endpoints & removes permissions v1 endpoint

Things that still need to be done:
- [ ] Some sort of caching for command permissions (may be problematic to implement into discord.Client)
- [ ] Implement the `APPLICATION_COMMAND_PERMISSIONS_UPDATE` gateway event (same issue as above)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
