### PR TITLE
Set store=False as default in load_extension(s)

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -748,7 +748,7 @@ class CogMixin:
         *,
         package: Optional[str] = None,
         recursive: bool = False,
-        store: bool = True,
+        store: bool = False,
     ) -> Optional[Union[Dict[str, Union[Exception, bool]], List[str]]]:
         """Loads an extension.
 
@@ -788,7 +788,7 @@ class CogMixin:
             encountered they will be raised and the bot will be closed.
             If no exceptions are encountered, a list of loaded
             extension names will be returned.
-            Defaults to ``True``.
+            Defaults to ``False``.
 
             .. versionadded:: 2.0
 
@@ -863,7 +863,7 @@ class CogMixin:
         *names: str,
         package: Optional[str] = None,
         recursive: bool = False,
-        store: bool = True,
+        store: bool = False,
     ) -> Optional[Union[Dict[str, Union[Exception, bool]], List[str]]]:
         """Loads multiple extensions at once.
 
@@ -896,7 +896,7 @@ class CogMixin:
             encountered they will be raised and the bot will be closed.
             If no exceptions are encountered, a list of loaded
             extension names will be returned.
-            Defaults to ``True``.
+            Defaults to ``False``.
 
             .. versionadded:: 2.0
 


### PR DESCRIPTION
Makes `store=False` the default in `load_extension`/`load_extensions`, which keeps the behaviour inline with previous versions.

## Summary

With #1423, extension loading was reworked to allow loading entire folders at once. This is a very convenient addition, however it introduced the `store` kwarg which decides whether `load_extension` will raise an error or not if a cog fails to load. 

In the past `load_extension` has always raised an error when this happens, however with this PR the default has been set as `store=True`, which instead stores the error in a dict for the user to parse themselves. While this *technically* isn't a breaking change since it still functions, the behaviour is different enough from before to cause confusion with users who updated: without setting the `store` kwarg, cogs that have errors will appear to load correctly if you haven't accounted for the change. Neither was this change made note of at all in any update notes.

As such, I believe it'd be more appropriate for `store=False` to be the default to be inline with previous behaviorr.


## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
