### PR TITLE
Update guild.py fetch_members() type hints

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1731,7 +1731,7 @@ class Guild(Hashable):
         return threads
 
     # TODO: Remove Optional typing here when async iterators are refactored
-    def fetch_members(self, *, limit: int = 1000, after: Optional[SnowflakeTime] = None) -> MemberIterator:
+    def fetch_members(self, *, limit: Union[int, None] = 1000, after: Optional[SnowflakeTime] = None) -> MemberIterator:
         """Retrieves an :class:`.AsyncIterator` that enables receiving the guild's members. In order to use this,
         :meth:`Intents.members` must be enabled.
 


### PR DESCRIPTION
Actually type hint for None OR int using Union[int, None]

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix type hinting for fetch_members so IDEs don't complain that it expects just an int
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
