### PR TITLE
Fix for application-based bots without the bot scope

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -178,15 +178,18 @@ class Interaction:
 
         # TODO: there's a potential data loss here
         if self.guild_id:
-            guild = self.guild or Object(id=self.guild_id)
+            guild = self.guild or self._state._get_guild(self.guild_id)
             try:
                 member = data["member"]  # type: ignore
             except KeyError:
                 pass
             else:
-                cache_flag = self._state.member_cache_flags.interaction
-                self.user = guild._get_and_update_member(member, int(member["user"]["id"]), cache_flag)
                 self._permissions = int(member.get("permissions", 0))
+                if guild:
+                    cache_flag = self._state.member_cache_flags.interaction
+                    self.user = guild._get_and_update_member(member, int(member["user"]["id"]), cache_flag)
+                else:
+                    self.user = Member(state=self._state, data=member, guild=guild)
         else:
             try:
                 self.user = User(state=self._state, data=data["user"])

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -185,7 +185,7 @@ class Interaction:
                 pass
             else:
                 self._permissions = int(member.get("permissions", 0))
-                if guild:
+                if not isinstance(guild, Object):
                     cache_flag = self._state.member_cache_flags.interaction
                     self.user = guild._get_and_update_member(member, int(member["user"]["id"]), cache_flag)
                 else:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -178,7 +178,7 @@ class Interaction:
 
         # TODO: there's a potential data loss here
         if self.guild_id:
-            guild = self.guild or self._state._get_guild(self.guild_id)
+            guild = self.guild or self._state._get_guild(self.guild_id) or Object(id=self.guild_id)
             try:
                 member = data["member"]  # type: ignore
             except KeyError:


### PR DESCRIPTION
Quick patch to how guild is received from a purely HTTP interaction

## Summary

A necessary fix to how an interaction's guild and user are assigned due to how interaction data is processed on a client without the `bot` scope. This patch allows avoiding the worst-case scenario, but further investigation into using this lib with HTTP clients is recommended.

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).
