### PR TITLE
Correct location of app_commands_badge flag

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1365,7 +1365,7 @@ class ApplicationFlags(BaseFlags):
 
     @flag_value
     def app_commands_badge(self):
-        """:class:`bool`: Returns ``True`` if the application has at least one registered application
+        """:class:`bool`: Returns ``True`` if the application has registered at least one global application
         command, and by extension has the badge.
 
         .. versionadded:: 2.1

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -282,15 +282,6 @@ class SystemChannelFlags(BaseFlags):
         """
         return 8
 
-    @flag_value
-    def app_commands_badge(self):
-        """:class:`bool`: Returns ``True`` if the application has registered a global application
-        command. This shows up as a badge in the bot's profile.
-
-         .. versionadded:: 2.1
-        """
-        return 1 << 23
-
 
 @fill_with_flags()
 class MessageFlags(BaseFlags):
@@ -1376,6 +1367,8 @@ class ApplicationFlags(BaseFlags):
     def application_command_badge(self):
         """:class:`bool`: Returns ``True`` if the application has at least one registered application
         command, and by extension has the badge.
+
+        .. versionadded:: 2.1
         """
         return 1 << 23
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1364,7 +1364,7 @@ class ApplicationFlags(BaseFlags):
         return 1 << 19
 
     @flag_value
-    def application_command_badge(self):
+    def app_commands_badge(self):
         """:class:`bool`: Returns ``True`` if the application has at least one registered application
         command, and by extension has the badge.
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1372,6 +1372,13 @@ class ApplicationFlags(BaseFlags):
         """
         return 1 << 19
 
+    @flag_value
+    def application_command_badge(self):
+        """:class:`bool`: Returns ``True`` if the application has at least one registered application
+        command, and by extension has the badge.
+        """
+        return 1 << 23
+
 
 @fill_with_flags()
 class ChannelFlags(BaseFlags):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -216,6 +216,7 @@ class Guild(Hashable):
         - ``HUB``: Hubs contain a directory channel that let you find school-related,
                    student-run servers for your school or university.
         - ``INTERNAL_EMPLOYEE_ONLY``: Indicates that only users with the staff badge can join the guild.
+        - ``INVITES_DISABLED``: Guild's invites have been temporarily disabled.
         - ``INVITE_SPLASH``: Guild's invite page can have a special splash.
         - ``LINKED_TO_HUB``: 'Guild is linked to a hub.
         - ``MEMBER_PROFILES``: Unknown.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -216,7 +216,6 @@ class Guild(Hashable):
         - ``HUB``: Hubs contain a directory channel that let you find school-related,
                    student-run servers for your school or university.
         - ``INTERNAL_EMPLOYEE_ONLY``: Indicates that only users with the staff badge can join the guild.
-        - ``INVITES_DISABLED``: Guild's invites have been temporarily disabled.
         - ``INVITE_SPLASH``: Guild's invite page can have a special splash.
         - ``LINKED_TO_HUB``: 'Guild is linked to a hub.
         - ``MEMBER_PROFILES``: Unknown.


### PR DESCRIPTION
## Summary
Moves `app_commands_badge` from `SystemChannelFlags` to `ApplicationFlags` . (#1535)

Reference: [discord-api-docs#5222](https://github.com/discord/discord-api-docs/pull/5222)

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.