### PR TITLE
Add news attribute to TextChannel

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -720,6 +720,10 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
         """:class:`bool`: Checks if the channel is a news/anouncements channel."""
         return self._type == ChannelType.news.value
 
+    @property
+    def news(self) -> bool:
+        return self.is_news()
+
     async def create_thread(
         self,
         *,


### PR DESCRIPTION
Add the `news` attribute to TextChannel which implements `is_news()`, which in turn fixes the `AttributeError` raised in the base `_TextChannel.__repr__` function.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
