### PR TITLE
Add another installation way

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,15 @@ To install the development version, do the following:
     $ git clone https://github.com/Pycord-Development/pycord
     $ cd pycord
     $ python3 -m pip install -U .[voice]
+    
+or if you do not want to clone the repository:
+
+.. code:: sh
+
+    # Linux/macOS
+    python3 -m pip install git+https://github.com/Pycord-Development/pycord
+    # Windows
+    py -3 -m pip install git+https://github.com/Pycord-Development/pycord
 
 
 Optional Packages


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request adds another way to install the development version of Pycord. If the user does not want to clone the repository they can just use this way to install the development version.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
