### PR TITLE
Tiny improvement relating to an example for slash commands

### DIFF
--- a/examples/app_commands/slash_basic.py
+++ b/examples/app_commands/slash_basic.py
@@ -21,9 +21,9 @@ bot = discord.Bot(intents=intents)
 async def hello(ctx: discord.ApplicationContext):
     """Say hello to the bot"""  # The command description can be supplied as the docstring
     await ctx.respond(f"Hello {ctx.author}!")
-    # Please note that you MUST respond with ctx.respond(), ctx.defer(), or any other
-    # interaction response within 3 seconds in your slash command code, otherwise the
-    # interaction will fail.
+    # Note: interactions must be responded to within 3 seconds, if they're not, an
+    # "Unknown interaction" error will be raised, you can circumvent this by using "ctx.defer()".
+    # Additional note: You cannot respond to the same interaction twice!
 
 
 @bot.slash_command(name="hi")


### PR DESCRIPTION
## Summary

Currently the slash command example is really wordy, and doesn't mention in inability to respond twice,
this PR aims to help clear up how ctx.defer is used, and also mentions the aforementioned limitation of responding twice.

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
