### PR TITLE
Update IDENTIFY packet connection properties

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -395,11 +395,9 @@ class DiscordWebSocket:
             "d": {
                 "token": self.token,
                 "properties": {
-                    "$os": sys.platform,
-                    "$browser": "pycord",
-                    "$device": "pycord",
-                    "$referrer": "",
-                    "$referring_domain": "",
+                    "os": sys.platform,
+                    "browser": "pycord",
+                    "device": "pycord",
                 },
                 "compress": True,
                 "large_threshold": 250,


### PR DESCRIPTION
## Summary

This PR updates the IDENTIFY packet connection properties per [this change log](https://discord.com/developers/docs/change-log#updated-connection-property-field-names). The unused properties of `"$referrer"` and `"$referring_domain"` were also removed here.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
