### PR TITLE
Update deprecated/incorrect endpoints

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -899,7 +899,7 @@ class HTTPClient:
         *,
         reason: Optional[str] = None,
     ) -> Response[member.Nickname]:
-        r = Route("PATCH", "/guilds/{guild_id}/members/@me/nick", guild_id=guild_id)
+        r = Route("PATCH", "/guilds/{guild_id}/members/@me", guild_id=guild_id)
         payload = {
             "nick": nickname,
         }
@@ -1136,7 +1136,7 @@ class HTTPClient:
     def join_thread(self, channel_id: Snowflake) -> Response[None]:
         return self.request(
             Route(
-                "POST",
+                "PUT",
                 "/channels/{channel_id}/thread-members/@me",
                 channel_id=channel_id,
             )


### PR DESCRIPTION
## Summary

This PR does two things:
* Removes the deprecated endpoint `/guilds/{guild_id}/members/@me/nick` and replaces it with `/guilds/{guild_id}/members/@me` in `HTTPClient.change_my_nickname`.
* Changes the incorrect `POST` HTTP method to the correct `PUT` HTTP method in `HTTPClient.join_thread`.

References:
* [Modify Current User Nick (Deprecated)](https://discord.com/developers/docs/resources/guild#modify-current-user-nick) -> [Modify Current Member](https://discord.com/developers/docs/resources/guild#modify-current-member)
* [Join Thread](https://discord.com/developers/docs/resources/channel#join-thread)

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)

## Note
* For some reason, it appears that the `POST` HTTP method does function for `HTTPClient.join_thread`, as well as `PUT`. Gonna go ahead and change to the currently documented method (`PUT`) anyways. 🤷 
