### PR TITLE
Make TextChannel._get_channel async

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -713,7 +713,7 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
     def _update(self, guild: Guild, data: TextChannelPayload) -> None:
         super()._update(guild, data)
 
-    def _get_channel(self) -> "TextChannel":
+    async def _get_channel(self) -> "TextChannel":
         return self
 
     def is_news(self) -> bool:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

`TextChannel._get_channel()` is called with `await` but isn't defined as `async`

For example:
https://github.com/Pycord-Development/pycord/blob/4d80dd5b02982b0f03726f4a97e23f2d1d03747a/discord/abc.py#L1428

This leads to exceptions such as `TypeError: object TextChannel can't be used in 'await' expression`

This change is consistent with all other classes in the module such as `VoiceChannel` which do use `async` in the definition of `_get_channel()`

https://github.com/Pycord-Development/pycord/blob/4d80dd5b02982b0f03726f4a97e23f2d1d03747a/discord/channel.py#L1160

https://github.com/Pycord-Development/pycord/blob/4d80dd5b02982b0f03726f4a97e23f2d1d03747a/discord/abc.py#L1247

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
