### PR TITLE
Resolve issues with `discord.Thread` and `discord.ThreadOption` when used in `discord.Option`

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -191,14 +191,14 @@ class _TextChannel(discord.abc.GuildChannel, Hashable):
         return f"<{self.__class__.__name__} {joined}>"
 
     def _update(self, guild: Guild, data: Union[TextChannelPayload, ForumChannelPayload]) -> None:
-        # These will always exist
+        # This data will always exist
         self.guild: Guild = guild
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self._type: int = data["type"]
 
-        # When getting data through SlashCommand._invoke, these don't always exist
-        if not data.pop("_invoke_flag", False):
+        # This data may be missing depending on how this object is being created/updated
+        if data.get("position", None) is not None:
             self.topic: Optional[str] = data.get("topic")
             self.position: int = data.get("position")
             self.nsfw: bool = data.get("nsfw", False)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -191,12 +191,14 @@ class _TextChannel(discord.abc.GuildChannel, Hashable):
         return f"<{self.__class__.__name__} {joined}>"
 
     def _update(self, guild: Guild, data: Union[TextChannelPayload, ForumChannelPayload]) -> None:
+        # These will always exist
         self.guild: Guild = guild
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils._get_as_snowflake(data, "parent_id")
         self._type: int = data["type"]
 
-        if not data.get("_invoke_flag"):
+        # When getting data through SlashCommand._invoke, these don't always exist
+        if not data.pop("_invoke_flag", False):
             self.topic: Optional[str] = data.get("topic")
             self.position: int = data.get("position")
             self.nsfw: bool = data.get("nsfw", False)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -198,7 +198,7 @@ class _TextChannel(discord.abc.GuildChannel, Hashable):
         self._type: int = data["type"]
 
         # This data may be missing depending on how this object is being created/updated
-        if data.get("position", None) is not None:
+        if not data.pop("_invoke_flag", False):
             self.topic: Optional[str] = data.get("topic")
             self.position: int = data.get("position")
             self.nsfw: bool = data.get("nsfw", False)

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -48,7 +48,7 @@ from typing import (
     Union,
 )
 
-from ..channel import _guild_channel_factory
+from ..channel import _guild_channel_factory, _threaded_guild_channel_factory
 from ..enums import MessageType, SlashCommandOptionType, try_enum, Enum as DiscordEnum
 from ..errors import (
     ApplicationCommandError,
@@ -61,6 +61,7 @@ from ..member import Member
 from ..message import Attachment, Message
 from ..object import Object
 from ..role import Role
+from ..threads import Thread
 from ..user import User
 from ..utils import async_all, find, utcnow
 from .context import ApplicationContext, AutocompleteContext
@@ -816,6 +817,9 @@ class SlashCommand(ApplicationCommand):
                         arg = ctx.guild.get_channel(int(arg))
                         _data["_invoke_flag"] = True
                         arg._update(ctx.guild, _data)
+                    elif op.input_type is SlashCommandOptionType.channel and int(arg) in ctx.guild._threads:
+                        arg = ctx.guild.get_thread(int(arg))
+                        arg._update(_data)
                     else:
                         obj_type = None
                         kw = {}
@@ -826,10 +830,16 @@ class SlashCommand(ApplicationCommand):
                             kw["guild"] = ctx.guild
                         elif op.input_type is SlashCommandOptionType.channel:
                             # NOTE:
-                            # This is a fallback in case the channel is not found in the guild's channels.
-                            # If this fallback occurs, at the very minimum, permissions will be incorrect
-                            # due to a lack of permission_overwrite data.
-                            obj_type = _guild_channel_factory(_data["type"])[0]
+                            # This is a fallback in case the channel/thread is not found in the
+                            # guild's channels/threads. For channels, if this fallback occurs, at the very minimum,
+                            # permissions will be incorrect due to a lack of permission_overwrite data.
+                            # For threads, if this fallback occurs, info like thread owner id, message count,
+                            # flags, and more will be missing due to a lack of data sent by Discord.
+                            if op._raw_type is Thread:
+                                obj_type = _threaded_guild_channel_factory(_data["type"])[0]
+                                _data["_invoke_flag"] = True
+                            else:
+                                obj_type = _guild_channel_factory(_data["type"])[0]
                             kw["guild"] = ctx.guild
                         elif op.input_type is SlashCommandOptionType.attachment:
                             obj_type = Attachment

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -817,6 +817,7 @@ class SlashCommand(ApplicationCommand):
                         int(arg) in ctx.guild._channels or int(arg) in ctx.guild._threads
                     ):
                         arg = ctx.guild.get_channel_or_thread(int(arg))
+                        _data["_invoke_flag"] = True
                         arg._update(_data) if isinstance(arg, Thread) else arg._update(ctx.guild, _data)
                     else:
                         obj_type = None

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -834,8 +834,7 @@ class SlashCommand(ApplicationCommand):
                             # For threads, if this fallback occurs, info like thread owner id, message count,
                             # flags, and more will be missing due to a lack of data sent by Discord.
                             obj_type = _threaded_guild_channel_factory(_data["type"])[0]
-                            if op._raw_type is not Thread:
-                                kw["guild"] = ctx.guild
+                            kw["guild"] = ctx.guild
                         elif op.input_type is SlashCommandOptionType.attachment:
                             obj_type = Attachment
                         arg = obj_type(state=ctx.interaction._state, data=_data, **kw)

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -41,7 +41,6 @@ channel_type_map = {
     "StageChannel": ChannelType.stage_voice,
     "CategoryChannel": ChannelType.category,
     "Thread": ChannelType.public_thread,
-    "ThreadOption": ChannelType.public_thread,
 }
 
 
@@ -158,6 +157,9 @@ class Option:
                                 input_type = (input_type,)
                         for i in input_type:
                             if i.__name__ == "GuildChannel":
+                                continue
+                            if isinstance(i, ThreadOption):
+                                self.channel_types.append(i._type)
                                 continue
 
                             channel_type = channel_type_map[i.__name__]

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -45,6 +45,14 @@ channel_type_map = {
 
 
 class ThreadOption:
+    """Represents a class that can be passed as the input_type for an Option class.
+
+    Parameters
+    -----------
+    thread_type: Literal["public", "private", "news"]
+        The thread type to expect for this options input.
+    """
+
     def __init__(self, thread_type: Literal["public", "private", "news"]):
         type_map = {
             "public": ChannelType.public_thread,

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -41,6 +41,7 @@ channel_type_map = {
     "StageChannel": ChannelType.stage_voice,
     "CategoryChannel": ChannelType.category,
     "Thread": ChannelType.public_thread,
+    "ThreadOption": ChannelType.public_thread,
 }
 
 
@@ -157,9 +158,6 @@ class Option:
                                 input_type = (input_type,)
                         for i in input_type:
                             if i.__name__ == "GuildChannel":
-                                continue
-                            if isinstance(i, ThreadOption):
-                                self.channel_types.append(i._type)
                                 continue
 
                             channel_type = channel_type_map[i.__name__]

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -355,8 +355,8 @@ class Guild(Hashable):
         self._members[member.id] = member
 
     def _get_and_update_member(self, payload: MemberPayload, user_id: int, cache_flag: bool, /) -> Member:
-        # we always get the member, and we only update if the cache_flag (this cache flag should
-        # always be MemberCacheFlag.interaction or MemberCacheFlag.option) is set to True
+        # we always get the member, and we only update if the cache_flag (this cache
+        # flag should always be MemberCacheFlag.interaction) is set to True
         if user_id in self._members:
             member = self.get_member(user_id)
             member._update(payload) if cache_flag else None

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -170,14 +170,18 @@ class Thread(Messageable, Hashable):
     def _from_data(self, data: ThreadPayload):
         self.id = int(data["id"])
         self.parent_id = int(data["parent_id"])
-        self.owner_id = int(data["owner_id"])
         self.name = data["name"]
         self._type = try_enum(ChannelType, data["type"])
-        self.last_message_id = _get_as_snowflake(data, "last_message_id")
-        self.slowmode_delay = data.get("rate_limit_per_user", 0)
-        self.message_count = data["message_count"]
-        self.member_count = data["member_count"]
-        self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
+
+        # Type ignore is used here as the linter doesn't expect ThreadPayload to have an '_invoke_flag' key
+        if not data.get("_invoke_flag"):  # type: ignore
+            self.owner_id = int(data["owner_id"])
+            self.last_message_id = _get_as_snowflake(data, "last_message_id")
+            self.slowmode_delay = data.get("rate_limit_per_user", 0)
+            self.message_count = data["message_count"]
+            self.member_count = data["member_count"]
+            self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
+
         self._unroll_metadata(data["thread_metadata"])
 
         try:

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -168,11 +168,13 @@ class Thread(Messageable, Hashable):
         return self.name
 
     def _from_data(self, data: ThreadPayload):
+        # These will always exist
         self.id = int(data["id"])
         self.parent_id = int(data["parent_id"])
         self.name = data["name"]
         self._type = try_enum(ChannelType, data["type"])
 
+        # When getting data through SlashCommand._invoke, these don't always exist
         if not data.pop("_invoke_flag", False):
             self.owner_id = int(data["owner_id"])
             self.last_message_id = _get_as_snowflake(data, "last_message_id")

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -176,7 +176,6 @@ class Thread(Messageable, Hashable):
 
         # This data may be missing depending on how this object is being created
         self.owner_id = int(data.get("owner_id")) if data.get("owner_id", None) is not None else None
-        self.owner_id = data.get("owner_id", None)
         self.last_message_id = _get_as_snowflake(data, "last_message_id")
         self.slowmode_delay = data.get("rate_limit_per_user", 0)
         self.message_count = data.get("message_count", None)

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -168,20 +168,22 @@ class Thread(Messageable, Hashable):
         return self.name
 
     def _from_data(self, data: ThreadPayload):
-        # These will always exist
+        # This data will always exist
         self.id = int(data["id"])
         self.parent_id = int(data["parent_id"])
         self.name = data["name"]
         self._type = try_enum(ChannelType, data["type"])
 
-        # When getting data through SlashCommand._invoke, these don't always exist
-        if not data.pop("_invoke_flag", False):
+        # This data may be missing depending on how this object is being created
+        try:
             self.owner_id = int(data["owner_id"])
             self.last_message_id = _get_as_snowflake(data, "last_message_id")
             self.slowmode_delay = data.get("rate_limit_per_user", 0)
             self.message_count = data["message_count"]
             self.member_count = data["member_count"]
             self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
+        except KeyError:
+            pass
 
         self._unroll_metadata(data["thread_metadata"])
 

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -184,7 +184,7 @@ class Thread(Messageable, Hashable):
         self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
 
         # Here, we try to fill in potentially missing data
-        if thread := self.guild.get_thread(self.id):
+        if thread := self.guild.get_thread(self.id) and data.pop("_invoke_flag", False):
             self.owner_id = thread.owner_id if self.owner_id is None else self.owner_id
             self.last_message_id = thread.last_message_id if self.last_message_id is None else self.last_message_id
             self.message_count = thread.message_count if self.message_count is None else self.message_count

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -173,8 +173,7 @@ class Thread(Messageable, Hashable):
         self.name = data["name"]
         self._type = try_enum(ChannelType, data["type"])
 
-        # Type ignore is used here as the linter doesn't expect ThreadPayload to have an '_invoke_flag' key
-        if not data.get("_invoke_flag"):  # type: ignore
+        if not data.pop("_invoke_flag", False):
             self.owner_id = int(data["owner_id"])
             self.last_message_id = _get_as_snowflake(data, "last_message_id")
             self.slowmode_delay = data.get("rate_limit_per_user", 0)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -152,6 +152,14 @@ Option
 .. autofunction:: discord.commands.Option
     :decorator:
 
+ThreadOption
+~~~~~~~~~~~~~
+
+.. attributetable:: ThreadOption
+
+.. autoclass:: ThreadOption
+    :members:
+
 OptionChoice
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

This PR resolves issues when using `discord.Thread` as a `discord.Option` input type. Previously, doing so raised an error: `TypeError: 'NoneType' object is not callable`. Now, threads are correctly handled when given as an option type. A few touchups to changes made in #1365 are also made here including comment updates and updates to how the `_invoke_flag` key works when being added to data. Atop of this, `discord.ThreadOption` now has documentation with this PR.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
