### PR TITLE
Change `Modal.children` to be a property, allow instantiating with list of InputText components

### DIFF
--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -29,24 +29,24 @@ class Modal:
 
     Parameters
     ----------
+    children: :class:`InputText`
+        The initial InputText fields that are displayed in the modal dialog.
     title: :class:`str`
         The title of the modal dialog.
         Must be 45 characters or fewer.
     custom_id: Optional[:class:`str`]
         The ID of the modal dialog that gets received during an interaction.
         Must be 100 characters or fewer.
-    children: Optional[List[:class:`InputText`]]
-        The list of InputText fields that are displayed in the modal dialog.
     """
 
-    def __init__(self, title: str, custom_id: Optional[str] = None, children: Optional[List[InputText]] = None) -> None:
+    def __init__(self, *children: InputText, title: str, custom_id: Optional[str] = None) -> None:
         if not isinstance(custom_id, str) and custom_id is not None:
             raise TypeError(f"expected custom_id to be str, not {custom_id.__class__.__name__}")
         self._custom_id: Optional[str] = custom_id or os.urandom(16).hex()
-        if len(str(title)) > 45:
+        if len(title) > 45:
             raise ValueError("title must be 45 characters or fewer")
         self._title = title
-        self._children: List[InputText] = children or []
+        self._children: List[InputText] = list(children)
         self._weights = _ModalWeights(self._children)
         loop = asyncio.get_running_loop()
         self._stopped: asyncio.Future[bool] = loop.create_future()

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -44,8 +44,8 @@ class Modal:
         if len(title) > 45:
             raise ValueError("title must be 45 characters or fewer")
         self._title = title
-        self.children: List[InputText] = []
-        self._weights = _ModalWeights(self.children)
+        self._children: List[InputText] = []
+        self._weights = _ModalWeights(self._children)
         loop = asyncio.get_running_loop()
         self._stopped: asyncio.Future[bool] = loop.create_future()
 
@@ -61,6 +61,11 @@ class Modal:
         if not isinstance(value, str):
             raise TypeError(f"expected title to be str, not {value.__class__.__name__}")
         self._title = value
+
+    @property
+    def children(self) -> List[InputText]:
+        """The child components associated with the modal dialog."""
+        return self._children
 
     @property
     def custom_id(self) -> str:
@@ -92,7 +97,7 @@ class Modal:
         def key(item: InputText) -> int:
             return item._rendered_row or 0
 
-        children = sorted(self.children, key=key)
+        children = sorted(self._children, key=key)
         components: List[Dict[str, Any]] = []
         for _, group in groupby(children, key=key):
             children = [item.to_component_dict() for item in group]
@@ -117,14 +122,14 @@ class Modal:
             The item to add to the modal dialog
         """
 
-        if len(self.children) > 5:
+        if len(self._children) > 5:
             raise ValueError("You can only have up to 5 items in a modal dialog.")
 
         if not isinstance(item, InputText):
             raise TypeError(f"expected InputText not {item.__class__!r}")
 
         self._weights.add_item(item)
-        self.children.append(item)
+        self._children.append(item)
 
     def remove_item(self, item: InputText):
         """Removes an InputText component from the modal dialog.
@@ -135,7 +140,7 @@ class Modal:
             The item to remove from the modal dialog.
         """
         try:
-            self.children.remove(item)
+            self._children.remove(item)
         except ValueError:
             pass
 


### PR DESCRIPTION
## Summary

This changes `Modal.children` to be a property instead of an attribute. This also adds a `children` parameter to `Modal.__init__` to allow instantiating the Modal with list of InputText objects instead of requiring developers to use `Modal.add_item`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
