### PR TITLE
Add set_mfa_required method

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1552,7 +1552,7 @@ class Guild(Hashable):
             via :meth:`delete`.
 
         Raises
-        --------
+        -------
         HTTPException
             Leaving the guild failed.
         """
@@ -1565,14 +1565,35 @@ class Guild(Hashable):
         guild.
 
         Raises
-        --------
+        -------
         HTTPException
             Deleting the guild failed.
         Forbidden
             You do not have permissions to delete the guild.
         """
-
         await self._state.http.delete_guild(self.id)
+
+    async def set_mfa_required(self, toggle: bool, *, reason: str = None):
+        """|coro|
+        
+        Set whether it is required to have MFA enabled on your account
+        to perform moderation actions. You must be the guild owner to do this.
+
+        Parameters
+        -----------
+        toggle: :class:`bool`
+            Whether or not it should be required.
+        reason: :class:`str`
+            The reason to show up in the audit log.
+
+        Raises
+        -------
+        HTTPException
+            The operation failed.
+        Forbidden
+            You are not the owner of the guild.
+        """
+        await self._state.http.edit_guild_mfa(self.id, toggle, reason=reason)
 
     async def edit(
         self,

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1573,7 +1573,7 @@ class Guild(Hashable):
         """
         await self._state.http.delete_guild(self.id)
 
-    async def set_mfa_required(self, toggle: bool, *, reason: str = None):
+    async def set_mfa_required(self, required: bool, *, reason: str = None) -> None:
         """|coro|
         
         Set whether it is required to have MFA enabled on your account
@@ -1581,8 +1581,8 @@ class Guild(Hashable):
 
         Parameters
         -----------
-        toggle: :class:`bool`
-            Whether it should be required.
+        required: :class:`bool`
+            Whether MFA should be required to perform moderation actions.
         reason: :class:`str`
             The reason to show up in the audit log.
 
@@ -1593,7 +1593,7 @@ class Guild(Hashable):
         Forbidden
             You are not the owner of the guild.
         """
-        await self._state.http.edit_guild_mfa(self.id, toggle, reason=reason)
+        await self._state.http.edit_guild_mfa(self.id, required, reason=reason)
 
     async def edit(
         self,

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1582,7 +1582,7 @@ class Guild(Hashable):
         Parameters
         -----------
         toggle: :class:`bool`
-            Whether or not it should be required.
+            Whether it should be required.
         reason: :class:`str`
             The reason to show up in the audit log.
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1334,10 +1334,10 @@ class HTTPClient:
             reason=reason,
         )
 
-    def edit_guild_mfa(self, guild_id: Snowflake, toggle: bool, *, reason: Optional[str]) -> Response[guild.GuildMFAModify]:
+    def edit_guild_mfa(self, guild_id: Snowflake, required: bool, *, reason: Optional[str]) -> Response[guild.GuildMFAModify]:
         return self.request(
             Route("POST", "/guilds/{guild_id}/mfa", guild_id=guild_id),
-            json={"level": int(toggle)},
+            json={"level": int(required)},
             reason=reason
         )
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1334,6 +1334,13 @@ class HTTPClient:
             reason=reason,
         )
 
+    def edit_guild_mfa(self, guild_id: Snowflake, toggle: bool, *, reason: Optional[str]) -> Response[guild.GuildMFAModify]:
+        return self.request(
+            Route("POST", "/guilds/{guild_id}/mfa", guild_id=guild_id),
+            json={"level": int(toggle)},
+            reason=reason
+        )
+
     def get_template(self, code: str) -> Response[template.Template]:
         return self.request(Route("GET", "/guilds/templates/{code}", code=code))
 

--- a/discord/types/guild.py
+++ b/discord/types/guild.py
@@ -183,3 +183,7 @@ class _RolePositionRequired(TypedDict):
 
 class RolePositionUpdate(_RolePositionRequired, total=False):
     position: Optional[Snowflake]
+
+
+class GuildMFAModify(TypedDict):
+    level: Literal[0, 1]


### PR DESCRIPTION
## Summary
Add method that can edit the guild mfa requirements

[docs](https://discord.com/developers/docs/resources/guild#modify-guild-mfa-level)
[discord-api-docs#5072](https://github.com/discord/discord-api-docs/pull/5072)

## Information

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.