### PR TITLE
Documentation improvements on bridge commands

### DIFF
--- a/discord/ext/bridge/context.py
+++ b/discord/ext/bridge/context.py
@@ -42,7 +42,7 @@ class BridgeContext(ABC):
     this class are meant to give parity between the two contexts, while still allowing for all of their functionality.
 
     When this is passed to a command, it will either be passed as :class:`BridgeExtContext`, or
-    :class:`BridgeApplicationContext`. Since they are two separate classes, it's easy to use `cts.is_app` 
+    :class:`BridgeApplicationContext`. Since they are two separate classes, it's easy to use the :attr:`BridgeContext.is_app` attribute.
     to make different functionality for each context. For example, if you want to respond to a command with the command
     type that it was invoked with, you can do the following:
 

--- a/discord/ext/bridge/context.py
+++ b/discord/ext/bridge/context.py
@@ -42,7 +42,7 @@ class BridgeContext(ABC):
     this class are meant to give parity between the two contexts, while still allowing for all of their functionality.
 
     When this is passed to a command, it will either be passed as :class:`BridgeExtContext`, or
-    :class:`BridgeApplicationContext`. Since they are two separate classes, it is quite simple to use :func:`isinstance`
+    :class:`BridgeApplicationContext`. Since they are two separate classes, it's easy to use `cts.is_app` 
     to make different functionality for each context. For example, if you want to respond to a command with the command
     type that it was invoked with, you can do the following:
 


### PR DESCRIPTION
## Summary

The example code right underneath the documentation was changed to no longer use isinstance and now use `ctx.is_app`, so the documentation was altered to reflect that

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
