### PR TITLE
`Interaction` hotfix

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -166,7 +166,7 @@ class Interaction:
         self.locale: Optional[str] = data.get("locale")
         self.guild_locale: Optional[str] = data.get("guild_locale")
         self.custom_id: Optional[str] = self.data.get("custom_id") if self.data is not None else None
-        self._app_permissions: int = int(data.get("app_permissions"))
+        self._app_permissions: int = int(data.get("app_permissions", 0))
 
         self.message: Optional[Message] = None
 


### PR DESCRIPTION
## Summary

This PR resolves an issue where `app_permissions` is not included in the data sent by discord and raises an error when constructing an `Interaction` object. 

More info: https://discord.com/channels/881207955029110855/969580926885580801/993574845839314944

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
