### PR TITLE
Fix subcommands having MISSING cog attribute

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -968,10 +968,6 @@ class SlashCommand(ApplicationCommand):
         else:
             return self.copy()
 
-    def _set_cog(self, cog):
-        super()._set_cog(cog)
-        self._validate_parameters()
-
 
 class SlashCommandGroup(ApplicationCommand):
     r"""A class that implements the protocol for a slash command group.
@@ -1090,10 +1086,16 @@ class SlashCommandGroup(ApplicationCommand):
 
         return as_dict
 
+    def add_command(self, command: SlashCommand) -> None:
+        if command.cog is MISSING:
+            command.cog = self.cog
+
+        self.subcommands.append(command)
+
     def command(self, cls: Type[T] = SlashCommand, **kwargs) -> Callable[[Callable], SlashCommand]:
         def wrap(func) -> T:
             command = cls(func, parent=self, **kwargs)
-            self.subcommands.append(command)
+            self.add_command(command)
             return command
 
         return wrap


### PR DESCRIPTION
## Summary
Subcommands aren't 'added' the same way as regular commands or the groups themselves 
[source help thread](https://discord.com/channels/881207955029110855/1012705198554218566)

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.