### PR TITLE
Fix threads made from messages breaking

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -760,7 +760,7 @@ class Message(Hashable):
                     if ref.channel_id == channel.id:
                         chan = channel
                     else:
-                        chan, _ = state._get_guild_channel(resolved)
+                        chan, _ = state._get_guild_channel(resolved, guild_id=self.guild.id)
 
                     # the channel will be the correct type here
                     ref.resolved = self.__class__(channel=chan, data=resolved, state=state)  # type: ignore

--- a/discord/state.py
+++ b/discord/state.py
@@ -476,10 +476,10 @@ class ConnectionState:
         # If presences are enabled then we get back the old guild.large behaviour
         return self._chunk_guilds and not guild.chunked and not (self._intents.presences and not guild.large)
 
-    def _get_guild_channel(self, data: MessagePayload) -> Tuple[Union[Channel, Thread], Optional[Guild]]:
+    def _get_guild_channel(self, data: MessagePayload, guild_id: Optional[int] = None) -> Tuple[Union[Channel, Thread], Optional[Guild]]:
         channel_id = int(data["channel_id"])
         try:
-            guild = self._get_guild(int(data["guild_id"]))
+            guild = self._get_guild(int(guild_id or data["guild_id"]))
         except KeyError:
             channel = DMChannel._from_message(self, channel_id)
             guild = None


### PR DESCRIPTION
## Summary
Messages sent when creating a thread of another message have the message_reference set to the original message, and so breaking everything. (https://github.com/Pycord-Development/pycord/issues/1491#issuecomment-1207431443 has more information)

Fix #1491 

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.