### PR TITLE
Rename `original_message` to `original_response`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `proxy` and `proxy_auth` params to many Webhook related methods.
   ([#1655](https://github.com/Pycord-Development/pycord/pull/1655))
 - `delete_message_seconds` parameter in ban methods. ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
+- New methods `Interaction.original_response`, `Interaction.edit_original_response` & `Interaction.delete_original_response` ([#1609](https://github.com/Pycord-Development/pycord/pull/1609)
 
 ### Deprecated
 - The `delete_message_days` parameter in ban methods is now deprecated. Please use `delete_message_seconds` instead.
+  ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
+- The `Interaction.original_message`, `Interaction.edit_original_message` & `Interaction.delete_original_message` methods are now deprecated. Please use `Interaction.original_response`, `Interaction.edit_original_response` & `Interaction.delete_original_response` respectively instead.
   ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
 
 ### Fixed
@@ -24,9 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unnecessary instance check in autocomplete. ([#1643](https://github.com/Pycord-Development/pycord/pull/1643))
 - Interaction responses are now passed the respective `proxy` and `proxy_auth` params as defined in `Client`.
   ([#1655](https://github.com/Pycord-Development/pycord/pull/1655))
-
-### Changed
-- Rename `original_message` to `original_response` ([#1609](https://github.com/Pycord-Development/pycord/pull/1609)
 
 ## [2.1.3] - 2022-09-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interaction responses are now passed the respective `proxy` and `proxy_auth` params as defined in `Client`.
   ([#1655](https://github.com/Pycord-Development/pycord/pull/1655))
 
+### Changed
+- Rename `original_message` to `original_response` ([#1609](https://github.com/Pycord-Development/pycord/pull/1609)
+
 ## [2.1.3] - 2022-09-06
 ### Fixed
 - Fix TypeError in `process_application_commands`. ([#1622](https://github.com/Pycord-Development/pycord/pull/1622))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - The `delete_message_days` parameter in ban methods is now deprecated. Please use `delete_message_seconds` instead.
   ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
-- The `Interaction.original_message`, `Interaction.edit_original_message` & `Interaction.delete_original_message` methods are now deprecated. Please use `Interaction.original_response`, `Interaction.edit_original_response` & `Interaction.delete_original_response` respectively instead.
+- The `original_message`, `edit_original_message` & `delete_original_message` methods for `Interaction` are now deprecated. Please use the respective `original_response`, `edit_original_response` & `delete_original_response` methods instead.
   ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `proxy` and `proxy_auth` params to many Webhook related methods.
   ([#1655](https://github.com/Pycord-Development/pycord/pull/1655))
 - `delete_message_seconds` parameter in ban methods. ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
-- New methods `Interaction.original_response`, `Interaction.edit_original_response` & `Interaction.delete_original_response` ([#1609](https://github.com/Pycord-Development/pycord/pull/1609)
+- New methods `original_response`, `edit_original_response` & `delete_original_response` for `Interaction` objects.
+  ([#1609](https://github.com/Pycord-Development/pycord/pull/1609)
 
 ### Deprecated
 - The `delete_message_days` parameter in ban methods is now deprecated. Please use `delete_message_seconds` instead.

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -314,7 +314,7 @@ class ApplicationContext(discord.abc.Messageable):
 
         Deletes the original interaction response message.
 
-        This is a higher level interface to :meth:`Interaction.delete_original_message`.
+        This is a higher level interface to :meth:`Interaction.delete_original_response`.
 
         Parameters
         -----------
@@ -331,12 +331,12 @@ class ApplicationContext(discord.abc.Messageable):
         if not self.interaction.response.is_done():
             await self.defer()
 
-        return await self.interaction.delete_original_message(delay=delay)
+        return await self.interaction.delete_original_response(delay=delay)
 
     @property
-    @discord.utils.copy_doc(Interaction.edit_original_message)
+    @discord.utils.copy_doc(Interaction.edit_original_response)
     def edit(self) -> Callable[..., Awaitable[InteractionMessage]]:
-        return self.interaction.edit_original_message
+        return self.interaction.edit_original_response
 
     @property
     def cog(self) -> Optional[Cog]:

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1109,7 +1109,7 @@ class Paginator(discord.ui.View):
         if isinstance(msg, (discord.Message, discord.WebhookMessage)):
             self.message = msg
         elif isinstance(msg, discord.Interaction):
-            self.message = await msg.original_message()
+            self.message = await msg.original_response()
 
         return self.message
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -309,7 +309,7 @@ class Interaction:
         self._original_response = message
         return message
 
-    @utils.warn_deprecated("Interaction.original_message", "Interaction.original_response", "2.1")
+    @utils.deprecated("Interaction.original_response", "2.1")
     async def original_message(self):
         """An alias for :meth:`original_response`.
         
@@ -431,7 +431,7 @@ class Interaction:
 
         return message
 
-    @utils.warn_deprecated("Interaction.edit_original_message", "Interaction.edit_original_response", "2.1")
+    @utils.deprecated("Interaction.edit_original_response", "2.1")
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
         
@@ -489,7 +489,7 @@ class Interaction:
         else:
             await func
 
-    @utils.warn_deprecated("Interaction.delete_original_message", "Interaction.delete_original_response", "2.1")
+    @utils.deprecated("Interaction.delete_original_response", "2.1")
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -26,7 +26,6 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-import warnings
 from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Optional, Tuple, Union
 
 from . import utils
@@ -307,6 +306,7 @@ class Interaction:
         self._original_response = message
         return message
 
+    @utils.deprecated(self.original_response())
     async def original_message(self):
         """An alias for :meth:`original_response`.
         
@@ -322,7 +322,6 @@ class Interaction:
         InteractionMessage
             The original interaction response message.
         """
-        warnings.warn("'Interaction.original_message()' is deprecated, use 'Interaction.original_response()' instead.", DeprecationWarning)
         return self.original_response()
 
     async def edit_original_response(
@@ -426,6 +425,7 @@ class Interaction:
 
         return message
 
+    @utils.deprecated(self.edit_original_response())
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
         
@@ -445,7 +445,6 @@ class Interaction:
         :class:`InteractionMessage`
             The newly edited message.
         """
-        warnings.warn("'Interaction.edit_original_message()' is deprecated, use 'Interaction.edit_original_response()' instead.", DeprecationWarning)
         return self.edit_original_response(**kwargs)
 
     async def delete_original_response(self, *, delay: Optional[float] = None) -> None:
@@ -481,6 +480,7 @@ class Interaction:
         else:
             await func
 
+    @utils.deprecated(self.delete_original_response())
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
 
@@ -491,7 +491,6 @@ class Interaction:
         Forbidden
             Deleted a message that is not yours.
         """
-        warnings.warn("'Interaction.delete_original_message()' is deprecated, use 'Interaction.delete_original_response()' instead.", DeprecationWarning)
         return self.delete_original_response(**kwargs)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -322,7 +322,7 @@ class Interaction:
         InteractionMessage
             The original interaction response message.
         """
-        warnings.warn("Use 'Interaction.original_response()' instead.", DeprecationWarning)
+        warnings.warn("'Interaction.original_message()' is deprecated, use 'Interaction.original_response()' instead.", DeprecationWarning)
         return self.original_response()
 
     async def edit_original_response(
@@ -445,7 +445,7 @@ class Interaction:
         :class:`InteractionMessage`
             The newly edited message.
         """
-        warnings.warn("Use 'Interaction.edit_original_response()' instead.", DeprecationWarning)
+        warnings.warn("'Interaction.edit_original_message()' is deprecated, use 'Interaction.edit_original_response()' instead.", DeprecationWarning)
         return self.edit_original_response(**kwargs)
 
     async def delete_original_response(self, *, delay: Optional[float] = None) -> None:
@@ -491,7 +491,7 @@ class Interaction:
         Forbidden
             Deleted a message that is not yours.
         """
-        warnings.warn("Use 'Interaction.delete_original_response()' instead.", DeprecationWarning)
+        warnings.warn("'Interaction.delete_original_message()' is deprecated, use 'Interaction.delete_original_response()' instead.", DeprecationWarning)
         return self.delete_original_response(**kwargs)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -139,7 +139,7 @@ class Interaction:
         "_app_permissions",
         "_state",
         "_session",
-        "_original_message",
+        "_original_response",
         "_cs_app_permissions",
         "_cs_response",
         "_cs_followup",
@@ -149,7 +149,7 @@ class Interaction:
     def __init__(self, *, data: InteractionPayload, state: ConnectionState):
         self._state: ConnectionState = state
         self._session: ClientSession = state.http._HTTPClient__session
-        self._original_message: Optional[InteractionMessage] = None
+        self._original_response: Optional[InteractionMessage] = None
         self._from_data(data)
 
     def _from_data(self, data: InteractionPayload):
@@ -263,7 +263,7 @@ class Interaction:
         }
         return Webhook.from_state(data=payload, state=self._state)
 
-    async def original_message(self) -> InteractionMessage:
+    async def original_response(self) -> InteractionMessage:
         """|coro|
 
         Fetches the original interaction response message associated with the interaction.
@@ -287,8 +287,8 @@ class Interaction:
             The original interaction response message.
         """
 
-        if self._original_message is not None:
-            return self._original_message
+        if self._original_response is not None:
+            return self._original_response
 
         # TODO: fix later to not raise?
         channel = self.channel
@@ -303,10 +303,10 @@ class Interaction:
         )
         state = _InteractionMessageState(self, self._state)
         message = InteractionMessage(state=state, channel=channel, data=data)  # type: ignore
-        self._original_message = message
+        self._original_response = message
         return message
 
-    async def edit_original_message(
+    async def edit_original_response(
         self,
         *,
         content: Optional[str] = MISSING,
@@ -403,11 +403,11 @@ class Interaction:
             self._state.store_view(view, message.id)
 
         if delete_after is not None:
-            await self.delete_original_message(delay=delete_after)
+            await self.delete_original_response(delay=delete_after)
 
         return message
 
-    async def delete_original_message(self, *, delay: Optional[float] = None) -> None:
+    async def delete_original_response(self, *, delay: Optional[float] = None) -> None:
         """|coro|
 
         Deletes the original interaction response message.
@@ -743,12 +743,12 @@ class InteractionResponse:
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 
-            view.message = await self._parent.original_message()
+            view.message = await self._parent.original_response()
             self._parent._state.store_view(view)
 
         self._responded = True
         if delete_after is not None:
-            await self._parent.delete_original_message(delay=delete_after)
+            await self._parent.delete_original_response(delay=delete_after)
         return self._parent
 
     async def edit_message(
@@ -873,7 +873,7 @@ class InteractionResponse:
 
         self._responded = True
         if delete_after is not None:
-            await self._parent.delete_original_message(delay=delete_after)
+            await self._parent.delete_original_response(delay=delete_after)
 
     async def send_autocomplete_result(
         self,
@@ -1003,7 +1003,7 @@ class InteractionMessage(Message):
     """Represents the original interaction response message.
 
     This allows you to edit or delete the message associated with
-    the interaction response. To retrieve this object see :meth:`Interaction.original_message`.
+    the interaction response. To retrieve this object see :meth:`Interaction.original_response`.
 
     This inherits from :class:`discord.Message` with changes to
     :meth:`edit` and :meth:`delete` to work.
@@ -1076,7 +1076,7 @@ class InteractionMessage(Message):
         """
         if attachments is MISSING:
             attachments = self.attachments or MISSING
-        return await self._state._interaction.edit_original_message(
+        return await self._state._interaction.edit_original_response(
             content=content,
             embeds=embeds,
             embed=embed,
@@ -1108,7 +1108,7 @@ class InteractionMessage(Message):
         HTTPException
             Deleting the message failed.
         """
-        await self._state._interaction.delete_original_message(delay=delay)
+        await self._state._interaction.delete_original_response(delay=delay)
 
 
 class MessageInteraction:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -306,9 +306,8 @@ class Interaction:
         self._original_response = message
         return message
 
-    async def original_message(self, **kwargs):
+    async def original_message(self):
         """An alias for :meth:`original_response`.
-        .. versionadded:: 2.0
         
         Raises
         -------
@@ -427,7 +426,6 @@ class Interaction:
 
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
-        .. versionadded:: 2.0
         
         Raises
         -------
@@ -482,7 +480,6 @@ class Interaction:
 
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
-        .. versionadded:: 2.0
 
         Raises
         -------

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
+import warnings
 from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Optional, Tuple, Union
 
 from . import utils
@@ -321,6 +322,7 @@ class Interaction:
         InteractionMessage
             The original interaction response message.
         """
+        warnings.warn("Use 'Interaction.original_response()' instead.", DeprecationWarning)
         return self.original_response()
 
     async def edit_original_response(
@@ -443,6 +445,7 @@ class Interaction:
         :class:`InteractionMessage`
             The newly edited message.
         """
+        warnings.warn("Use 'Interaction.edit_original_response()' instead.", DeprecationWarning)
         return self.edit_original_response(**kwargs)
 
     async def delete_original_response(self, *, delay: Optional[float] = None) -> None:
@@ -488,6 +491,7 @@ class Interaction:
         Forbidden
             Deleted a message that is not yours.
         """
+        warnings.warn("Use 'Interaction.delete_original_response()' instead.", DeprecationWarning)
         return self.delete_original_response(**kwargs)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -321,7 +321,7 @@ class Interaction:
         InteractionMessage
             The original interaction response message.
         """
-        return self.original_response(**kwargs)
+        return self.original_response()
 
     async def edit_original_response(
         self,

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -309,7 +309,7 @@ class Interaction:
         self._original_response = message
         return message
 
-    @utils.warn_deprecated("Interaction.original_response")
+    @utils.warn_deprecated("Interaction.original_message", "Interaction.original_response", "2.1")
     async def original_message(self):
         """An alias for :meth:`original_response`.
         
@@ -431,7 +431,7 @@ class Interaction:
 
         return message
 
-    @utils.warn_deprecated("Interaction.edit_original_response")
+    @utils.warn_deprecated("Interaction.edit_original_message", "Interaction.edit_original_response", "2.1")
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
         
@@ -489,7 +489,7 @@ class Interaction:
         else:
             await func
 
-    @utils.warn_deprecated("Interaction.delete_original_response")
+    @utils.warn_deprecated("Interaction.delete_original_message", "Interaction.delete_original_response", "2.1")
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -306,7 +306,7 @@ class Interaction:
         self._original_response = message
         return message
 
-    @utils.deprecated(self.original_response())
+    @utils.deprecated("Interaction.original_response")
     async def original_message(self):
         """An alias for :meth:`original_response`.
         
@@ -425,7 +425,7 @@ class Interaction:
 
         return message
 
-    @utils.deprecated(self.edit_original_response())
+    @utils.deprecated("Interaction.edit_original_response")
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
         
@@ -480,7 +480,7 @@ class Interaction:
         else:
             await func
 
-    @utils.deprecated(self.delete_original_response())
+    @utils.deprecated("Interaction.delete_original_response")
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -309,7 +309,7 @@ class Interaction:
         self._original_response = message
         return message
 
-    @utils.deprecated("Interaction.original_response")
+    @utils.warn_deprecated("Interaction.original_response")
     async def original_message(self):
         """An alias for :meth:`original_response`.
         
@@ -431,7 +431,7 @@ class Interaction:
 
         return message
 
-    @utils.deprecated("Interaction.edit_original_response")
+    @utils.warn_deprecated("Interaction.edit_original_response")
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
         
@@ -489,7 +489,7 @@ class Interaction:
         else:
             await func
 
-    @utils.deprecated("Interaction.delete_original_response")
+    @utils.warn_deprecated("Interaction.delete_original_response")
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -306,6 +306,24 @@ class Interaction:
         self._original_response = message
         return message
 
+    async def original_message(self, **kwargs):
+        """An alias for :meth:`original_response`.
+        .. versionadded:: 2.0
+        
+        Raises
+        -------
+        HTTPException
+            Fetching the original response message failed.
+        ClientException
+            The channel for the message could not be resolved.
+
+        Returns
+        --------
+        InteractionMessage
+            The original interaction response message.
+        """
+        return self.original_response(**kwargs)
+
     async def edit_original_response(
         self,
         *,
@@ -407,6 +425,28 @@ class Interaction:
 
         return message
 
+    async def edit_original_message(self, **kwargs):
+        """An alias for :meth:`edit_original_response`.
+        .. versionadded:: 2.0
+        
+        Raises
+        -------
+        HTTPException
+            Editing the message failed.
+        Forbidden
+            Edited a message that is not yours.
+        TypeError
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
+        ValueError
+            The length of ``embeds`` was invalid.
+
+        Returns
+        --------
+        :class:`InteractionMessage`
+            The newly edited message.
+        """
+        return self.edit_original_response(**kwargs)
+
     async def delete_original_response(self, *, delay: Optional[float] = None) -> None:
         """|coro|
 
@@ -439,6 +479,19 @@ class Interaction:
             utils.delay_task(delay, func)
         else:
             await func
+
+    async def delete_original_message(self, **kwargs):
+        """An alias for :meth:`delete_original_response`.
+        .. versionadded:: 2.0
+
+        Raises
+        -------
+        HTTPException
+            Deleting the message failed.
+        Forbidden
+            Deleted a message that is not yours.
+        """
+        return self.delete_original_response(**kwargs)
 
     def to_dict(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary

This PR renames `original_message` to `original_response`.

Depends on #1657 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
