### PR TITLE
A better fix for subcommands having MISSING cogs

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -133,7 +133,7 @@ class ApplicationCommandMixin(ABC):
             raise TypeError("The provided command is a sub-command of group")
 
         if command.cog is MISSING:
-            command.cog = None
+            command._set_cog(None)
 
         if self._bot.debug_guilds and command.guild_ids is None:
             command.guild_ids = self._bot.debug_guilds

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1086,16 +1086,10 @@ class SlashCommandGroup(ApplicationCommand):
 
         return as_dict
 
-    def add_command(self, command: SlashCommand) -> None:
-        if command.cog is MISSING:
-            command.cog = self.cog
-
-        self.subcommands.append(command)
-
     def command(self, cls: Type[T] = SlashCommand, **kwargs) -> Callable[[Callable], SlashCommand]:
         def wrap(func) -> T:
             command = cls(func, parent=self, **kwargs)
-            self.add_command(command)
+            self.subcommands.append(command)
             return command
 
         return wrap


### PR DESCRIPTION
## Summary
A better fix for subcommands not having the cog attribute set.
It's better because `SlashCommandGroup._set_cog` will set the subcommands cogs as well as its own.

## Information

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.