### PR TITLE
New `discord.Thread` additions

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -657,6 +657,10 @@ class Message(Hashable):
         The guild that the message belongs to, if applicable.
     interaction: Optional[:class:`MessageInteraction`]
         The interaction associated with the message, if applicable.
+    thread: Optional[:class:`Thread`]
+        The thread created from this message, if applicable.
+
+        .. versionadded:: 2.0
     """
 
     __slots__ = (
@@ -691,6 +695,7 @@ class Message(Hashable):
         "components",
         "guild",
         "interaction",
+        "thread",
     )
 
     if TYPE_CHECKING:
@@ -765,6 +770,12 @@ class Message(Hashable):
             self.interaction = MessageInteraction(data=data["interaction"], state=state)
         except KeyError:
             self.interaction = None
+
+        self.thread: Optional[Thread]
+        try:
+            self.thread = Thread(guild=self.guild, state=self._state, data=data["thread"])
+        except KeyError:
+            self.thread = None
 
         for handler in ("author", "member", "mentions", "mention_roles"):
             try:
@@ -1590,13 +1601,16 @@ class Message(Hashable):
         default_auto_archive_duration: ThreadArchiveDuration = getattr(
             self.channel, "default_auto_archive_duration", 1440
         )
+
         data = await self._state.http.start_thread_with_message(
             self.channel.id,
             self.id,
             name=name,
             auto_archive_duration=auto_archive_duration or default_auto_archive_duration,
         )
-        return Thread(guild=self.guild, state=self._state, data=data)
+
+        self.thread = Thread(guild=self.guild, state=self._state, data=data)
+        return self.thread
 
     async def reply(self, content: Optional[str] = None, **kwargs) -> Message:
         """|coro|

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -86,6 +86,10 @@ class Thread(Messageable, Hashable):
         The guild the thread belongs to.
     id: :class:`int`
         The thread ID.
+
+        .. note::
+            This ID is the same as the thread starting message ID.
+
     parent_id: :class:`int`
         The parent :class:`TextChannel` ID this thread belongs to.
     owner_id: :class:`int`
@@ -260,7 +264,7 @@ class Thread(Messageable, Hashable):
 
     @property
     def last_message(self) -> Optional[Message]:
-        """Fetches the last message from this channel in cache.
+        """Returns the last message from this thread in cache.
 
         The message might not be valid or point to an existing message.
 
@@ -273,7 +277,7 @@ class Thread(Messageable, Hashable):
             attribute.
 
         Returns
-        ---------
+        --------
         Optional[:class:`Message`]
             The last message in this channel or ``None`` if not found.
         """
@@ -289,7 +293,7 @@ class Thread(Messageable, Hashable):
             The parent channel was not cached and returned ``None``.
 
         Returns
-        -------
+        --------
         Optional[:class:`CategoryChannel`]
             The parent channel's category.
         """
@@ -309,7 +313,7 @@ class Thread(Messageable, Hashable):
             The parent channel was not cached and returned ``None``.
 
         Returns
-        -------
+        --------
         Optional[:class:`int`]
             The parent channel's category ID.
         """
@@ -318,6 +322,22 @@ class Thread(Messageable, Hashable):
         if parent is None:
             raise ClientException("Parent channel not found")
         return parent.category_id
+
+    @property
+    def starting_message(self) -> Optional[Message]:
+        """Returns the message that started this thread.
+
+        The message might not be valid or point to an existing message.
+
+        .. note::
+            The ID for this message is the same as the thread ID.
+
+        Returns
+        --------
+        Optional[:class:`Message`]
+            The message that started this thread or ``None`` if not found in the cache.
+        """
+        return self._state._get_message(self.id)
 
     def is_private(self) -> bool:
         """:class:`bool`: Whether the thread is a private thread.

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -34,6 +34,7 @@ from .emoji import PartialEmoji
 from .member import Member, UserWithMember
 from .snowflake import Snowflake, SnowflakeList
 from .sticker import StickerItem
+from .threads import Thread
 from .user import User
 
 if TYPE_CHECKING:
@@ -110,6 +111,7 @@ class _MessageOptional(TypedDict, total=False):
     referenced_message: Optional[Message]
     interaction: MessageInteraction
     components: List[Component]
+    thread: Optional[Thread]
 
 
 MessageType = Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21]


### PR DESCRIPTION
## Summary

This PR adds the `thread` attribute to `discord.Message` which represents the thread created from the message, if any. This part is mostly a resurrection of the stale/closed #850. Atop of this, the `starting_message` property is added to `discord.Thread` which returns the message which started the thread. A few consistency changes to dashes and a docstring are made as well.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
