### PR TITLE
Respect limit argument in Guild.bans()

### DIFF
--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -722,6 +722,8 @@ class BanIterator(_AsyncIterator["BanEntry"]):
         if not data:
             # no data, terminate
             return
+        if self.limit:
+            self.limit -= self.retrieve
 
         if len(data) < 1000:
             self.limit = 0  # terminate loop


### PR DESCRIPTION
## Summary
Fixes `limit` being ignored for `limit > 1000` when using `Guild.bans()` by decrementing it (as seen in other iterators). 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
