### PR TITLE
chore: cleanup documentation issues

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1377,8 +1377,7 @@ class Messageable:
 
             .. versionadded:: 1.4
 
-        reference: Union[:class:`~discord.Message`, :class:`~discord.MessageReference`,
-        :class:`~discord.PartialMessage`]
+        reference: Union[:class:`~discord.Message`, :class:`~discord.MessageReference`, :class:`~discord.PartialMessage`]
             A reference to the :class:`~discord.Message` to which you are replying, this can be created using
             :meth:`~discord.Message.to_reference` or passed directly as a :class:`~discord.Message`. You can control
             whether this mentions the author of the referenced message using the

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -340,8 +340,8 @@ class AutoModRule(Hashable):
     
     @cached_property
     def exempt_channels(self) -> List[Union[Union[TextChannel, ForumChannel, VoiceChannel], Object]]:
-        """List[Union[Union[:class:`TextChannel`, :class:`ForumChannel`, :class:`VoiceChannel`], :class:`Object`]]:
-        The channels that are exempt from this rule.
+        """List[Union[Union[:class:`TextChannel`, :class:`ForumChannel`, :class:`VoiceChannel`], :class:`Object`]]: The
+        channels that are exempt from this rule.
        
         If a channel is not found in the guild's cache, 
         then it will be returned as an :class:`Object`.

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -270,7 +270,7 @@ class _TextChannel(discord.abc.GuildChannel, Hashable):
             is only available to guilds that contain ``NEWS`` in :attr:`Guild.features`.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to channel permissions. Useful for creating secret channels.
         default_auto_archive_duration: :class:`int`
             The new default auto archive duration in minutes for threads created in this channel.
@@ -1549,7 +1549,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
             category.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to channel permissions. Useful for creating secret channels.
         rtc_region: Optional[:class:`VoiceRegion`]
             The new region for the voice channel's voice communication.
@@ -1889,7 +1889,7 @@ class StageChannel(VocalGuildChannel):
             category.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to channel permissions. Useful for creating secret channels.
         rtc_region: Optional[:class:`VoiceRegion`]
             The new region for the stage channel's voice communication.
@@ -2057,7 +2057,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
             To mark the category as NSFW or not.
         reason: Optional[:class:`str`]
             The reason for editing this category. Shows up on the audit log.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to channel permissions. Useful for creating secret channels.
 
         Raises

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -85,13 +85,13 @@ class CogMeta(type):
 
         import abc
 
-        class CogABCMeta(commands.CogMeta, abc.ABCMeta):
+        class CogABCMeta(discord.CogMeta, abc.ABCMeta):
             pass
 
         class SomeMixin(metaclass=abc.ABCMeta):
             pass
 
-        class SomeCogMixin(SomeMixin, commands.Cog, metaclass=CogABCMeta):
+        class SomeCogMixin(SomeMixin, discord.Cog, metaclass=CogABCMeta):
             pass
 
     .. note::
@@ -102,7 +102,7 @@ class CogMeta(type):
 
         .. code-block:: python3
 
-            class MyCog(commands.Cog, name='My Cog'):
+            class MyCog(discord.Cog, name='My Cog'):
                 pass
 
     Attributes
@@ -122,12 +122,12 @@ class CogMeta(type):
 
         .. code-block:: python3
 
-            class MyCog(commands.Cog, command_attrs=dict(hidden=True)):
-                @commands.command()
+            class MyCog(discord.Cog, command_attrs=dict(hidden=True)):
+                @discord.slash_command()
                 async def foo(self, ctx):
                     pass # hidden -> True
 
-                @commands.command(hidden=False)
+                @discord.slash_command(hidden=False)
                 async def bar(self, ctx):
                     pass # hidden -> False
 
@@ -476,7 +476,7 @@ class Cog(metaclass=CogMeta):
     async def cog_before_invoke(self, ctx: ApplicationContext) -> None:
         """A special method that acts as a cog local pre-invoke hook.
 
-        This is similar to :meth:`.Command.before_invoke`.
+        This is similar to :meth:`.ApplicationCommand.before_invoke`.
 
         This **must** be a coroutine.
 
@@ -491,7 +491,7 @@ class Cog(metaclass=CogMeta):
     async def cog_after_invoke(self, ctx: ApplicationContext) -> None:
         """A special method that acts as a cog local post-invoke hook.
 
-        This is similar to :meth:`.Command.after_invoke`.
+        This is similar to :meth:`.ApplicationCommand.after_invoke`.
 
         This **must** be a coroutine.
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -303,7 +303,7 @@ class Option:
 
 class OptionChoice:
     """
-    Represents a name:value pairing for a selected :class:`Option`.
+    Represents a name:value pairing for a selected :class:`.Option`.
 
     .. versionadded:: 2.0
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -226,8 +226,7 @@ class PageGroup:
 
     Parameters
     ----------
-    pages: Union[List[:class:`str`], List[:class:`Page`],
-    List[Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
+    pages: Union[List[:class:`str`], List[:class:`Page`], List[Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
         The list of :class:`Page` objects, strings, embeds, or list of embeds to include in the page group.
     label: :class:`str`
         The label shown on the corresponding PaginatorMenu dropdown option.
@@ -307,8 +306,7 @@ class Paginator(discord.ui.View):
 
     Parameters
     ----------
-    pages: Union[List[:class:`PageGroup`], List[:class:`Page`], List[:class:`str`],
-    List[Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
+    pages: Union[List[:class:`PageGroup`], List[:class:`Page`], List[:class:`str`], List[Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]
         The list of :class:`PageGroup` objects, :class:`Page` objects, strings, embeds, or list of embeds to paginate.
         If a list of :class:`PageGroup` objects is provided and `show_menu` is ``False``,
         only the first page group will be displayed.
@@ -453,8 +451,7 @@ class Paginator(discord.ui.View):
 
         Parameters
         ----------
-        pages: Optional[Union[List[:class:`PageGroup`], List[:class:`Page`], List[:class:`str`],
-        List[Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]]
+        pages: Optional[Union[List[:class:`PageGroup`], List[:class:`Page`], List[:class:`str`], List[Union[List[:class:`discord.Embed`], :class:`discord.Embed`]]]]
             The list of :class:`PageGroup` objects, :class:`Page` objects, strings,
             embeds, or list of embeds to paginate.
         show_disabled: :class:`bool`
@@ -863,8 +860,7 @@ class Paginator(discord.ui.View):
             A target where the paginated message should be sent, if different from the original :class:`Context`
         target_message: Optional[:class:`str`]
             An optional message shown when the paginator message is sent elsewhere.
-        reference: Optional[Union[:class:`discord.Message`,
-        :class:`discord.MessageReference`, :class:`discord.PartialMessage`]]
+        reference: Optional[Union[:class:`discord.Message`, :class:`discord.MessageReference`, :class:`discord.PartialMessage`]]
             A reference to the :class:`~discord.Message` to which you are replying with the paginator.
             This can be created using :meth:`~discord.Message.to_reference` or passed directly as a
             :class:`~discord.Message`. You can control whether this mentions the author of the referenced message

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -213,8 +213,7 @@ class Guild(Hashable):
         - ``COMMUNITY``: Guild is a community server.
         - ``DISCOVERABLE``: Guild shows up in Server Discovery.
         - ``HAS_DIRECTORY_ENTRY``: Unknown.
-        - ``HUB``: Hubs contain a directory channel that let you find school-related,
-                   student-run servers for your school or university.
+        - ``HUB``: Hubs contain a directory channel that let you find school-related, student-run servers for your school or university.
         - ``INTERNAL_EMPLOYEE_ONLY``: Indicates that only users with the staff badge can join the guild.
         - ``INVITE_SPLASH``: Guild's invite page can have a special splash.
         - ``LINKED_TO_HUB``: 'Guild is linked to a hub.
@@ -226,17 +225,14 @@ class Guild(Hashable):
         - ``NEWS``: Guild can create news channels.
         - ``NEW_THREAD_PERMISSIONS``: Guild has new thread permissions.
         - ``PARTNERED``: Guild is a partnered server.
-        - ``PREMIUM_TIER_3_OVERRIDE``: Forces the server to server boosting level 3 (specifically created by Discord
-                                       Staff Member "Jethro" for their personal server).
+        - ``PREMIUM_TIER_3_OVERRIDE``: Forces the server to server boosting level 3 (specifically created by Discord Staff Member "Jethro" for their personal server).
         - ``PREVIEW_ENABLED``: Guild can be viewed before being accepted via Membership Screening.
         - ``PRIVATE_THREADS``: Guild has access to create private threads.
         - ``ROLE_ICONS``: Guild can set an image or emoji as a role icon.
         - ``ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE``: Role subscriptions are available for purchasing.
         - ``ROLE_SUBSCRIPTIONS_ENABLED``: Guild is able to view and manage role subscriptions.
-        - ``TEXT_IN_VOICE_ENABLED``: Guild has a chat button inside voice channels that opens a dedicated text channel
-                                     in a sidebar similar to thread view.
-        - ``THREADS_ENABLED_TESTING``: Used by bot developers to test their bots with threads in guilds with 5 or fewer
-                                       members and a bot. Also gives the premium thread features.
+        - ``TEXT_IN_VOICE_ENABLED``: Guild has a chat button inside voice channels that opens a dedicated text channel in a sidebar similar to thread view.
+        - ``THREADS_ENABLED_TESTING``: Used by bot developers to test their bots with threads in guilds with 5 or fewer members and a bot. Also gives the premium thread features.
         - ``TICKETED_EVENTS_ENABLED``: Guild has enabled ticketed events.
         - ``VANITY_URL``: Guild can have a vanity invite URL (e.g. discord.gg/discord-api).
         - ``VERIFIED``: Guild is a verified server.
@@ -1156,7 +1152,7 @@ class Guild(Hashable):
         -----------
         name: :class:`str`
             The channel's name.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to the channel. Useful for creating secret channels.
         category: Optional[:class:`CategoryChannel`]
             The category to place the newly created channel under.
@@ -1238,7 +1234,7 @@ class Guild(Hashable):
         -----------
         name: :class:`str`
             The channel's name.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to the channel. Useful for creating secret channels.
         category: Optional[:class:`CategoryChannel`]
             The category to place the newly created channel under.
@@ -1329,7 +1325,7 @@ class Guild(Hashable):
             The channel's name.
         topic: :class:`str`
             The new channel's topic.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to the channel. Useful for creating secret channels.
         category: Optional[:class:`CategoryChannel`]
             The category to place the newly created channel under.
@@ -1430,7 +1426,7 @@ class Guild(Hashable):
         -----------
         name: :class:`str`
             The channel's name.
-        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`Snowflake`], :class:`PermissionOverwrite`]
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`, :class:`~discord.abc.Snowflake`], :class:`PermissionOverwrite`]
             The overwrites to apply to the channel. Useful for creating secret channels.
         category: Optional[:class:`CategoryChannel`]
             The category to place the newly created channel under.
@@ -2025,7 +2021,7 @@ class Guild(Hashable):
             Retrieving the channel failed.
         NotFound
             Invalid Channel ID.
-        :exc:`.Forbidden`
+        Forbidden
             You do not have permission to fetch this channel.
 
         Returns

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -216,8 +216,8 @@ class Interaction:
 
     @utils.cached_slot_property("_cs_channel")
     def channel(self) -> Optional[InteractionChannel]:
-        """Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]:
-        The channel the interaction was sent from.
+        """Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]: The channel the
+        interaction was sent from.
 
         Note that due to a Discord limitation, DM channels are not resolved since there is
         no data to complete them. These are :class:`PartialMessageable` instead.

--- a/discord/message.py
+++ b/discord/message.py
@@ -578,8 +578,7 @@ class Message(Hashable):
         This is not stored long term within Discord's servers and is only used ephemerally.
     embeds: List[:class:`Embed`]
         A list of embeds the message has.
-    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`,
-    :class:`GroupChannel`, :class:`PartialMessageable`]
+    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
         The :class:`TextChannel` or :class:`Thread` that the message was sent from.
         Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
     reference: Optional[:class:`~discord.MessageReference`]
@@ -1034,8 +1033,8 @@ class Message(Hashable):
 
     @property
     def edited_at(self) -> Optional[datetime.datetime]:
-        """Optional[:class:`datetime.datetime`]:
-        An aware UTC datetime object containing the edited time of the message.
+        """Optional[:class:`datetime.datetime`]: An aware UTC datetime object containing the
+        edited time of the message.
         """
         return self._edited_timestamp
 

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -395,8 +395,8 @@ class AutoShardedClient(Client):
 
     @property
     def latencies(self) -> List[Tuple[int, float]]:
-        """List[Tuple[:class:`int`, :class:`float`]]:
-        A list of latencies between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
+        """List[Tuple[:class:`int`, :class:`float`]]: A list of latencies between a
+        HEARTBEAT and a HEARTBEAT_ACK in seconds.
 
         This returns a list of tuples with elements ``(shard_id, latency)``.
         """
@@ -413,7 +413,7 @@ class AutoShardedClient(Client):
 
     @property
     def shards(self) -> Dict[int, ShardInfo]:
-        """Mapping[int, :class:`ShardInfo`]: Returns a mapping of shard IDs to their respective info object."""
+        """Mapping[:class:`int`, :class:`ShardInfo`]: Returns a mapping of shard IDs to their respective info object."""
         return {shard_id: ShardInfo(parent, self.shard_count) for shard_id, parent in self.__shards.items()}
 
     async def launch_shard(self, gateway: str, shard_id: int, *, initial: bool = False) -> None:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1133,18 +1133,13 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
 
     Parameters
     -----------
-    values: Union[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`],
-    Iterable[:class:`float`]], Callable[[:class:`.AutocompleteContext`], Union[Union[Iterable[:class:`str`],
-    Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`],
-    Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`],
-    Iterable[:class:`int`], Iterable[:class:`float`]]]]
+    values: Union[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Callable[[:class:`.AutocompleteContext`], Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         Possible values for the option. Accepts an iterable of :class:`str`, a callable (sync or async) that takes a
         single argument of :class:`.AutocompleteContext`, or a coroutine. Must resolve to an iterable of :class:`str`.
 
     Returns
     --------
-    Callable[[:class:`.AutocompleteContext`], Awaitable[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`],
-    Iterable[:class:`int`], Iterable[:class:`float`]]]]
+    Callable[[:class:`.AutocompleteContext`], Awaitable[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         A wrapped callback for the autocomplete.
     """
 

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -58,7 +58,7 @@ class WelcomeScreenChannel:
         The channel that is being referenced.
     description: :class:`str`
         The description of the channel that is shown on the welcome screen.
-    emoji: :class:`Union[:class:`Emoji`, :class:`PartialEmoji`, :class:`str`]`
+    emoji: Union[:class:`Emoji`, :class:`PartialEmoji`, :class:`str`]
         The emoji of the channel that is shown on welcome screen.
     """
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4486,15 +4486,6 @@ CategoryChannel
     :members:
     :inherited-members:
 
-ForumChannel
-~~~~~~~~~~~~~~~~~
-
-.. attributetable:: ForumChannel
-
-.. autoclass:: ForumChannel()
-    :members:
-    :inherited-members:
-
 DMChannel
 ~~~~~~~~~
 


### PR DESCRIPTION
## Summary

This PR cleans up issues with the current master branch documentation. Most of these issues stemmed from #1476 (my bad lol), but a few are newly discovered/created issues. 

A couple issues are yet to be solved and I'd like to get that done in this PR. These are:
* ~The [ForumChannel](https://docs.pycord.dev/en/master/api.html#discord.ForumChannel) reference's attribute and method table are currently duplicated (I have absolutely zero clue why, please help me).~
* An [ApplicationContext property](https://docs.pycord.dev/en/master/api.html#discord.ApplicationContext.voice_client) that was intended to be fixed in #1476 but remains with a broken reference.
* [Guild.create_auto_moderation_rule](https://docs.pycord.dev/en/master/api.html#discord.Guild.create_auto_moderation_rule) contains 4 broken type references to objects that are not placed anywhere on the documentation.

I'm really not sure how to handle any of the above, any contributions are welcomed. ~PR will (probably) remain in draft status until the above reach some sort of solution.~

## Information

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
