### PR TITLE
Update thread.members on thread.fetch_members

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -735,7 +735,13 @@ class Thread(Messageable, Hashable):
         """
 
         members = await self._state.http.get_thread_members(self.id)
-        return [ThreadMember(parent=self, data=data) for data in members]
+
+        thread_members = [ThreadMember(parent=self, data=data) for data in members]
+
+        for member in thread_members:
+            self._add_member(member)
+
+        return thread_members
 
     async def delete(self):
         """|coro|


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
On `thread.fetch_members()` the `thread.members` attribute wasn't updated which results in the need of always using `thread.fetch_members()` instead of relying on the cache afterwards.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.

