### PR TITLE
Add is_nsfw to voice channels

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -923,7 +923,11 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         .. versionadded:: 2.0
     """
 
-    __slots__ = ()
+    __slots__ = ('nsfw')
+
+    def _update(self, guild: Guild, data: Union[VoiceChannelPayload, StageChannelPayload]):
+        super()._update(guild, data)
+        self.nsfw: bool = data.get("nsfw", False)
 
     def __repr__(self) -> str:
         attrs = [
@@ -941,6 +945,10 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
 
     async def _get_channel(self):
         return self
+
+    def is_nsfw(self) -> bool:
+        """:class:`bool`: Checks if the channel is NSFW."""
+        return self.nsfw
 
     @property
     def last_message(self) -> Optional[Message]:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -925,7 +925,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
 
     __slots__ = ('nsfw')
 
-    def _update(self, guild: Guild, data: Union[VoiceChannelPayload, StageChannelPayload]):
+    def _update(self, guild: Guild, data: VoiceChannelPayload):
         super()._update(guild, data)
         self.nsfw: bool = data.get("nsfw", False)
 


### PR DESCRIPTION
## Summary
Now that you can send messages in voice channels, you can also set it to be age-restricted.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
