### PR TITLE
Make intents a required kwarg

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -158,7 +158,6 @@ class Client:
     intents: :class:`Intents`
         The intents that you want to enable for the session. This is a way of
         disabling and enabling certain gateway events from triggering and being sent.
-        If not given, defaults to a regularly constructed :class:`Intents` class.
 
         .. versionadded:: 1.5
     member_cache_flags: :class:`MemberCacheFlags`
@@ -220,6 +219,7 @@ class Client:
     def __init__(
         self,
         *,
+        intents: Intents,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         **options: Any,
     ):


### PR DESCRIPTION
## Summary
As Discord is soon to be enforcing the message content intent, I figured it'd be a good opportunity to make passing the `intents` kwarg required by the user. Even if they're just passing in `discord.Intents.default()`, it would further raise awareness to them.

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
