### PR TITLE
Fix Missing space causing docs to not format properly

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1134,6 +1134,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         .. versionadded:: 2.0
     last_message_id: Optional[:class:`int`]
         The ID of the last message sent to this channel. It may not always point to an existing or valid message.
+        
         .. versionadded:: 2.0
     flags: :class:`ChannelFlags`
         Extra features of the channel.


### PR DESCRIPTION
The docs currently have a missing return carriage, so don't format the "Added in" formatting, this fixes that:
(How it currently is)
https://imgur.com/a/zR0M4jK

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
