### PR TITLE
customize websocket properties

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -229,6 +229,7 @@ class Client:
         self._listeners: Dict[str, List[Tuple[asyncio.Future, Callable[..., bool]]]] = {}
         self.shard_id: Optional[int] = options.get("shard_id")
         self.shard_count: Optional[int] = options.get("shard_count")
+        self.ws_properties: Dict[str, str] = options.get("ws_properties", {})
 
         connector: Optional[aiohttp.BaseConnector] = options.pop("connector", None)
         proxy: Optional[str] = options.pop("proxy", None)

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -335,6 +335,7 @@ class DiscordWebSocket:
         ws._connection = client._connection
         ws._discord_parsers = client._connection.parsers
         ws._dispatch = client.dispatch
+        ws._properties = client.ws_properties
         ws.gateway = gateway
         ws.call_hooks = client._connection.call_hooks
         ws._initial_identify = initial
@@ -404,6 +405,8 @@ class DiscordWebSocket:
                 "v": 3,
             },
         }
+
+        payload["d"]["properties"].update(self._properties)
 
         if self.shard_id is not None and self.shard_count is not None:
             payload["d"]["shard"] = [self.shard_id, self.shard_count]


### PR DESCRIPTION
## Summary

This PR allows to pass your own properties when sending websocket identify.
Example: `client = discord.Client(ws_properties={"browser": "Discord Android"})`

## Information

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
