### PR TITLE
Resolve issues with `ext.bridge` docs

### DIFF
--- a/discord/ext/bridge/bot.py
+++ b/discord/ext/bridge/bot.py
@@ -58,7 +58,7 @@ class BotBase(ABC):
         command.add_to(self)  # type: ignore
 
     def bridge_command(self, **kwargs):
-        """A shortcut decorator that invokes :func:`~.bridge_command` and adds it to
+        """A shortcut decorator that invokes :func:`bridge_command` and adds it to
         the internal command list via :meth:`~.Bot.add_bridge_command`.
 
         Returns

--- a/discord/ext/bridge/context.py
+++ b/discord/ext/bridge/context.py
@@ -97,7 +97,7 @@ class BridgeContext(ABC):
         """|coro|
 
         Defers the command with the respective approach to the current context. In :class:`BridgeExtContext`, this will
-        be :meth:`~discord.Messageable.trigger_typing` while in :class:`BridgeApplicationContext`, this will be
+        be :meth:`~discord.abc.Messageable.trigger_typing` while in :class:`BridgeApplicationContext`, this will be
         :attr:`~.ApplicationContext.defer`.
 
         .. note::

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -69,7 +69,7 @@ class BridgeCommand:
 
     Parameters
     ----------
-    callback: Callable[[BridgeContext, ...], Awaitable[Any]]
+    callback: Callable[[:class:`.BridgeContext`, ...], Awaitable[Any]]
         The callback to invoke when the command is executed. The first argument will be a :class:`BridgeContext`,
         and any additional arguments will be passed to the callback. This callback must be a coroutine.
     kwargs: Optional[Dict[:class:`str`, Any]]
@@ -108,7 +108,7 @@ class BridgeCommand:
 
         Parameters
         ----------
-        bot: Union[:class:`.ExtBot`, :class:`.ExtAutoShardedBot`]
+        bot: Union[:class:`.Bot`, :class:`.AutoShardedBot`]
             The bot to add the command to.
         """
 

--- a/docs/ext/bridge/api.rst
+++ b/docs/ext/bridge/api.rst
@@ -1,0 +1,86 @@
+.. currentmodule:: discord
+
+API Reference
+==============
+
+The reference manual that follows details the API of Pycord's bridge command extension module.
+
+.. note::
+
+    Using the prefixed command version (which uses the ``ext.commands`` extension) of bridge
+    commands in guilds requires :attr:`Intents.message_context` to be enabled.
+
+
+.. _ext_bridge_api:
+
+Bots
+-----
+
+Bot
+~~~~
+
+.. attributetable:: discord.ext.bridge.Bot
+
+.. autoclass:: discord.ext.bridge.Bot
+    :members:
+
+    .. automethod:: Bot.add_bridge_command()
+
+    .. automethod:: Bot.bridge_command()
+        :decorator:
+
+AutoShardedBot
+~~~~~~~~~~~~~~~
+
+.. attributetable:: discord.ext.bridge.AutoShardedBot
+
+.. autoclass:: discord.ext.bridge.AutoShardedBot
+    :members:
+
+Commands
+---------
+
+BridgeCommand
+~~~~~~~~~~~~~~
+
+.. attributetable:: discord.ext.bridge.BridgeCommand
+
+.. autoclass:: discord.ext.bridge.BridgeCommand
+    :members:
+
+.. automethod:: discord.ext.bridge.bridge_command()
+    :decorator:
+
+BridgeCommand Subclasses
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: discord.ext.bridge.BridgeExtCommand
+    :members:
+
+.. autoclass:: discord.ext.bridge.BridgeSlashCommand
+    :members:
+
+Context
+--------
+
+BridgeContext
+~~~~~~~~~~~~~~
+
+.. attributetable:: discord.ext.bridge.BridgeContext
+
+.. autoclass:: discord.ext.bridge.BridgeContext
+    :members:
+    :exclude-members: _respond, _defer, _edit, _get_super
+
+BridgeContext Subclasses
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: discord.ext.bridge.BridgeApplicationContext
+
+.. autoclass:: discord.ext.bridge.BridgeApplicationContext
+    :members:
+
+.. attributetable:: discord.ext.bridge.BridgeExtContext
+
+.. autoclass:: discord.ext.bridge.BridgeExtContext
+    :members:

--- a/docs/ext/bridge/index.rst
+++ b/docs/ext/bridge/index.rst
@@ -9,9 +9,6 @@ This module allows using one command callback in order to make both a prefix com
 This page includes the API reference/documentation for the module, but only contains a short example. For a more
 detailed guide on how to use this, see our `discord.ext.bridge guide <https://guide.pycord.dev/extensions/bridge>`_.
 
-.. note::
-    ``ext.bridge`` requires the message content intent to be enabled, as it uses the ``ext.commands`` extension.
-
 Example usage:
 
 .. code-block:: python3
@@ -39,61 +36,8 @@ Example usage:
 
     bot.run("TOKEN")
 
-.. _discord_ext_bridge_api:
 
-API Reference
-===============
+.. toctree::
+    :maxdepth: 2
 
-Bots
------
-
-.. attributetable:: discord.ext.bridge.Bot
-
-.. autoclass:: discord.ext.bridge.Bot
-    :members:
-
-    .. automethod:: Bot.add_bridge_command()
-
-    .. automethod:: Bot.bridge_command()
-        :decorator:
-
-.. attributetable:: discord.ext.bridge.AutoShardedBot
-
-.. autoclass:: discord.ext.bridge.AutoShardedBot
-    :members:
-
-Commands
----------
-
-.. attributetable:: discord.ext.bridge.BridgeCommand
-
-.. autoclass:: discord.ext.bridge.BridgeCommand
-    :members:
-
-.. automethod:: discord.ext.bridge.bridge_command()
-    :decorator:
-
-.. autoclass:: discord.ext.bridge.BridgeExtCommand
-    :members:
-
-.. autoclass:: discord.ext.bridge.BridgeSlashCommand
-    :members:
-
-Context
---------
-
-.. attributetable:: discord.ext.bridge.BridgeContext
-
-.. autoclass:: discord.ext.bridge.BridgeContext
-    :members:
-    :exclude-members: _respond, _defer, _edit, _get_super
-
-.. attributetable:: discord.ext.bridge.BridgeApplicationContext
-
-.. autoclass:: discord.ext.bridge.BridgeApplicationContext
-    :members:
-
-.. attributetable:: discord.ext.bridge.BridgeExtContext
-
-.. autoclass:: discord.ext.bridge.BridgeExtContext
-    :members:
+    api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ These pages go into great detail about everything the API can do.
   discord.ext.commands API Reference <ext/commands/api.rst>
   discord.ext.tasks API Reference <ext/tasks/index.rst>
   discord.ext.pages API Reference <ext/pages/index.rst>
-  discord.ext.bridge API Reference <ext/bridge/index.rst>
+  discord.ext.bridge API Reference <ext/bridge/api.rst>
 
 Meta
 ------


### PR DESCRIPTION
## Summary

This PR serves as somewhat of a follow-up to #1454. In this PR, `docs/ext/bridge/index.rst` is now split into `index.rst` and `api.rst` to resolve a bug with the docs homepage displaying links doubly. A few more docs fixes are also made here, and more detail is added to the API Reference sections/table of contents.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
