### PR TITLE
chore: add pre-commit ci

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,33 @@
+name: format
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: pip
+
+      - name: Run pre-commit
+        id: precommitrun
+        uses: pre-commit/action@v3.0.0
+
+      - name: Commit changes
+        if: ${{ failure() && steps.precommitrun.conclusion == 'failure' }}
+        run: |
+          git config user.name "pre-commit autofixer"
+
+          git pull
+          git add .
+          git commit -m "style: pre-commit autofix"
+          git push

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-profile = black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+ci:
+    autofix_commit_msg: |
+        style: pre-commit autofix
+    autoupdate_commit_msg: |
+        chore: pre-commit autoupdate
+
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        args: ["--line-length", "100", "--target-version", "py38", "py39", "py310"]
+
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    -   id: check-ast
+    -   id: end-of-file-fixer
+        exclude: ".yml$"
+    -   id: trailing-whitespace
+        exclude: ".yml$"


### PR DESCRIPTION
## Summary

This PR adds a CI for pre-commit and adds a pre-commit config file. The pre-commit config file has hooks that format the code automatically unlike flake8 which only points out what's wrong with the code and doesn't do anything more.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
