### PR TITLE
Fix SlashCommandGroup description not being truly optional

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1017,10 +1017,10 @@ class SlashCommandGroup(ApplicationCommand):
         parent: Optional[SlashCommandGroup] = None,
         **kwargs,
     ) -> None:
-        validate_chat_input_name(name)
-        validate_chat_input_description(description)
         self.name = str(name)
-        self.description = description
+        self.description = description or "No description provided"
+        validate_chat_input_name(self.name)
+        validate_chat_input_description(self.description)
         self.input_type = SlashCommandOptionType.sub_command_group
         self.subcommands: List[Union[SlashCommand, SlashCommandGroup]] = self.__initial_commands__
         self.guild_ids = guild_ids


### PR DESCRIPTION
## Summary

Fixes `SlashCommandGroup` raising a `TypeError` when not passing in a `description`. 

This attribute is listed as optional in the library, but it's actually required by Discord; as such, if you pass `None` into it the library is meant to set it to `"No description provided"` for the user. However, validation came before setting it to the default value which resulted in users having to pass it in.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
