### PR TITLE
Allow PartialMessageChannel to be in voice channels (which now support text)

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1712,6 +1712,7 @@ class PartialMessage(Hashable):
     def __init__(self, *, channel: PartialMessageableChannel, id: int):
         if channel.type not in (
             ChannelType.text,
+            ChannelType.voice,
             ChannelType.news,
             ChannelType.private,
             ChannelType.news_thread,


### PR DESCRIPTION
raise TypeError(f"Expected TextChannel, VoiceChannel, DMChannel or Thread not {type(channel)!r}")
TypeError: Expected TextChannel, VoiceChannel, DMChannel or Thread not <class 'discord.channel.VoiceChannel'>

(from: https://discord.com/channels/881207955029110855/881735314987708456/989938163134918687)

This needs testing is so currently a draft

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
