### PR TITLE
Fix parsing for string, integer, number, and boolean option types

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -825,6 +825,12 @@ class SlashCommand(ApplicationCommand):
             elif op.input_type == SlashCommandOptionType.string and (converter := op.converter) is not None:
                 arg = await converter.convert(converter, ctx, arg)
 
+            elif op._raw_type in (SlashCommandOptionType.integer,
+                                  SlashCommandOptionType.number,
+                                  SlashCommandOptionType.string,
+                                  SlashCommandOptionType.boolean):
+                pass
+
             elif issubclass(op._raw_type, Enum):
                 if isinstance(arg, str) and arg.isdigit():
                     try:


### PR DESCRIPTION
## Summary

Supporting enums recently broke the mentioned option types with the following error:
```py
[ERROR: 16:32:21] Traceback (most recent call last):
[ERROR: 16:32:21]   File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\commands\core.py", line 126, in wrapped
[ERROR: 16:32:21]     ret = await coro(arg)
[ERROR: 16:32:21]   File "C:\Users\cplun\Documents\GitHub\SkyKings Public Bot\venv\lib\site-packages\discord\commands\core.py", line 828, in _invoke
[ERROR: 16:32:21]     elif issubclass(op._raw_type, Enum):
[ERROR: 16:32:21] TypeError: issubclass() arg 1 must be a class
```

This PR adds a block that simply prevents SlashCommandOptionTypes from reaching the block that parses enums.

I'm unsure if this is the correct fix, but it seems to work.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
