### PR TITLE
fixing issue with not working audo_recordings example

### DIFF
--- a/examples/audio_recording.py
+++ b/examples/audio_recording.py
@@ -1,20 +1,19 @@
-from enum import Enum
-
 import discord
 
 bot = discord.Bot(debug_guilds=[...])
 connections = {}
 
 
-class Sinks(Enum):
-    mp3 = discord.sinks.MP3Sink()
-    wav = discord.sinks.WaveSink()
-    pcm = discord.sinks.PCMSink()
-    ogg = discord.sinks.OGGSink()
-    mka = discord.sinks.MKASink()
-    mkv = discord.sinks.MKVSink()
-    mp4 = discord.sinks.MP4Sink()
-    m4a = discord.sinks.M4ASink()
+sinks = {
+    "mp3": discord.sinks.MP3Sink(),
+    "wav": discord.sinks.WaveSink(),
+    "pcm": discord.sinks.PCMSink(),
+    "ogg": discord.sinks.OGGSink(),
+    "mka": discord.sinks.MKASink(),
+    "mkv": discord.sinks.MKVSink(),
+    "mp4": discord.sinks.MP4Sink(),
+    "m4a": discord.sinks.M4ASink()
+}
 
 
 async def finished_callback(sink, channel: discord.TextChannel, *args):
@@ -30,10 +29,12 @@ async def finished_callback(sink, channel: discord.TextChannel, *args):
 
 
 @bot.command()
-async def start(ctx: discord.ApplicationContext, sink: Sinks):
+async def start(ctx: discord.ApplicationContext, sink: discord.Option(str, choices=sinks)):
     """
     Record your voice!
     """
+    sink = sinks.get(sink)
+
     voice = ctx.author.voice
 
     if not voice:
@@ -43,7 +44,7 @@ async def start(ctx: discord.ApplicationContext, sink: Sinks):
     connections.update({ctx.guild.id: vc})
 
     vc.start_recording(
-        sink.value,
+        sink,
         finished_callback,
         ctx.channel,
     )


### PR DESCRIPTION
## Summary

I fixed an error that was caused probably by using enum, but im not sure.
My personal opinion, is that pevious example was cleaner and simply better.
Had to use dict once again, because i was too lazy to fix Enum thing, if someone wants to try fixing it using Enum - you're welcome.

I prefer using Enum aswell, because it looks cooler, but it just didn't work well here.

There is some error messages that user on pycord's discord server was getting:

![image](https://user-images.githubusercontent.com/49173264/177060142-d3bd6684-67d3-4331-8e7b-c117043d9fe6.png)

I was able to recreate the issue by simply trying to use code from example:
![image](https://user-images.githubusercontent.com/49173264/177060211-30f536b4-9e56-46fd-a865-eec51f254b3f.png)

**With updated code i got it to work**:

![p9MvbK0hvd](https://user-images.githubusercontent.com/49173264/177060298-2bd00bef-1fb8-4489-b1a2-5c2338a10a05.gif)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
