### PR TITLE
Fix bridge commands to ignore the ephemeral kwarg

### DIFF
--- a/discord/ext/bridge/context.py
+++ b/discord/ext/bridge/context.py
@@ -144,12 +144,14 @@ class BridgeExtContext(BridgeContext, Context):
         self._original_response_message: Optional[Message] = None
 
     async def _respond(self, *args, **kwargs) -> Message:
+        kwargs.pop("ephemeral", None)
         message = await self._get_super("reply")(*args, **kwargs)
         if self._original_response_message is None:
             self._original_response_message = message
         return message
 
     async def _defer(self, *args, **kwargs) -> None:
+        kwargs.pop("ephemeral", None)
         return await self._get_super("trigger_typing")(*args, **kwargs)
 
     async def _edit(self, *args, **kwargs) -> Message:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Closes #1449 by removing the `ephemeral=` kwarg in `BridgeExtContext`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
