### PR TITLE
Make description an optional arg in a PageGroup

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -264,7 +264,7 @@ class PageGroup:
         self,
         pages: Union[List[str], List[Page], List[Union[List[discord.Embed], discord.Embed]]],
         label: str,
-        description: str,
+        description: Optional[str] = None,
         emoji: Union[str, discord.Emoji, discord.PartialEmoji] = None,
         show_disabled: Optional[bool] = None,
         show_indicator: Optional[bool] = None,


### PR DESCRIPTION
## Summary
The description is used for a SelectOption when the PageGroup is added to the Paginator. As such it should be optional to be similar to a SelectOption, where a description isn't compulsory for an option.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
