### PR TITLE
Add `BridgeExtContext.delete()` method

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -256,13 +256,29 @@ class ApplicationContext(discord.abc.Messageable):
     def followup(self) -> Webhook:
         return self.interaction.followup
 
-    async def delete(self):
-        """Calls :attr:`~discord.commands.ApplicationContext.respond`.
-        If the response is done, then calls :attr:`~discord.commands.ApplicationContext.respond` first."""
+    async def delete(self, *, delay: Optional[float] = None) -> None:
+        """|coro|
+
+        Deletes the original interaction response message.
+
+        This is a higher level interface to :meth:`Interaction.delete_original_message`.
+
+        Parameters
+        -----------
+        delay: Optional[:class:`float`]
+            If provided, the number of seconds to wait before deleting the message.
+
+        Raises
+        -------
+        HTTPException
+            Deleting the message failed.
+        Forbidden
+            Deleted a message that is not yours.
+        """
         if not self.interaction.response.is_done():
             await self.defer()
 
-        return await self.interaction.delete_original_message()
+        return await self.interaction.delete_original_message(delay=delay)
 
     @property
     def edit(self) -> Callable[..., Awaitable[InteractionMessage]]:

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -273,7 +273,7 @@ class ApplicationContext(discord.abc.Messageable):
         HTTPException
             Deleting the message failed.
         Forbidden
-            Deleted a message that is not yours.
+            You do not have proper permissions to delete the message.
         """
         if not self.interaction.response.is_done():
             await self.defer()

--- a/discord/ext/bridge/context.py
+++ b/discord/ext/bridge/context.py
@@ -141,13 +141,9 @@ class BridgeExtContext(BridgeContext, Context):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._original_response_message: Optional[Message] = None
 
     async def _respond(self, *args, **kwargs) -> Message:
-        message = await self._get_super("reply")(*args, **kwargs)
-        if self._original_response_message == None:
-            self._original_response_message = message
-        return message
+        return await self._get_super("reply")(*args, **kwargs)
 
     async def _defer(self, *args, **kwargs) -> None:
         return await self._get_super("trigger_typing")(*args, **kwargs)

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -149,7 +149,6 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         self.subcommand_passed: Optional[str] = subcommand_passed
         self.command_failed: bool = command_failed
         self.current_parameter: Optional[inspect.Parameter] = current_parameter
-        self._original_response_message: Optional[Message] = None
         self._state: ConnectionState = self.message._state
 
     async def invoke(self, command: Command[CogT, P, T], /, *args: P.args, **kwargs: P.kwargs) -> T:
@@ -397,22 +396,4 @@ class Context(discord.abc.Messageable, Generic[BotT]):
 
     @discord.utils.copy_doc(Message.reply)
     async def reply(self, content: Optional[str] = None, **kwargs: Any) -> Message:
-        msg = await self.message.reply(content, **kwargs)
-        if self._original_response_message is None:
-            self._original_response_message = msg
-        return msg
-
-    async def delete(self, *, delay: Optional[float] = None, reason: Optional[str] = None) -> None:
-        """|coro|
-
-        Deletes the original response message, if it exists.
-
-        Parameters
-        -----------
-        delay: Optional[:class:`float`]
-            If provided, the number of seconds to wait before deleting the message.
-        reason: Optional[:class:`str`]
-            The reason for deleting the message. Shows up on the audit log.
-        """
-        if self._original_response_message:
-            await self._original_response_message.delete(delay=delay, reason=reason)
+        return await self.message.reply(content, **kwargs)

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -149,6 +149,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         self.subcommand_passed: Optional[str] = subcommand_passed
         self.command_failed: bool = command_failed
         self.current_parameter: Optional[inspect.Parameter] = current_parameter
+        self._original_response_message: Optional[Message] = None
         self._state: ConnectionState = self.message._state
 
     async def invoke(self, command: Command[CogT, P, T], /, *args: P.args, **kwargs: P.kwargs) -> T:
@@ -396,4 +397,22 @@ class Context(discord.abc.Messageable, Generic[BotT]):
 
     @discord.utils.copy_doc(Message.reply)
     async def reply(self, content: Optional[str] = None, **kwargs: Any) -> Message:
-        return await self.message.reply(content, **kwargs)
+        msg = await self.message.reply(content, **kwargs)
+        if self._original_response_message is None:
+            self._original_response_message = msg
+        return msg
+
+    async def delete(self, *, delay: Optional[float] = None, reason: Optional[str] = None) -> None:
+        """|coro|
+
+        Deletes the original response message, if it exists.
+
+        Parameters
+        -----------
+        delay: Optional[:class:`float`]
+            If provided, the number of seconds to wait before deleting the message.
+        reason: Optional[:class:`str`]
+            The reason for deleting the message. Shows up on the audit log.
+        """
+        if self._original_response_message:
+            await self._original_response_message.delete(delay=delay, reason=reason)


### PR DESCRIPTION
## Summary

This PR attempts to add a `BridgeExtContext.delete()` method. The method itself only tries to delete if a response has been made and currently doesn't raise an exception if a response has not been made.

The `ApplicationContext.delete()` method now has new documentation and allows for the `delay` parameter.

Closes #1343

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
