### PR TITLE
Update TextChannel Option type to support NewsChannel

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -158,6 +158,8 @@ class Option:
                         for i in input_type:
                             if i.__name__ == "GuildChannel":
                                 continue
+                            elif i.__name__ == "TextChannel":
+                                self.channel_types.append(ChannelType.news)
                             if isinstance(i, ThreadOption):
                                 self.channel_types.append(i._type)
                                 continue


### PR DESCRIPTION
Patches the TextChannel option type to properly parse News (Announcement) channels.

## Summary

Announcement channels have an odd place in the library; they are considered as a `TextChannel` and thus `NewsChannel` is only a channel type, not its own class of channel. However, the Discord API treats them as a separate type, having an ID of 5 instead of 0. Because of this, NewsChannels would never be processed when using `discord.TextChannel` as a slash option type, as ID 5 was never considered.

This PR changes the Option `__init__` to include ID 5 when `TextChannel` is passed in, however there's probably a cleaner way of handling this.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
