### PR TITLE
Fix Enum options breaking again & wrong typing import

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -169,6 +169,7 @@ class Option:
         if self.name is not None:
             self.name = str(self.name)
         self._parameter_name = self.name  # default
+        self._raw_type: Union[InputType, tuple] = input_type
 
         enum_choices = []
         input_type_is_class = isinstance(input_type, type)
@@ -177,13 +178,12 @@ class Option:
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__
             if all(isinstance(elem.value, value_class) for elem in enum_choices):
-                self.input_type = SlashCommandOptionType.from_datatype(enum_choices[0].value.__class__)
+                input_type = SlashCommandOptionType.from_datatype(enum_choices[0].value.__class__)
             else:
                 enum_choices = [OptionChoice(e.name, str(e.value)) for e in input_type]
-                self.input_type = SlashCommandOptionType.string
-        self.description = description or "No description provided"
+                input_type = SlashCommandOptionType.string
 
-        self._raw_type: Union[InputType, tuple] = input_type
+        self.description = description or "No description provided"
         self.channel_types: List[ChannelType] = kwargs.pop("channel_types", [])
 
         if isinstance(input_type, SlashCommandOptionType):

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -43,6 +43,7 @@ import aiohttp
 
 from .backoff import ExponentialBackoff
 from .client import Client
+from .enums import Status
 from .errors import (
     ClientException,
     ConnectionClosed,
@@ -55,7 +56,6 @@ from .state import AutoShardedConnectionState
 
 if TYPE_CHECKING:
     from .activity import BaseActivity
-    from .enums import Status
     from .gateway import DiscordWebSocket
 
     EI = TypeVar("EI", bound="EventItem")


### PR DESCRIPTION
## Summary
Fixes enum options breaking because of `from_datatype`

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
