### PR TITLE
refactor: Pass the `exception` into `client.on_error`

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -382,9 +382,9 @@ class Client:
             await coro(*args, **kwargs)
         except asyncio.CancelledError:
             pass
-        except Exception:
+        except Exception as exc:
             try:
-                await self.on_error(event_name, *args, **kwargs)
+                await self.on_error(event_name, exc, *args)
             except asyncio.CancelledError:
                 pass
 
@@ -439,7 +439,7 @@ class Client:
         else:
             self._schedule_event(coro, method, *args, **kwargs)
 
-    async def on_error(self, event_method: str, *args: Any, **kwargs: Any) -> None:
+    async def on_error(self, event_name: str, exception: Exception, *args: Any) -> None:
         """|coro|
 
         The default error handler provided by the client.
@@ -448,7 +448,7 @@ class Client:
         overridden to have a different implementation.
         Check :func:`~discord.on_error` for more details.
         """
-        print(f"Ignoring exception in {event_method}", file=sys.stderr)
+        print(f"Ignoring exception in {event_name}", file=sys.stderr)
         traceback.print_exc()
 
     # hooks

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -427,7 +427,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param shard_id: The shard ID that has resumed.
     :type shard_id: :class:`int`
 
-.. function:: on_error(event, *args, **kwargs)
+.. function:: on_error(event, error, *args)
 
     Usually when an event raises an uncaught exception, a traceback is
     printed to stderr and the exception is ignored. If you want to
@@ -453,10 +453,10 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     :param event: The name of the event that raised the exception.
     :type event: :class:`str`
+    :param error: The error that was raised.
+    :type error: :class:`Exception` derived
 
     :param args: The positional arguments for the event that raised the
-        exception.
-    :param kwargs: The keyword arguments for the event that raised the
         exception.
 
 .. function:: on_socket_event_type(event_type)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This pull request refactors how `on_error` works by passing into the `exc` caught from running an event coro into `on_error`. This solves the problem of having the get the error from `stdout` and behaves in a similiar way to `on_command_error` to keep code consistency. Changes have been updated to reflect the changes.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
