### PR TITLE
Example of using semi-implemented private emojis.

### DIFF
--- a/examples/create_private_emoji.py
+++ b/examples/create_private_emoji.py
@@ -20,7 +20,7 @@ async def add_private_emoji(
     image_file = await image.read()  # Reading attachment's content to get bytes
 
     await ctx.guild.create_custom_emoji(name=name, image=image_file, roles=[role])  # Image argument only takes bytes!
-    await ctx.respond(content=f'Private emoji is successfully created!')
+    await ctx.respond(content="Private emoji is successfully created!")
 
 
 bot.run("TOKEN")

--- a/examples/create_private_emoji.py
+++ b/examples/create_private_emoji.py
@@ -1,0 +1,26 @@
+import discord
+
+bot = discord.Bot()
+
+allowed_content_types = ['image/jpeg', 'image/png']  # Setting up allowed attachments types
+
+
+# Discord doesn't support creating private emojis by default, its semi-implemented feature and can be done by bots only.
+
+# This command is publicly available, to set up command permissions look for other examples in repo
+@bot.command(guild_ids=[...])
+async def add_private_emoji(
+        ctx, name: discord.Option(str),
+        attachment: discord.Option(discord.Attachment, name='image'),
+        role: discord.Option(discord.Role)
+):
+    if attachment.content_type not in allowed_content_types:
+        return await ctx.respond(ephemeral=True, content='Invalid attachment type!')
+
+    image_file = await attachment.read()  # Reading attachment's content to get bytes
+
+    await ctx.guild.create_custom_emoji(name=name, image=image_file, roles=[role])  # Image argument only takes bytes!
+    await ctx.respond(content=f'Private emoji is successfully created!')
+
+
+bot.run("TOKEN")

--- a/examples/create_private_emoji.py
+++ b/examples/create_private_emoji.py
@@ -15,7 +15,7 @@ async def add_private_emoji(
         role: discord.Option(discord.Role)
 ):
     if image.content_type not in allowed_content_types:
-        return await ctx.respond(ephemeral=True, content='Invalid attachment type!')
+        return await ctx.respond("Invalid attachment type!", ephemeral=True)
 
     image_file = await image.read()  # Reading attachment's content to get bytes
 

--- a/examples/create_private_emoji.py
+++ b/examples/create_private_emoji.py
@@ -11,13 +11,13 @@ allowed_content_types = ['image/jpeg', 'image/png']  # Setting up allowed attach
 @bot.command(guild_ids=[...])
 async def add_private_emoji(
         ctx, name: discord.Option(str),
-        attachment: discord.Option(discord.Attachment, name='image'),
+        image: discord.Option(discord.Attachment),
         role: discord.Option(discord.Role)
 ):
-    if attachment.content_type not in allowed_content_types:
+    if image.content_type not in allowed_content_types:
         return await ctx.respond(ephemeral=True, content='Invalid attachment type!')
 
-    image_file = await attachment.read()  # Reading attachment's content to get bytes
+    image_file = await image.read()  # Reading attachment's content to get bytes
 
     await ctx.guild.create_custom_emoji(name=name, image=image_file, roles=[role])  # Image argument only takes bytes!
     await ctx.respond(content=f'Private emoji is successfully created!')


### PR DESCRIPTION
## Summary

Added here an example of semi-implemented feature of creating role-based private emojis.

![DiscordCanary_dJeq1FnuXD](https://user-images.githubusercontent.com/49173264/177051884-84bfff30-04f7-4e78-bd90-5c86fec91548.gif)

![tP6pwFOo7w](https://user-images.githubusercontent.com/49173264/177051896-1442c05b-ded9-4a0e-9151-071b56d571fb.gif)

![DiscordCanary_jx74ZeU0GK](https://user-images.githubusercontent.com/49173264/177051898-148524d7-a3f1-439c-883a-ed4519a88f9c.png)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
