### PR TITLE
Adjust category and guild _channels attributes to work with NoneType positions

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2094,7 +2094,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         """
 
         def comparator(channel):
-            return not isinstance(channel, _TextChannel), channel.position
+            return not isinstance(channel, _TextChannel), (channel.position or -1)
 
         ret = [c for c in self.guild.channels if c.category_id == self.id]
         ret.sort(key=comparator)
@@ -2104,14 +2104,14 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
     def text_channels(self) -> List[TextChannel]:
         """List[:class:`TextChannel`]: Returns the text channels that are under this category."""
         ret = [c for c in self.guild.channels if c.category_id == self.id and isinstance(c, TextChannel)]
-        ret.sort(key=lambda c: (c.position, c.id))
+        ret.sort(key=lambda c: (c.position or -1, c.id))
         return ret
 
     @property
     def voice_channels(self) -> List[VoiceChannel]:
         """List[:class:`VoiceChannel`]: Returns the voice channels that are under this category."""
         ret = [c for c in self.guild.channels if c.category_id == self.id and isinstance(c, VoiceChannel)]
-        ret.sort(key=lambda c: (c.position, c.id))
+        ret.sort(key=lambda c: (c.position or -1, c.id))
         return ret
 
     @property
@@ -2121,7 +2121,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         .. versionadded:: 1.7
         """
         ret = [c for c in self.guild.channels if c.category_id == self.id and isinstance(c, StageChannel)]
-        ret.sort(key=lambda c: (c.position, c.id))
+        ret.sort(key=lambda c: (c.position or -1, c.id))
         return ret
 
     @property
@@ -2131,7 +2131,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         .. versionadded:: 2.0
         """
         ret = [c for c in self.guild.channels if c.category_id == self.id and isinstance(c, ForumChannel)]
-        ret.sort(key=lambda c: (c.position, c.id))
+        ret.sort(key=lambda c: (c.position or -1, c.id))
         return ret
 
     async def create_text_channel(self, name: str, **options: Any) -> TextChannel:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -620,7 +620,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, VoiceChannel)]
-        r.sort(key=lambda c: (c.position, c.id))
+        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
         return r
 
     @property
@@ -632,7 +632,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, StageChannel)]
-        r.sort(key=lambda c: (c.position, c.id))
+        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
         return r
 
     @property
@@ -644,7 +644,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, ForumChannel)]
-        r.sort(key=lambda c: (c.position, c.id))
+        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
         return r
 
     @property
@@ -668,7 +668,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, TextChannel)]
-        r.sort(key=lambda c: (c.position, c.id))
+        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
         return r
 
     @property
@@ -678,7 +678,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, CategoryChannel)]
-        r.sort(key=lambda c: (c.position, c.id))
+        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
         return r
 
     def by_category(self) -> List[ByCategoryItem]:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -620,7 +620,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, VoiceChannel)]
-        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
+        r.sort(key=lambda c: (c.position or -1, c.id))
         return r
 
     @property
@@ -632,7 +632,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, StageChannel)]
-        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
+        r.sort(key=lambda c: (c.position or -1, c.id))
         return r
 
     @property
@@ -644,7 +644,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, ForumChannel)]
-        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
+        r.sort(key=lambda c: (c.position or -1, c.id))
         return r
 
     @property
@@ -668,7 +668,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, TextChannel)]
-        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
+        r.sort(key=lambda c: (c.position or -1, c.id))
         return r
 
     @property
@@ -678,7 +678,7 @@ class Guild(Hashable):
         This is sorted by the position and are in UI order from top to bottom.
         """
         r = [ch for ch in self._channels.values() if isinstance(ch, CategoryChannel)]
-        r.sort(key=lambda c: (c.position or len(self._channels), c.id))
+        r.sort(key=lambda c: (c.position or -1, c.id))
         return r
 
     def by_category(self) -> List[ByCategoryItem]:
@@ -707,13 +707,13 @@ class Guild(Hashable):
 
         def key(t: ByCategoryItem) -> Tuple[Tuple[int, int], List[GuildChannel]]:
             k, v = t
-            return (k.position, k.id) if k else (-1, -1), v
+            return (k.position or -1, k.id) if k else (-1, -1), v
 
         _get = self._channels.get
         as_list: List[ByCategoryItem] = [(_get(k), v) for k, v in grouped.items()]  # type: ignore
         as_list.sort(key=key)
         for _, channels in as_list:
-            channels.sort(key=lambda c: (c._sorting_bucket, c.position, c.id))
+            channels.sort(key=lambda c: (c._sorting_bucket, c.position or -1, c.id))
         return as_list
 
     def _resolve_channel(self, id: Optional[int], /) -> Optional[Union[GuildChannel, Thread]]:


### PR DESCRIPTION
## Summary

Adapts guild/category _channels attributes (text_channels, voice_channels etc.) to work correctly with Optional positions.
Currently when grabbing a list of a guild's or a category's channels, the library attempts to sort them by position to output them in their UI order: 
```py
r.sort(key=lambda c: (c.position, c.id))
```
This worked fine when we just had TextChannel and VoiceChannel because `position` under `abc.GuildChannel` was required, but since 2.0 with new channel types and interaction payloads `position` has been made optional for all channel types; since `position` can now be None, this sort breaks with `TypeError: '<' not supported between instances of 'NoneType' and 'int'`.

The solution i've applied is to assume the channel's position is -1 if `position = None`, so it will order as much as possible; other solutions could be to try-except, completely give up on sorting, or to make -1 the default instead of None (achieving the same result, but perhaps with a knock-on effect elsewhere in the library).

I went with -1 since this was actually already present in `Guild.by_category()`, where it's assumed ID and position are -1 if it runs into a NoneType category. Alternatively, it could be a large number to assume the position is last instead of first.
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
