### PR TITLE
Update content retrieval from AutoModActionExecution

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -461,7 +461,7 @@ class AutoModActionExecutionEvent:
         self.user_id: int = int(data["user_id"])
         self.content: Optional[str] = data.get("content", None)
         self.matched_keyword: str = data["matched_keyword"]
-        self.matched_content: str = data.get("matched_content", None)
+        self.matched_content: Optional[str] = data.get("matched_content", None)
         
         if self.guild:
             self.member: Optional[Member] = self.guild.get_member(self.user_id)

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -459,7 +459,7 @@ class AutoModActionExecutionEvent:
         self.guild_id: int = int(data["guild_id"])
         self.guild: Optional[Guild] = state._get_guild(self.guild_id)
         self.user_id: int = int(data["user_id"])
-        self.content: str = data.get("content", None)
+        self.content: Optional[str] = data.get("content", None)
         self.matched_keyword: str = data["matched_keyword"]
         self.matched_content: str = data.get("matched_content", None)
         

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -459,9 +459,9 @@ class AutoModActionExecutionEvent:
         self.guild_id: int = int(data["guild_id"])
         self.guild: Optional[Guild] = state._get_guild(self.guild_id)
         self.user_id: int = int(data["user_id"])
-        self.content: str = data["content"]
+        self.content: str = data.get("content", None)
         self.matched_keyword: str = data["matched_keyword"]
-        self.matched_content: str = data["matched_content"]
+        self.matched_content: str = data.get("matched_content", None)
         
         if self.guild:
             self.member: Optional[Member] = self.guild.get_member(self.user_id)


### PR DESCRIPTION
Update to fix `data["content"]` raising a KeyError for Automod Events when the bot [lacks the Message Content intent](https://discord.com/developers/docs/change-log#jun-21-2022).

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
