### PR TITLE
fix(docs): correct AutoMod event arguments

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1447,7 +1447,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param rule: The deleted rule.
     :type rule: :class:`AutoModRule`
 
-.. function:: on_auto_moderation_action_execution(guild, action)
+.. function:: on_auto_moderation_action_execution(payload)
 
     Called when an auto moderation action is executed.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Kinda related discussion: https://canary.discord.com/channels/881207955029110855/1014517367243538523

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
