### PR TITLE
Fix on_scheduled_event_update event

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -1392,7 +1392,7 @@ class ConnectionState:
 
         creator = None if not data.get("creator", None) else guild.get_member(data.get("creator_id"))
         scheduled_event = ScheduledEvent(state=self, guild=guild, creator=creator, data=data)
-        old_event = guild.get_scheduled_event(data["id"])
+        old_event = guild.get_scheduled_event(int(data["id"]))
         guild._add_scheduled_event(scheduled_event)
         self.dispatch("scheduled_event_update", old_event, scheduled_event)
 


### PR DESCRIPTION
## Summary

Fixes `on_scheduled_event_update`'s `before` argument always being `None` by converting the ID to int before getting the event.

Closes #1579 

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
