### PR TITLE
Add overloads to load_extension(s)

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -43,6 +43,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    overload,
 )
 
 import discord.utils
@@ -754,6 +755,17 @@ class CogMixin:
         except ImportError:
             raise errors.ExtensionNotFound(name)
 
+    @overload
+    def load_extension(
+        self,
+        name: str,
+        *,
+        package: Optional[str] = None,
+        recursive: bool = False,
+    ) -> List[str]:
+        ...
+
+    @overload
     def load_extension(
         self,
         name: str,
@@ -761,6 +773,11 @@ class CogMixin:
         package: Optional[str] = None,
         recursive: bool = False,
         store: bool = False,
+    ) -> Optional[Union[Dict[str, Union[Exception, bool]], List[str]]]:
+        ...
+
+    def load_extension(
+        self, name, *, package = None, recursive = False, store = False
     ) -> Optional[Union[Dict[str, Union[Exception, bool]], List[str]]]:
         """Loads an extension.
 
@@ -870,12 +887,27 @@ class CogMixin:
         else:
             return final_out
 
+    @overload
+    def load_extensions(
+        self,
+        *names: str,
+        package: Optional[str] = None,
+        recursive: bool = False,
+    ) -> List[str]:
+        ...
+
+    @overload
     def load_extensions(
         self,
         *names: str,
         package: Optional[str] = None,
         recursive: bool = False,
         store: bool = False,
+    ) -> Optional[Union[Dict[str, Union[Exception, bool]], List[str]]]:
+        ...
+
+    def load_extensions(
+        self, *names, package = None, recursive = False, store = False
     ) -> Optional[Union[Dict[str, Union[Exception, bool]], List[str]]]:
         """Loads multiple extensions at once.
 


### PR DESCRIPTION
## Summary
Adds overload typehints to `load_extension` and `load_extensions` to make it easier for users to understand that leaving the `store` parameter will result in a list.

## Information
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
