### PR TITLE
Enum options not setting `input_type` to a SlashCommandOptionType

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -689,7 +689,7 @@ class SlashCommand(ApplicationCommand):
 
             if not isinstance(option, Option):
                 if isinstance(p_obj.default, Option):
-                    p_obj.default.input_type = option
+                    p_obj.default.input_type = SlashCommandOptionType.from_datatype(option)
                     option = p_obj.default
                 else:
                     option = Option(option)


### PR DESCRIPTION
## Summary
An enum option with a default value:
```py
async def command(ctx, opt = discord.Option(ThisEnum, default=ThisEnum.value):
```
errors with `AttributeError: type object 'str' has no attribute 'value'`

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)