### PR TITLE
Update validation regex for command names & options

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1625,9 +1625,9 @@ def validate_chat_input_name(name: Any, locale: Optional[str] = None):
     error = None
     if not isinstance(name, str):
         error = TypeError(f"Command names and options must be of type str. Received \"{name}\"")
-    elif not re.match(r"^[\w-]{1,32}$", name):
+    elif not re.match(r"^[-_\w\d\u0901-\u097D\u0E00-\u0E7F]{1,32}$", name):
         error = ValidationError(
-            r"Command names and options must follow the regex \"^[\w-]{1,32}$\". For more information, see "
+            r"Command names and options must follow the regex \"^[-_\w\d\u0901-\u097D\u0E00-\u0E7F]{1,32}$\". For more information, see "
             f"{docs}/interactions/application-commands#application-command-object-application-command-naming. "
             f"Received \"{name}\""
         )


### PR DESCRIPTION
## :sparkles: Summary

Update validation regex for command names & options, to now support localized command names & options.
This is an adaptation of Discord's suggested Perl-like regex `^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` as Python's re module does not support unicode character properties

## :memo: Checklist

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
