### PR TITLE
Fix the enum options fix breaking bridge commands

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -693,7 +693,7 @@ class SlashCommand(ApplicationCommand):
             if option.default is None:
                 if p_obj.default == inspect.Parameter.empty:
                     option.default = None
-                elif issubclass(p_obj.default, (DiscordEnum, Enum)):
+                elif inspect.isclass(p_obj.default) and issubclass(p_obj.default, (DiscordEnum, Enum)):
                     option = Option(p_obj.default)
                 else:
                     option.default = p_obj.default

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -693,7 +693,7 @@ class SlashCommand(ApplicationCommand):
             if option.default is None:
                 if p_obj.default == inspect.Parameter.empty:
                     option.default = None
-                elif inspect.isclass(p_obj.default) and issubclass(p_obj.default, (DiscordEnum, Enum)):
+                elif isinstance(p_obj.default, type) and issubclass(p_obj.default, (DiscordEnum, Enum)):
                     option = Option(p_obj.default)
                 else:
                     option.default = p_obj.default


### PR DESCRIPTION
## Summary
Specifically [using `None` as a default value](https://canary.discord.com/channels/881207955029110855/881735314987708456/975598404002537492).

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
