### PR TITLE
Add message property to views

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1534,6 +1534,7 @@ class Messageable:
         ret = state.create_message(channel=channel, data=data)
         if view:
             state.store_view(view, ret.id)
+            view.message = ret
 
         if delete_after is not None:
             await ret.delete(delay=delete_after)

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -144,6 +144,8 @@ class View:
         If ``None`` then there is no timeout.
     children: List[:class:`Item`]
         The list of children attached to this view.
+    message: Optional[:class:`Message`]
+        The message that this view is attached to. Returns ``None`` if the view has not been sent with a message.
     """
 
     __discord_ui_view__: ClassVar[bool] = True

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -145,7 +145,8 @@ class View:
     children: List[:class:`Item`]
         The list of children attached to this view.
     message: Optional[:class:`Message`]
-        The message that this view is attached to. Returns ``None`` if the view has not been sent with a message.
+        The message that this view is attached to. 
+        If ``None`` then the view has not been sent with a message.
     """
 
     __discord_ui_view__: ClassVar[bool] = True

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -184,7 +184,7 @@ class View:
         self.__timeout_expiry: Optional[float] = None
         self.__timeout_task: Optional[asyncio.Task[None]] = None
         self.__stopped: asyncio.Future[bool] = loop.create_future()
-        self._message: Message | None = None
+        self._message: Optional[Message] = None
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} timeout={self.timeout} children={len(self.children)}>"

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -181,6 +181,7 @@ class View:
         self.__timeout_expiry: Optional[float] = None
         self.__timeout_task: Optional[asyncio.Task[None]] = None
         self.__stopped: asyncio.Future[bool] = loop.create_future()
+        self._message: Message | None = None
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} timeout={self.timeout} children={len(self.children)}>"
@@ -491,6 +492,14 @@ class View:
             if exclusions is None or child not in exclusions:
                 child.disabled = False
 
+    @property
+    def message(self):
+        return self._message
+    
+    @message.setter
+    def message(self, value):
+        print("Setting")
+        self._message = value
 
 class ViewStore:
     def __init__(self, state: ConnectionState):

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -501,7 +501,6 @@ class View:
     
     @message.setter
     def message(self, value):
-        print("Setting")
         self._message = value
 
 class ViewStore:


### PR DESCRIPTION
## Summary

This pull request is to give views a new `message` property for after a message is sent with the view attached. This makes it easier for users to manipulate the view with no interaction, such as in the on_timeout function.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
