### PR TITLE
Fixed format_dt using wrong format

### DIFF
--- a/examples/app_commands/info.py
+++ b/examples/app_commands/info.py
@@ -24,12 +24,12 @@ async def info(ctx, user: discord.Member = None):
     e.add_field(name="ID", value=user.id, inline=False)  # user ID
     e.add_field(
         name="Joined",
-        value=discord.utils.format_dt(round(user.joined_at.timestamp()), "F"),
+        value=discord.utils.format_dt(user.joined_at, "F"),
         inline=False,
     )  # When the user joined the server
     e.add_field(
         name="Created",
-        value=discord.utils.format_dt(round(user.created_at.timestamp()), "F"),
+        value=discord.utils.format_dt(user.created_at, "F"),
         inline=False,
     )  # When the user's account was created
     colour = user.colour


### PR DESCRIPTION
## Summary

The example for an Info commands use an outdated format for format_dt

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
