### PR TITLE
Fix enum options breaking with redesigned options

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -49,7 +49,7 @@ from typing import (
 )
 
 from ..channel import _guild_channel_factory
-from ..enums import MessageType, SlashCommandOptionType, try_enum
+from ..enums import MessageType, SlashCommandOptionType, try_enum, Enum as DiscordEnum
 from ..errors import (
     ApplicationCommandError,
     ApplicationCommandInvokeError,
@@ -693,6 +693,8 @@ class SlashCommand(ApplicationCommand):
             if option.default is None:
                 if p_obj.default == inspect.Parameter.empty:
                     option.default = None
+                elif issubclass(p_obj.default, (DiscordEnum, Enum)):
+                    option = Option(p_obj.default)
                 else:
                     option.default = p_obj.default
                     option.required = False


### PR DESCRIPTION
## Summary
works:
```py
async def toggle(self, ctx, opt: OnOffEnum):
```
doesn't work:
```py
async def toggle(self, ctx, opt = OnOffEnum):
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
