### PR TITLE
Fixed small bug in `ApplicationCommand`

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -221,7 +221,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         if getattr(self, "id", None) is not None and getattr(other, "id", None) is not None:
             check = self.id == other.id
         else:
-            check = self.name == other.name and self.guild_ids == self.guild_ids
+            check = self.name == other.name and self.guild_ids == other.guild_ids
         return isinstance(other, self.__class__) and self.parent == other.parent and check
 
     async def __call__(self, ctx, *args, **kwargs):


### PR DESCRIPTION
Fixed small bug where `ApplicationCommand.__eq__` would do this comparison: `self.guild_ids == self.guild_ids` instead of `self.guild_ids == other.guild_ids`

## Summary

Fixes a small bug in `discord.core.ApplicationCommand`

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
