### PR TITLE
Change guild_only to dm_permission in to_dict

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -767,7 +767,7 @@ class SlashCommand(ApplicationCommand):
             as_dict["type"] = SlashCommandOptionType.sub_command.value
 
         if self.guild_only is not None:
-            as_dict["guild_only"] = self.guild_only
+            as_dict["dm_permission"] = not self.guild_only
 
         if self.default_member_permissions is not None:
             as_dict["default_member_permissions"] = self.default_member_permissions.value
@@ -1025,7 +1025,7 @@ class SlashCommandGroup(ApplicationCommand):
             as_dict["type"] = self.input_type.value
 
         if self.guild_only is not None:
-            as_dict["guild_only"] = self.guild_only
+            as_dict["dm_permission"] = not self.guild_only
 
         if self.default_member_permissions is not None:
             as_dict["default_member_permissions"] = self.default_member_permissions.value
@@ -1300,7 +1300,7 @@ class ContextMenuCommand(ApplicationCommand):
         }
 
         if self.guild_only is not None:
-            as_dict["guild_only"] = self.guild_only
+            as_dict["dm_permission"] = not self.guild_only
 
         if self.default_member_permissions is not None:
             as_dict["default_member_permissions"] = self.default_member_permissions.value


### PR DESCRIPTION
## Summary

`guild_only` is not a valid field in the app commands structure expected by Discord, it expects `dm_permission` instead.

Fixes #1367

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
