### PR TITLE
feat: add additional operations to `BaseFlags`

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -568,7 +568,7 @@ class Intents(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
 
         .. describe:: x + y
-         Adds two flags together.
+        Adds two flags together.
 
         .. describe:: x - y
         Subtracts two flags from each other.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -39,6 +39,7 @@ from typing import (
     overload,
 )
 
+import discord
 from .enums import UserFlags
 
 __all__ = (
@@ -140,6 +141,44 @@ class BaseFlags:
             if isinstance(value, flag_value):
                 yield (name, self._has_flag(value.flag))
 
+    def __and__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__class__._from_value(self.value & other.value)
+        elif isinstance(other, flag_value):
+            return self.__class__._from_value(self.value & other.flag)
+        else:
+            raise TypeError(f"'&' not supported between instances of {type(self)} and {type(other)}")
+
+    def __or__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__class__._from_value(self.value | other.value)
+        elif isinstance(other, flag_value):
+            return self.__class__._from_value(self.value | other.flag)
+        else:
+            raise TypeError(f"'|' not supported between instances of {type(self)} and {type(other)}")
+
+    def __add__(self, other):
+        try:
+            return self | other
+        except TypeError:
+            raise TypeError(f"'+' not supported between instances of {type(self)} and {type(other)}")
+
+    def __sub__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__class__._from_value(self.value & ~other.value)
+        elif isinstance(other, flag_value):
+            return self.__class__._from_value(self.value & ~other.flag)
+        else:
+            raise TypeError(f"'-' not supported between instances of {type(self)} and {type(other)}")
+
+    def __invert__(self):
+        return self.__class__._from_value(~self.value)
+
+    __rand__: Callable[[BaseFlags], bool] = __and__
+    __ror__: Callable[[BaseFlags], bool] = __or__
+    __radd__: Callable[[BaseFlags], bool] = __add__
+    __rsub__: Callable[[BaseFlags], bool] = __sub__
+
     def _has_flag(self, o: int) -> bool:
         return (self.value & o) == o
 
@@ -176,6 +215,19 @@ class SystemChannelFlags(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
+
+            Adds two flags together.
+        .. describe:: x + y
+
+            Subtracts two flags from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two flags.
+        .. describe:: x & y
+
+            Returns the inverse of a flag.
+        .. describe:: ~x
+
 
     Attributes
     -----------
@@ -249,6 +301,19 @@ class MessageFlags(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
+
+            Adds two flags together.
+        .. describe:: x + y
+
+            Subtracts two flags from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two flags.
+        .. describe:: x & y
+
+            Returns the inverse of a flags.
+        .. describe:: ~x
+
 
     .. versionadded:: 1.3
 
@@ -345,6 +410,19 @@ class PublicUserFlags(BaseFlags):
             Returns an iterator of ``(name, value)`` pairs. This allows it
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
+
+            Adds two flags together.
+        .. describe:: x + y
+
+            Subtracts two flags from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two flags.
+        .. describe:: x & y
+
+            Returns the inverse of a flag.
+        .. describe:: ~x
+
 
     .. versionadded:: 1.4
 
@@ -489,6 +567,19 @@ class Intents(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
+
+            Adds two flags together.
+        .. describe:: x + y
+
+            Subtracts two flags from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two flags.
+        .. describe:: x & y
+
+            Returns the inverse of a flag.
+        .. describe:: ~x
+
 
     Attributes
     -----------
@@ -970,7 +1061,7 @@ class Intents(BaseFlags):
         - :meth:`Guild.get_scheduled_event`
         """
         return 1 << 16
-    
+
     @flag_value
     def auto_moderation_configuration(self):
         """:class:`bool`: Whether guild auto moderation configuration events are enabled.
@@ -982,7 +1073,7 @@ class Intents(BaseFlags):
         - :func:`on_auto_moderation_rule_delete`
         """
         return 1 << 20
-    
+
     @flag_value
     def auto_moderation_execution(self):
         """:class:`bool`: Whether guild auto moderation execution events are enabled.
@@ -1029,6 +1120,18 @@ class MemberCacheFlags(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
+
+            Adds two flags together.
+        .. describe:: x + y
+
+            Subtracts two flags from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two flags.
+        .. describe:: x & y
+
+            Returns the inverse of a flag.
+        .. describe:: ~x
 
     Attributes
     -----------
@@ -1155,6 +1258,18 @@ class ApplicationFlags(BaseFlags):
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
 
+            Adds two flags together.
+        .. describe:: x + y
+
+            Subtracts two flags from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two flags.
+        .. describe:: x & y
+
+            Returns the inverse of a flag.
+        .. describe:: ~x
+
     .. versionadded:: 2.0
 
     Attributes
@@ -1252,6 +1367,18 @@ class ChannelFlags(BaseFlags):
             Returns an iterator of ``(name, value)`` pairs. This allows it
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
+
+            Adds two flags together.
+        .. describe:: x + y
+
+            Subtracts two flags from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two flags.
+        .. describe:: x & y
+
+            Returns the inverse of a flag.
+        .. describe:: ~x
 
     .. versionadded:: 2.0
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -302,7 +302,7 @@ class MessageFlags(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
 
         .. describe:: x + y
-         Adds two flags together.
+        Adds two flags together.
 
         .. describe:: x - y
         Subtracts two flags from each other.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1258,7 +1258,7 @@ class ApplicationFlags(BaseFlags):
             Note that aliases are not shown.
 
         .. describe:: x + y
-         Adds two flags together.
+        Adds two flags together.
 
         .. describe:: x - y
         Subtracts two flags from each other.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1121,7 +1121,7 @@ class MemberCacheFlags(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
 
         .. describe:: x + y
-         Adds two flags together.
+        Adds two flags together.
 
         .. describe:: x - y
         Subtracts two flags from each other.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -36,10 +36,10 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    Union,
     overload,
 )
 
-import discord
 from .enums import UserFlags
 
 __all__ = (
@@ -174,10 +174,10 @@ class BaseFlags:
     def __invert__(self):
         return self.__class__._from_value(~self.value)
 
-    __rand__: Callable[[BaseFlags], bool] = __and__
-    __ror__: Callable[[BaseFlags], bool] = __or__
-    __radd__: Callable[[BaseFlags], bool] = __add__
-    __rsub__: Callable[[BaseFlags], bool] = __sub__
+    __rand__: Callable[[Union[BaseFlags, flag_value]], bool] = __and__
+    __ror__: Callable[[Union[BaseFlags, flag_value]], bool] = __or__
+    __radd__: Callable[[Union[BaseFlags, flag_value]], bool] = __add__
+    __rsub__: Callable[[Union[BaseFlags, flag_value]], bool] = __sub__
 
     def _has_flag(self, o: int) -> bool:
         return (self.value & o) == o
@@ -216,18 +216,17 @@ class SystemChannelFlags(BaseFlags):
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
 
-            Adds two flags together.
         .. describe:: x + y
+         Adds two flags together.
 
-            Subtracts two flags from each other.
         .. describe:: x - y
+        Subtracts two flags from each other.
 
-            Returns the intersection of two flags.
         .. describe:: x & y
+        Returns the intersection of two flags.
 
-            Returns the inverse of a flag.
         .. describe:: ~x
-
+        Returns the inverse of a flag.
 
     Attributes
     -----------
@@ -302,17 +301,17 @@ class MessageFlags(BaseFlags):
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
 
-            Adds two flags together.
         .. describe:: x + y
+         Adds two flags together.
 
-            Subtracts two flags from each other.
         .. describe:: x - y
+        Subtracts two flags from each other.
 
-            Returns the intersection of two flags.
         .. describe:: x & y
+        Returns the intersection of two flags.
 
-            Returns the inverse of a flags.
         .. describe:: ~x
+        Returns the inverse of a flag.
 
 
     .. versionadded:: 1.3
@@ -411,17 +410,17 @@ class PublicUserFlags(BaseFlags):
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
 
-            Adds two flags together.
         .. describe:: x + y
+         Adds two flags together.
 
-            Subtracts two flags from each other.
         .. describe:: x - y
+        Subtracts two flags from each other.
 
-            Returns the intersection of two flags.
         .. describe:: x & y
+        Returns the intersection of two flags.
 
-            Returns the inverse of a flag.
         .. describe:: ~x
+        Returns the inverse of a flag.
 
 
     .. versionadded:: 1.4
@@ -568,17 +567,17 @@ class Intents(BaseFlags):
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
 
-            Adds two flags together.
         .. describe:: x + y
+         Adds two flags together.
 
-            Subtracts two flags from each other.
         .. describe:: x - y
+        Subtracts two flags from each other.
 
-            Returns the intersection of two flags.
         .. describe:: x & y
+        Returns the intersection of two flags.
 
-            Returns the inverse of a flag.
         .. describe:: ~x
+        Returns the inverse of a flag.
 
 
     Attributes
@@ -1121,17 +1120,17 @@ class MemberCacheFlags(BaseFlags):
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
 
-            Adds two flags together.
         .. describe:: x + y
+         Adds two flags together.
 
-            Subtracts two flags from each other.
         .. describe:: x - y
+        Subtracts two flags from each other.
 
-            Returns the intersection of two flags.
         .. describe:: x & y
+        Returns the intersection of two flags.
 
-            Returns the inverse of a flag.
         .. describe:: ~x
+        Returns the inverse of a flag.
 
     Attributes
     -----------
@@ -1258,17 +1257,17 @@ class ApplicationFlags(BaseFlags):
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
 
-            Adds two flags together.
         .. describe:: x + y
+         Adds two flags together.
 
-            Subtracts two flags from each other.
         .. describe:: x - y
+        Subtracts two flags from each other.
 
-            Returns the intersection of two flags.
         .. describe:: x & y
+        Returns the intersection of two flags.
 
-            Returns the inverse of a flag.
         .. describe:: ~x
+        Returns the inverse of a flag.
 
     .. versionadded:: 2.0
 
@@ -1368,17 +1367,17 @@ class ChannelFlags(BaseFlags):
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
 
-            Adds two flags together.
         .. describe:: x + y
+         Adds two flags together.
 
-            Subtracts two flags from each other.
         .. describe:: x - y
+        Subtracts two flags from each other.
 
-            Returns the intersection of two flags.
         .. describe:: x & y
+        Returns the intersection of two flags.
 
-            Returns the inverse of a flag.
         .. describe:: ~x
+        Returns the inverse of a flag.
 
     .. versionadded:: 2.0
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -217,7 +217,7 @@ class SystemChannelFlags(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
 
         .. describe:: x + y
-         Adds two flags together.
+        Adds two flags together.
 
         .. describe:: x - y
         Subtracts two flags from each other.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -208,6 +208,21 @@ class SystemChannelFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -215,18 +230,6 @@ class SystemChannelFlags(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
-
-        .. describe:: x + y
-        Adds two flags together.
-
-        .. describe:: x - y
-        Subtracts two flags from each other.
-
-        .. describe:: x & y
-        Returns the intersection of two flags.
-
-        .. describe:: ~x
-        Returns the inverse of a flag.
 
     Attributes
     -----------
@@ -293,6 +296,21 @@ class MessageFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -300,19 +318,6 @@ class MessageFlags(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
-
-        .. describe:: x + y
-        Adds two flags together.
-
-        .. describe:: x - y
-        Subtracts two flags from each other.
-
-        .. describe:: x & y
-        Returns the intersection of two flags.
-
-        .. describe:: ~x
-        Returns the inverse of a flag.
-
 
     .. versionadded:: 1.3
 
@@ -401,6 +406,21 @@ class PublicUserFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two PublicUserFlags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
         .. describe:: hash(x)
 
             Return the flag's hash.
@@ -409,19 +429,6 @@ class PublicUserFlags(BaseFlags):
             Returns an iterator of ``(name, value)`` pairs. This allows it
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
-
-        .. describe:: x + y
-        Adds two flags together.
-
-        .. describe:: x - y
-        Subtracts two flags from each other.
-
-        .. describe:: x & y
-        Returns the intersection of two flags.
-
-        .. describe:: ~x
-        Returns the inverse of a flag.
-
 
     .. versionadded:: 1.4
 
@@ -559,6 +566,21 @@ class Intents(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -566,19 +588,6 @@ class Intents(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
-
-        .. describe:: x + y
-        Adds two flags together.
-
-        .. describe:: x - y
-        Subtracts two flags from each other.
-
-        .. describe:: x & y
-        Returns the intersection of two flags.
-
-        .. describe:: ~x
-        Returns the inverse of a flag.
-
 
     Attributes
     -----------
@@ -1112,6 +1121,21 @@ class MemberCacheFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -1119,18 +1143,6 @@ class MemberCacheFlags(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
-
-        .. describe:: x + y
-        Adds two flags together.
-
-        .. describe:: x - y
-        Subtracts two flags from each other.
-
-        .. describe:: x & y
-        Returns the intersection of two flags.
-
-        .. describe:: ~x
-        Returns the inverse of a flag.
 
     Attributes
     -----------
@@ -1248,6 +1260,21 @@ class ApplicationFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two ApplicationFlags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
         .. describe:: hash(x)
 
             Return the flag's hash.
@@ -1256,18 +1283,6 @@ class ApplicationFlags(BaseFlags):
             Returns an iterator of ``(name, value)`` pairs. This allows it
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
-
-        .. describe:: x + y
-        Adds two flags together.
-
-        .. describe:: x - y
-        Subtracts two flags from each other.
-
-        .. describe:: x & y
-        Returns the intersection of two flags.
-
-        .. describe:: ~x
-        Returns the inverse of a flag.
 
     .. versionadded:: 2.0
 
@@ -1358,6 +1373,21 @@ class ChannelFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two ChannelFlags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
         .. describe:: hash(x)
 
             Return the flag's hash.
@@ -1366,18 +1396,6 @@ class ChannelFlags(BaseFlags):
             Returns an iterator of ``(name, value)`` pairs. This allows it
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
-
-        .. describe:: x + y
-        Adds two flags together.
-
-        .. describe:: x - y
-        Subtracts two flags from each other.
-
-        .. describe:: x & y
-        Returns the intersection of two flags.
-
-        .. describe:: ~x
-        Returns the inverse of a flag.
 
     .. versionadded:: 2.0
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -411,7 +411,7 @@ class PublicUserFlags(BaseFlags):
             Note that aliases are not shown.
 
         .. describe:: x + y
-         Adds two flags together.
+        Adds two flags together.
 
         .. describe:: x - y
         Subtracts two flags from each other.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1368,7 +1368,7 @@ class ChannelFlags(BaseFlags):
             Note that aliases are not shown.
 
         .. describe:: x + y
-         Adds two flags together.
+        Adds two flags together.
 
         .. describe:: x - y
         Subtracts two flags from each other.

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -98,16 +98,20 @@ class Permissions(BaseFlags):
         .. describe:: x > y
 
         .. describe:: x + y
-        Adds two permissions together.
 
+            Adds two permissions together. Equivalent to ``x | y``.
         .. describe:: x - y
-        Subtracts two permissions from each other.
 
+            Subtracts two permissions from each other.
+        .. describe:: x | y
+
+            Returns the union of two permissions. Equivalent to ``x + y``.
         .. describe:: x & y
-        Returns the intersection of two permissions.
 
+            Returns the intersection of two permissions.
         .. describe:: ~x
-        Returns the inverse of a permission.
+
+            Returns the inverse of a permission.
 
              Checks if a permission is a strict superset of another permission.
         .. describe:: hash(x)

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -97,17 +97,17 @@ class Permissions(BaseFlags):
              Checks if a permission is a strict subset of another permission.
         .. describe:: x > y
 
-            Adds two permissions together.
-        .. describe:: x + y
+         .. describe:: x + y
+         Adds two permissions together.
 
-            Subtracts two permissions from each other.
         .. describe:: x - y
+        Subtracts two permissions from each other.
 
-            Returns the intersection of two permissions.
         .. describe:: x & y
+        Returns the intersection of two permissions.
 
-            Returns the inverse of a permission.
         .. describe:: ~x
+        Returns the inverse of a permission.
 
              Checks if a permission is a strict superset of another permission.
         .. describe:: hash(x)

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -166,8 +166,6 @@ class Permissions(BaseFlags):
     __lt__: Callable[[Permissions], bool] = is_strict_subset
     __gt__: Callable[[Permissions], bool] = is_strict_superset
 
-
-
     @classmethod
     def none(cls: Type[P]) -> P:
         """A factory method that creates a :class:`Permissions` with all

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -97,8 +97,8 @@ class Permissions(BaseFlags):
              Checks if a permission is a strict subset of another permission.
         .. describe:: x > y
 
-         .. describe:: x + y
-         Adds two permissions together.
+        .. describe:: x + y
+        Adds two permissions together.
 
         .. describe:: x - y
         Subtracts two permissions from each other.

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -161,51 +161,6 @@ class Permissions(BaseFlags):
         """Returns ``True`` if the permissions on other are a strict superset of those on self."""
         return self.is_superset(other) and self != other
 
-    def __and__(self, other):
-        if isinstance(other, Permissions):
-            return self.__class__(self.value & other.value)
-        elif isinstance(other, flag_value):
-            return self.__class__(self.value & other.flag)
-        elif isinstance(other, int):
-            return self.__class__(self.value & other)
-        else:
-            raise TypeError(f"'&' not supported between instances of '{type(self)}' and '{type(other)}'")
-
-    def __or__(self, other):
-        if isinstance(other, Permissions):
-            return self.__class__(self.value | other.value)
-        elif isinstance(other, flag_value):
-            return self.__class__(self.value | other.flag)
-        elif isinstance(other, int):
-            return self.__class__(self.value | other)
-        else:
-            raise TypeError(f"'|' not supported between instances of '{type(self)}' and '{type(other)}'")
-
-    def __add__(self, other):
-        try:
-            return self | other
-        except TypeError:
-            raise TypeError(f"'+' not supported between instances of '{type(self)}' and '{type(other)}'")
-
-    def __sub__(self, other):
-        try:
-            if isinstance(other, Permissions or int):
-                return self & ~other
-            elif isinstance(other, flag_value):
-                return self & ~other.flag
-        except TypeError:
-            raise TypeError(f"'-' not supported between instances of '{type(self)}' and '{type(other)}'")
-
-    def __invert__(self):
-        if isinstance(self, Permissions):
-            return self.__class__(~self.value)
-        else:
-            raise TypeError(f"'~' not supported for '{type(self)}'")
-
-    __rand__ = __and__
-    __ror__ = __or__
-    __radd__ = __add__
-    __rsub__ = __sub__
     __le__: Callable[[Permissions], bool] = is_subset
     __ge__: Callable[[Permissions], bool] = is_superset
     __lt__: Callable[[Permissions], bool] = is_strict_subset

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -97,6 +97,18 @@ class Permissions(BaseFlags):
              Checks if a permission is a strict subset of another permission.
         .. describe:: x > y
 
+            Adds two permissions together.
+        .. describe:: x + y
+
+            Subtracts two permissions from each other.
+        .. describe:: x - y
+
+            Returns the intersection of two permissions.
+        .. describe:: x & y
+
+            Returns the inverse of a permission.
+        .. describe:: ~x
+
              Checks if a permission is a strict superset of another permission.
         .. describe:: hash(x)
 
@@ -149,10 +161,57 @@ class Permissions(BaseFlags):
         """Returns ``True`` if the permissions on other are a strict superset of those on self."""
         return self.is_superset(other) and self != other
 
+    def __and__(self, other):
+        if isinstance(other, Permissions):
+            return self.__class__(self.value & other.value)
+        elif isinstance(other, flag_value):
+            return self.__class__(self.value & other.flag)
+        elif isinstance(other, int):
+            return self.__class__(self.value & other)
+        else:
+            raise TypeError(f"'&' not supported between instances of '{type(self)}' and '{type(other)}'")
+
+    def __or__(self, other):
+        if isinstance(other, Permissions):
+            return self.__class__(self.value | other.value)
+        elif isinstance(other, flag_value):
+            return self.__class__(self.value | other.flag)
+        elif isinstance(other, int):
+            return self.__class__(self.value | other)
+        else:
+            raise TypeError(f"'|' not supported between instances of '{type(self)}' and '{type(other)}'")
+
+    def __add__(self, other):
+        try:
+            return self.__or__(other)
+        except TypeError:
+            raise TypeError(f"'+' not supported between instances of '{type(self)}' and '{type(other)}'")
+
+    def __sub__(self, other):
+        try:
+            if isinstance(other, Permissions or int):
+                return self.__and__(~other)
+            elif isinstance(other, flag_value):
+                return self.__and__(~other.flag)
+        except TypeError:
+            raise TypeError(f"'-' not supported between instances of '{type(self)}' and '{type(other)}'")
+
+    def __invert__(self):
+        if isinstance(self, Permissions):
+            return self.__class__(~self.value)
+        else:
+            raise TypeError(f"'~' not supported for '{type(self)}'")
+
+    __rand__ = __and__
+    __ror__ = __or__
+    __radd__ = __add__
+    __rsub__ = __sub__
     __le__: Callable[[Permissions], bool] = is_subset
     __ge__: Callable[[Permissions], bool] = is_superset
     __lt__: Callable[[Permissions], bool] = is_strict_subset
     __gt__: Callable[[Permissions], bool] = is_strict_superset
+
+
 
     @classmethod
     def none(cls: Type[P]) -> P:

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -183,16 +183,16 @@ class Permissions(BaseFlags):
 
     def __add__(self, other):
         try:
-            return self.__or__(other)
+            return self | other
         except TypeError:
             raise TypeError(f"'+' not supported between instances of '{type(self)}' and '{type(other)}'")
 
     def __sub__(self, other):
         try:
             if isinstance(other, Permissions or int):
-                return self.__and__(~other)
+                return self & ~other
             elif isinstance(other, flag_value):
-                return self.__and__(~other.flag)
+                return self & ~other.flag
         except TypeError:
             raise TypeError(f"'-' not supported between instances of '{type(self)}' and '{type(other)}'")
 


### PR DESCRIPTION
## Summary

This pull request implements addition (+), subtraction (-), union (|), intersection (&), and inversion (~) operations on the `BaseFlags` class and accordingly updates the documentation for its inheritors. The addition and union operations are equivalent and their operators interchangeable.

I made this change with the `Permissions` class in mind, intending to enable functionality such as adding two `Permissions` objects together to obtain the combined set of permissions they represent; subtracting two `Permissions` objects to set all permissions that are `True` in one object to `False` in the other; finding the intersection of two `Permissions` objects to obtain the set of permissions that are `True` in both; and inverting a `Permissions` object to set all of its `True` permissions to `False` and vice versa. However, this PR enables these operations on _all_ inheritors of `BaseFlags` - the previously-described actions could be similarly applied to objects of the `Intents` class, for example. 

The addition, subtraction, union, and intersection operations can operate on a `BaseFlags` object and a) another `BaseFlags` object, or b) a `flag_value` object. Reverse methods for each of these operations are also implemented, allowing operations between `BaseFlags` and `flag_value` objects to be properly commutative.

## Information

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
