### PR TITLE
Revert "Bump sphinx from 4.5.0 to 5.0.1"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ with open("README.rst") as f:
 extras_require = {
     "voice": ["PyNaCl>=1.3.0,<1.6"],
     "docs": [
-        "sphinx==5.0.1",
+        "sphinx==4.5.0",
         "sphinxcontrib_trio==1.1.2",
         "sphinxcontrib-websupport",
         "myst-parser",


### PR DESCRIPTION
Reverts Pycord-Development/pycord#1397

[Ref](https://discord.com/channels/881207955029110855/881735314987708456/984950666797649970)
![image](https://user-images.githubusercontent.com/14029133/173160153-eaddb944-48a3-4da5-9131-38654c4a240d.png)
