### PR TITLE
Add 'suppress' to messageable.send()

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1256,6 +1256,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress: bool = ...,
     ) -> Message:
         ...
 
@@ -1274,6 +1275,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress: bool = ...,
     ) -> Message:
         ...
 
@@ -1292,6 +1294,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress: bool = ...,
     ) -> Message:
         ...
 
@@ -1310,6 +1313,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress: bool = ...,
     ) -> Message:
         ...
 
@@ -1329,6 +1333,7 @@ class Messageable:
         reference=None,
         mention_author=None,
         view=None,
+        suppress=None
     ):
         """|coro|
 
@@ -1401,6 +1406,8 @@ class Messageable:
             A list of stickers to upload. Must be a maximum of 3.
 
             .. versionadded:: 2.0
+        suppress: :class:`bool`
+            Indicates if message should suppress embeds.
 
         Raises
         --------
@@ -1486,6 +1493,7 @@ class Messageable:
                     message_reference=reference,
                     stickers=stickers,
                     components=components,
+                    suppress=suppress,
                 )
             finally:
                 file.close()
@@ -1509,6 +1517,7 @@ class Messageable:
                     message_reference=reference,
                     stickers=stickers,
                     components=components,
+                    suppress=suppress,
                 )
             finally:
                 for f in files:
@@ -1525,6 +1534,7 @@ class Messageable:
                 message_reference=reference,
                 stickers=stickers,
                 components=components,
+                suppress=suppress,
             )
 
         ret = state.create_message(channel=channel, data=data)

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1444,7 +1444,7 @@ class Messageable:
                 raise InvalidArgument("embeds parameter must be a list of up to 10 elements")
             embeds = [embed.to_dict() for embed in embeds]
             
-        if suppress is not None:
+        if suppress:
             flags = MessageFlags.suppress_embeds
         else:
             flags = MessageFlags.DEFAULT_VALUE

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1408,7 +1408,7 @@ class Messageable:
 
             .. versionadded:: 2.0
         suppress: :class:`bool`
-            Indicates if message should suppress embeds.
+            Whether to suppress embeds for the message.
 
         Raises
         --------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1408,7 +1408,7 @@ class Messageable:
 
             .. versionadded:: 2.0
         suppress: :class:`bool`
-            Whether or not embeds should be suppressed for this message.
+            Whether to suppress embeds for the message.
 
         Raises
         --------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1408,7 +1408,7 @@ class Messageable:
 
             .. versionadded:: 2.0
         suppress: :class:`bool`
-            Whether to suppress embeds for the message.
+            Whether or not embeds should be suppressed for this message.
 
         Raises
         --------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1444,10 +1444,7 @@ class Messageable:
                 raise InvalidArgument("embeds parameter must be a list of up to 10 elements")
             embeds = [embed.to_dict() for embed in embeds]
             
-        if suppress:
-            flags = MessageFlags.suppress_embeds
-        else:
-            flags = MessageFlags.DEFAULT_VALUE
+        flags = MessageFlags.suppress_embeds if suppress else MessageFlags.DEFAULT_VALUE
 
         if stickers is not None:
             stickers = [sticker.id for sticker in stickers]

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -50,6 +50,7 @@ from .context_managers import Typing
 from .enums import ChannelType
 from .errors import ClientException, InvalidArgument
 from .file import File
+from .flags import MessageFlags
 from .invite import Invite
 from .iterators import HistoryIterator
 from .mentions import AllowedMentions
@@ -1442,6 +1443,11 @@ class Messageable:
             if len(embeds) > 10:
                 raise InvalidArgument("embeds parameter must be a list of up to 10 elements")
             embeds = [embed.to_dict() for embed in embeds]
+            
+        if suppress is not None:
+            flags = MessageFlags.suppress_embeds
+        else:
+            flags = MessageFlags.DEFAULT_VALUE
 
         if stickers is not None:
             stickers = [sticker.id for sticker in stickers]
@@ -1493,7 +1499,7 @@ class Messageable:
                     message_reference=reference,
                     stickers=stickers,
                     components=components,
-                    suppress=suppress,
+                    flags=flags,
                 )
             finally:
                 file.close()
@@ -1517,7 +1523,7 @@ class Messageable:
                     message_reference=reference,
                     stickers=stickers,
                     components=components,
-                    suppress=suppress,
+                    flags=flags,
                 )
             finally:
                 for f in files:
@@ -1534,7 +1540,7 @@ class Messageable:
                 message_reference=reference,
                 stickers=stickers,
                 components=components,
-                suppress=suppress,
+                flags=flags,
             )
 
         ret = state.create_message(channel=channel, data=data)

--- a/discord/http.py
+++ b/discord/http.py
@@ -449,6 +449,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
+        suppress: Optional[bool] = False,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
         payload = {}
@@ -479,6 +480,9 @@ class HTTPClient:
 
         if stickers:
             payload["sticker_ids"] = stickers
+            
+        if suppress:
+            payload["flags"] = 4
 
         return self.request(r, json=payload)
 
@@ -499,6 +503,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
+        suppress: Optional[bool] = False,
     ) -> Response[message.Message]:
         form = []
 
@@ -519,6 +524,8 @@ class HTTPClient:
             payload["components"] = components
         if stickers:
             payload["sticker_ids"] = stickers
+        if suppress:
+            payload["flags"] = 4
 
         attachments = []
         form.append({"name": "payload_json"})
@@ -556,6 +563,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
+        suppress: Optional[bool] = False,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
         return self.send_multipart_helper(
@@ -570,6 +578,7 @@ class HTTPClient:
             message_reference=message_reference,
             stickers=stickers,
             components=components,
+            suppress=suppress,
         )
 
     def edit_multipart_helper(

--- a/discord/http.py
+++ b/discord/http.py
@@ -503,7 +503,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
-        flags: Optional[int] = 0,
+        flags: Optional[int] = None,
     ) -> Response[message.Message]:
         form = []
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -449,7 +449,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
-        flags: Optional[int] = 0,
+        flags: Optional[int] = None,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
         payload = {}

--- a/discord/http.py
+++ b/discord/http.py
@@ -563,7 +563,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
-        flags: Optional[int] = 0,
+        flags: Optional[int] = None,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
         return self.send_multipart_helper(

--- a/discord/http.py
+++ b/discord/http.py
@@ -449,7 +449,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
-        suppress: Optional[bool] = False,
+        flags: Optional[int] = 0,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
         payload = {}
@@ -481,8 +481,8 @@ class HTTPClient:
         if stickers:
             payload["sticker_ids"] = stickers
             
-        if suppress:
-            payload["flags"] = 4
+        if flags:
+            payload["flags"] = flags
 
         return self.request(r, json=payload)
 
@@ -503,7 +503,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
-        suppress: Optional[bool] = False,
+        flags: Optional[int] = 0,
     ) -> Response[message.Message]:
         form = []
 
@@ -524,8 +524,8 @@ class HTTPClient:
             payload["components"] = components
         if stickers:
             payload["sticker_ids"] = stickers
-        if suppress:
-            payload["flags"] = 4
+        if flags:
+            payload["flags"] = flags
 
         attachments = []
         form.append({"name": "payload_json"})
@@ -563,7 +563,7 @@ class HTTPClient:
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[List[sticker.StickerItem]] = None,
         components: Optional[List[components.Component]] = None,
-        suppress: Optional[bool] = False,
+        flags: Optional[int] = 0,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
         return self.send_multipart_helper(
@@ -578,7 +578,7 @@ class HTTPClient:
             message_reference=message_reference,
             stickers=stickers,
             components=components,
-            suppress=suppress,
+            flags=flags,
         )
 
     def edit_multipart_helper(


### PR DESCRIPTION
## Summary

Adds support for "suppress" argument for messageable.send(), mirroring message.edit() suppression argument.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
