### PR TITLE
Changed styling for most of the examples.

### DIFF
--- a/examples/deleted.py
+++ b/examples/deleted.py
@@ -1,28 +1,33 @@
-# This example requires the `message_content` privileged intent for access to message content.
-
 import discord
 
-
-class MyClient(discord.Client):
-    async def on_ready(self):
-        print(f"Logged in as {self.user} (ID: {self.user.id})")
-        print("------")
-
-    async def on_message(self, message: discord.Message):
-        if message.content.startswith("!deleteme"):
-            msg = await message.channel.send("I will delete myself now...")
-            await msg.delete()
-
-            # This also works:
-            await message.channel.send("Goodbye in 3 seconds...", delete_after=3.0)
-
-    async def on_message_delete(self, message: discord.Message):
-        msg = f"{message.author} has deleted the message: {message.content}"
-        await message.channel.send(msg)
-
-
 intents = discord.Intents.default()
-intents.message_content = True
+intents.message_content = True  # < This may give you `read-only` warning, just ignore it.
+# This intent requires "Message Content Intent" to be enabled at https://discord.com/developers
 
-client = MyClient(intents=intents)
-client.run("TOKEN")
+
+bot = discord.Bot(intents=intents)
+
+
+@bot.event
+async def on_ready():
+    print('Ready!')
+
+
+@bot.event
+async def on_message(message: discord.Message):
+    if message.content.startswith("!deleteme"):
+        msg = await message.channel.send("I will delete myself now...")
+        await msg.delete()
+
+        # This also works:
+        await message.channel.send("Goodbye in 3 seconds...", delete_after=3.0)
+
+
+@bot.event
+async def on_message_delete(message: discord.Message):
+    msg = f"{message.author} has deleted the message: {message.content}"
+    await message.channel.send(msg)
+
+
+bot.run("TOKEN")
+

--- a/examples/edits.py
+++ b/examples/edits.py
@@ -1,28 +1,31 @@
-# This example requires the `message_content` privileged intent for access to message content.
-
+import discord
 import asyncio
 
-import discord
-
-
-class MyClient(discord.Client):
-    async def on_ready(self):
-        print(f"Logged in as {self.user} (ID: {self.user.id})")
-        print("------")
-
-    async def on_message(self, message: discord.Message):
-        if message.content.startswith("!editme"):
-            msg = await message.channel.send("10")
-            await asyncio.sleep(3.0)
-            await msg.edit(content="40")
-
-    async def on_message_edit(self, before: discord.Message, after: discord.Message):
-        msg = f"**{before.author}** edited their message:\n{before.content} -> {after.content}"
-        await before.channel.send(msg)
-
-
 intents = discord.Intents.default()
-intents.message_content = True
+intents.message_content = True  # < This may give you `read-only` warning, just ignore it.
+# This intent requires "Message Content Intent" to be enabled at https://discord.com/developers
 
-client = MyClient(intents=intents)
-client.run("TOKEN")
+
+bot = discord.Bot(intents=intents)
+
+
+@bot.event
+async def on_ready():
+    print('Ready!')
+
+
+@bot.event
+async def on_message(message: discord.Message):
+    if message.content.startswith("!editme"):
+        msg = await message.channel.send("10")
+        await asyncio.sleep(3.0)
+        await msg.edit(content="40")
+
+
+@bot.event
+async def on_message_edit(before: discord.Message, after: discord.Message):
+    msg = f"**{before.author}** edited their message:\n{before.content} -> {after.content}"
+    await before.channel.send(msg)
+
+
+bot.run("TOKEN")

--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -1,87 +1,94 @@
-# This example requires the 'members' privileged intent for access to .get_member.
-
 import discord
-
-
-class MyClient(discord.Client):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.role_message_id = 0  # ID of the message that can be reacted to for adding/removing a role.
-        self.emoji_to_role = {
-            discord.PartialEmoji(name="🔴"): 0,  # ID of the role associated with unicode emoji '🔴'.
-            discord.PartialEmoji(name="🟡"): 0,  # ID of the role associated with unicode emoji '🟡'.
-            discord.PartialEmoji(name="green", id=0): 0,  # ID of the role associated with a partial emoji's ID.
-        }
-
-    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
-        """Gives a role based on a reaction emoji."""
-        # Make sure that the message the user is reacting to is the one we care about.
-        if payload.message_id != self.role_message_id:
-            return
-
-        guild = self.get_guild(payload.guild_id)
-        if guild is None:
-            # Make sure we're still in the guild, and it's cached.
-            return
-
-        try:
-            role_id = self.emoji_to_role[payload.emoji]
-        except KeyError:
-            # If the emoji isn't the one we care about then exit as well.
-            return
-
-        role = guild.get_role(role_id)
-        if role is None:
-            # Make sure the role still exists and is valid.
-            return
-
-        try:
-            # Finally, add the role.
-            await payload.member.add_roles(role)
-        except discord.HTTPException:
-            # If we want to do something in case of errors we'd do it here.
-            pass
-
-    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
-        """Removes a role based on a reaction emoji."""
-        # Make sure that the message the user is reacting to is the one we care about.
-        if payload.message_id != self.role_message_id:
-            return
-
-        guild = self.get_guild(payload.guild_id)
-        if guild is None:
-            # Make sure we're still in the guild, and it's cached.
-            return
-
-        try:
-            role_id = self.emoji_to_role[payload.emoji]
-        except KeyError:
-            # If the emoji isn't the one we care about then exit as well.
-            return
-
-        role = guild.get_role(role_id)
-        if role is None:
-            # Make sure the role still exists and is valid.
-            return
-
-        # The payload for `on_raw_reaction_remove` does not provide `.member`
-        # so we must get the member ourselves from the payload's `.user_id`.
-        member = guild.get_member(payload.user_id)
-        if member is None:
-            # Make sure the member still exists and is valid.
-            return
-
-        try:
-            # Finally, remove the role.
-            await member.remove_roles(role)
-        except discord.HTTPException:
-            # If we want to do something in case of errors we'd do it here.
-            pass
-
+import asyncio
 
 intents = discord.Intents.default()
-intents.members = True
+intents.members = True  # < This may give you `read-only` warning, just ignore it.
+# This intent requires "Server Members Intent" to be enabled at https://discord.com/developers
 
-client = MyClient(intents=intents)
-client.run("TOKEN")
+
+bot = discord.Bot(intents=intents)
+
+role_message_id = 0  # ID of the message that can be reacted to for adding/removing a role.
+
+emoji_to_role = {
+    discord.PartialEmoji(name="🔴"): 0,  # ID of the role associated with unicode emoji '🔴'.
+    discord.PartialEmoji(name="🟡"): 0,  # ID of the role associated with unicode emoji '🟡'.
+    discord.PartialEmoji(name="green", id=0): 0,  # ID of the role associated with a partial emoji's ID.
+}
+
+
+@bot.event
+async def on_ready():
+    print('Ready!')
+
+
+@bot.event
+async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
+    """Gives a role based on a reaction emoji."""
+    # Make sure that the message the user is reacting to is the one we care about.
+    if payload.message_id != role_message_id:
+        return
+
+    guild = bot.get_guild(payload.guild_id)
+    if guild is None:
+        # Make sure we're still in the guild, and it's cached.
+        return
+
+    try:
+        role_id = emoji_to_role[payload.emoji]
+    except KeyError:
+        # If the emoji isn't the one we care about then exit as well.
+        return
+
+    role = guild.get_role(role_id)
+    if role is None:
+        # Make sure the role still exists and is valid.
+        return
+
+    try:
+        # Finally, add the role.
+        await payload.member.add_roles(role)
+    except discord.HTTPException:
+        # If we want to do something in case of errors we'd do it here.
+        pass
+
+
+@bot.event
+async def on_raw_reaction_remove(payload: discord.RawReactionActionEvent):
+    """Removes a role based on a reaction emoji."""
+    # Make sure that the message the user is reacting to is the one we care about.
+    if payload.message_id != role_message_id:
+        return
+
+    guild = bot.get_guild(payload.guild_id)
+    if guild is None:
+        # Make sure we're still in the guild, and it's cached.
+        return
+
+    try:
+        role_id = emoji_to_role[payload.emoji]
+    except KeyError:
+        # If the emoji isn't the one we care about then exit as well.
+        return
+
+    role = guild.get_role(role_id)
+    if role is None:
+        # Make sure the role still exists and is valid.
+        return
+
+    # The payload for `on_raw_reaction_remove` does not provide `.member`
+    # so we must get the member ourselves from the payload's `.user_id`.
+    member = guild.get_member(payload.user_id)
+    if member is None:
+        # Make sure the member still exists and is valid.
+        return
+
+    try:
+        # Finally, remove the role.
+        await member.remove_roles(role)
+    except discord.HTTPException:
+        # If we want to do something in case of errors we'd do it here.
+        pass
+
+
+bot.run("TOKEN")

--- a/examples/reply.py
+++ b/examples/reply.py
@@ -1,24 +1,26 @@
-# This example requires the `message_content` privileged intent for access to message content.
-
 import discord
 
-
-class MyClient(discord.Client):
-    async def on_ready(self):
-        print(f"Logged in as {self.user} (ID: {self.user.id})")
-        print("------")
-
-    async def on_message(self, message: discord.Message):
-        # Make sure we won't be replying to ourselves.
-        if message.author.id == self.user.id:
-            return
-
-        if message.content.startswith("!hello"):
-            await message.reply("Hello!", mention_author=True)
-
-
 intents = discord.Intents.default()
-intents.message_content = True
+intents.message_content = True  # < This may give you `read-only` warning, just ignore it.
+# This intent requires "Message Content Intent" to be enabled at https://discord.com/developers
 
-client = MyClient(intents=intents)
-client.run("TOKEN")
+
+bot = discord.Bot(intents=intents)
+
+
+@bot.event
+async def on_ready():
+    print('Ready!')
+
+
+@bot.event
+async def on_message(message: discord.Message):
+    # Make sure we won't be replying to ourselves.
+    if message.author.id == bot.user.id:
+        return
+
+    if message.content.startswith("!hello"):
+        await message.reply("Hello!", mention_author=True)
+
+
+bot.run("TOKEN")

--- a/examples/wait_for_event.py
+++ b/examples/wait_for_event.py
@@ -1,48 +1,47 @@
-# This example requires the `message_content` privileged intent for access to message content.
-
-import asyncio
 import random
-
 import discord
-
-
-class MyClient(discord.Client):
-    async def on_ready(self):
-        print(f"Logged in as {self.user} (ID: {self.user.id})")
-        print("------")
-
-    async def on_message(self, message: discord.Message):
-        # Make sure we won't be replying to ourselves.
-        if message.author.id == self.user.id:
-            return
-
-        if message.content.startswith("!guess"):
-            await message.channel.send("Guess a number between 1 and 10.")
-
-            def is_valid_guess(m: discord.Message):
-                # This function checks three things at once:
-                # - The author of the message we've received via
-                #   the wait_for is the same as the first message.
-                # - The content of the message is a digit.
-                # - The digit received is within the range of 1-10.
-                # If any one of these checks fail, we ignore this message.
-                return m.author == message.author and m.content.isdigit() and 1 <= int(m.content) <= 10
-
-            answer = random.randint(1, 10)
-
-            try:
-                guess = await self.wait_for("message", check=is_valid_guess, timeout=5.0)
-            except asyncio.TimeoutError:
-                return await message.channel.send(f"Sorry, you took too long it was {answer}.")
-
-            if int(guess.content) == answer:
-                await message.channel.send("You are right!")
-            else:
-                await message.channel.send(f"Oops. It is actually {answer}.")
-
+from asyncio import TimeoutError
 
 intents = discord.Intents.default()
-intents.message_content = True
+intents.message_content = True  # < This may give you `read-only` warning, just ignore it.
+# This intent requires "Message Content Intent" to be enabled at https://discord.com/developers
 
-client = MyClient(intents=intents)
-client.run("TOKEN")
+
+bot = discord.Bot(intents=intents)
+
+
+@bot.event
+async def on_ready():
+    print('Ready!')
+
+
+# For more examples regarding slash commands, checkout:
+# https://github.com/Pycord-Development/pycord/tree/master/examples/app_commands
+
+@bot.slash_command(name="guess", description="Guess a number between 1 and 10!")
+async def guess_number(ctx: discord.ApplicationContext):
+    await ctx.respond("Type in your number. *(It should be between 1 and 10)*")
+
+    def is_valid_guess(m: discord.Message):
+        # This function checks three things at once:
+        # - The author of the message we've received via
+        #   the wait_for is the same as the first message.
+        # - The content of the message is a digit.
+        # - The digit received is within the range of 1-10.
+        # If any one of these checks fail, we ignore this message.
+        return m.author == ctx.author and m.content.isdigit() and 1 <= int(m.content) <= 10
+
+    answer = random.randint(1, 10)
+
+    try:
+        guess: discord.Message = await bot.wait_for("message", check=is_valid_guess, timeout=5.0)
+    except TimeoutError:
+        return await ctx.send_followup(f"Sorry, you took too long it was {answer}.")
+
+    if int(guess.content) == answer:
+        await guess.reply("You are right!", mention_author=True)
+    else:
+        await guess.reply(f"Oops. It is actually {answer}.", mention_author=True)
+
+
+bot.run("TOKEN")

--- a/examples/wait_for_event.py
+++ b/examples/wait_for_event.py
@@ -25,7 +25,7 @@ async def guess_number(ctx: discord.ApplicationContext):
     def is_valid_guess(m: discord.Message):
         # This function checks three things at once:
         # - The author of the message we've received via
-        #   the wait_for is the same as the first message.
+        #   the wait_for is the same as command author.
         # - The content of the message is a digit.
         # - The digit received is within the range of 1-10.
         # If any one of these checks fail, we ignore this message.


### PR DESCRIPTION
## Summary

I talked to Bob regarding example styling few days ago, and he agreed with me about it:
![image](https://user-images.githubusercontent.com/49173264/184673661-aeefdf60-1559-4914-a786-0e460c01d3bb.png)

I think, i remade most of them, i wasn't really changing much, but i made `wait_for event` into slash_command. (I think its more suitable for this one)

`discord.Bot` is used instead of `discord.Client` on purpose. I'm pretty sure most of other examples use it too.

## Information

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
