### PR TITLE
Revert "enclose in square brackets"

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -241,8 +241,8 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
     def callback(
         self,
     ) -> Union[
-        Callable[[Concatenate[CogT, ApplicationContext, P]], Coro[T]],
-        Callable[[Concatenate[ApplicationContext, P]], Coro[T]],
+        Callable[Concatenate[CogT, ApplicationContext, P], Coro[T]],
+        Callable[Concatenate[ApplicationContext, P], Coro[T]],
     ]:
         return self._callback
 
@@ -250,8 +250,8 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
     def callback(
         self,
         function: Union[
-            Callable[[Concatenate[CogT, ApplicationContext, P]], Coro[T]],
-            Callable[[Concatenate[ApplicationContext, P]], Coro[T]],
+            Callable[Concatenate[CogT, ApplicationContext, P], Coro[T]],
+            Callable[Concatenate[ApplicationContext, P], Coro[T]],
         ],
     ) -> None:
         self._callback = function

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1607,7 +1607,7 @@ def command(
 ) -> Callable[
     [
         Union[
-            CallableConcatenate[CogT, ContextT, P], Coro[T],
+            Callable[Concatenate[CogT, ContextT, P]], Coro[T],
             CallableConcatenate[ContextT, P], Coro[T],
         ]
     ],

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -324,11 +324,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self,
         func: Union[
             Callable[
-                [Concatenate[CogT, ContextT, P]],
+                Concatenate[CogT, ContextT, P],
                 Coro[T]
             ],
             Callable[
-                [Concatenate[ContextT, P]],
+                Concatenate[ContextT, P],
                 Coro[T]
             ],
         ],
@@ -425,11 +425,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self,
     ) -> Union[
         Callable[
-            [Concatenate[CogT, Context, P]],
+            Concatenate[CogT, Context, P],
             Coro[T]
         ],
         Callable[
-            [Concatenate[Context, P]],
+            Concatenate[Context, P],
             Coro[T]
         ],
     ]:
@@ -440,11 +440,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self,
         function: Union[
             Callable[
-                [Concatenate[CogT, Context, P]],
+                Concatenate[CogT, Context, P],
                 Coro[T]
             ],
             Callable[
-                [Concatenate[Context, P]],
+                Concatenate[Context, P],
                 Coro[T]
             ],
         ],
@@ -1368,11 +1368,11 @@ class GroupMixin(Generic[CogT]):
         [
             Union[
                 Callable[
-                    [Concatenate[CogT, ContextT, P]],
+                    Concatenate[CogT, ContextT, P],
                     Coro[T]
                 ],
                 Callable[
-                    [Concatenate[ContextT, P]],
+                    Concatenate[ContextT, P],
                     Coro[T]
                 ],
             ]
@@ -1391,7 +1391,7 @@ class GroupMixin(Generic[CogT]):
     ) -> Callable[
         [
             Callable[
-                 [Concatenate[ContextT, P]],
+                 Concatenate[ContextT, P],
                  Coro[Any]
             ]
         ],
@@ -1408,7 +1408,7 @@ class GroupMixin(Generic[CogT]):
     ) -> Callable[
         [
             Callable[
-                [Concatenate[ContextT, P]],
+                Concatenate[ContextT, P],
                 Coro[Any]
             ]
         ],
@@ -1423,7 +1423,7 @@ class GroupMixin(Generic[CogT]):
             A decorator that converts the provided method into a Command, adds it to the bot, then returns it.
         """
 
-        def decorator(func: Callable[[Concatenate[ContextT, P]], Coro[Any]]) -> CommandT:
+        def decorator(func: Callable[Concatenate[ContextT, P], Coro[Any]]) -> CommandT:
             kwargs.setdefault("parent", self)
             result = command(name=name, cls=cls, *args, **kwargs)(func)
             self.add_command(result)
@@ -1441,8 +1441,8 @@ class GroupMixin(Generic[CogT]):
     ) -> Callable[
         [
             Union[
-                Callable[[Concatenate[CogT, ContextT, P]], Coro[T]],
-                Callable[[Concatenate[ContextT, P]], Coro[T]],
+                Callable[Concatenate[CogT, ContextT, P], Coro[T]],
+                Callable[Concatenate[ContextT, P], Coro[T]],
             ]
         ],
         Group[CogT, P, T],
@@ -1456,7 +1456,7 @@ class GroupMixin(Generic[CogT]):
         cls: Type[GroupT] = ...,
         *args: Any,
         **kwargs: Any,
-    ) -> Callable[[Callable[[Concatenate[ContextT, P]], Coro[Any]]], GroupT]:
+    ) -> Callable[[Callable[Concatenate[ContextT, P], Coro[Any]]], GroupT]:
         ...
 
     def group(
@@ -1465,7 +1465,7 @@ class GroupMixin(Generic[CogT]):
         cls: Type[GroupT] = MISSING,
         *args: Any,
         **kwargs: Any,
-    ) -> Callable[[Callable[[Concatenate[ContextT, P]], Coro[Any]]], GroupT]:
+    ) -> Callable[[Callable[Concatenate[ContextT, P], Coro[Any]]], GroupT]:
         """A shortcut decorator that invokes :func:`.group` and adds it to
         the internal command list via :meth:`~.GroupMixin.add_command`.
 
@@ -1475,7 +1475,7 @@ class GroupMixin(Generic[CogT]):
             A decorator that converts the provided method into a Group, adds it to the bot, then returns it.
         """
 
-        def decorator(func: Callable[[Concatenate[ContextT, P]], Coro[Any]]) -> GroupT:
+        def decorator(func: Callable[Concatenate[ContextT, P], Coro[Any]]) -> GroupT:
             kwargs.setdefault("parent", self)
             result = group(name=name, cls=cls, *args, **kwargs)(func)
             self.add_command(result)
@@ -1607,8 +1607,8 @@ def command(
 ) -> Callable[
     [
         Union[
-            Callable[Concatenate[CogT, ContextT, P]], Coro[T],
-            Callable[Concatenate[ContextT, P]], Coro[T],
+            CallableConcatenate[CogT, ContextT, P], Coro[T],
+            CallableConcatenate[ContextT, P], Coro[T],
         ]
     ],
     Command[CogT, P, T],
@@ -1624,8 +1624,8 @@ def command(
 ) -> Callable[
     [
         Union[
-            Callable[[Concatenate[CogT, ContextT, P]], Coro[T]],
-            Callable[[Concatenate[ContextT, P]], Coro[T]],
+            Callable[Concatenate[CogT, ContextT, P], Coro[T]],
+            Callable[Concatenate[ContextT, P], Coro[T]],
         ]
     ],
     Command[CogT, P, T],
@@ -1641,8 +1641,8 @@ def command(
 ) -> Callable[
     [
         Union[
-            Callable[[Concatenate[CogT, ContextT, P]], Coro[Any]],
-            Callable[[Concatenate[ContextT, P]], Coro[Any]],
+            Callable[Concatenate[CogT, ContextT, P], Coro[Any]],
+            Callable[Concatenate[ContextT, P], Coro[Any]],
         ]
     ],
     CommandT,
@@ -1655,8 +1655,8 @@ def command(
 ) -> Callable[
     [
         Union[
-            Callable[[Concatenate[ContextT, P]], Coro[Any]],
-            Callable[[Concatenate[CogT, ContextT, P]], Coro[T]],
+            Callable[Concatenate[ContextT, P], Coro[Any]],
+            Callable[Concatenate[CogT, ContextT, P], Coro[T]],
         ]
     ],
     Union[Command[CogT, P, T], CommandT],
@@ -1695,8 +1695,8 @@ def command(
 
     def decorator(
         func: Union[
-            Callable[[Concatenate[ContextT, P]], Coro[Any]],
-            Callable[[Concatenate[CogT, ContextT, P]], Coro[Any]],
+            Callable[Concatenate[ContextT, P], Coro[Any]],
+            Callable[Concatenate[CogT, ContextT, P], Coro[Any]],
         ]
     ) -> CommandT:
         if isinstance(func, Command):
@@ -1714,8 +1714,8 @@ def group(
 ) -> Callable[
     [
         Union[
-            Callable[[Concatenate[CogT, ContextT, P]], Coro[T]],
-            Callable[[Concatenate[ContextT, P]], Coro[T]],
+            Callable[Concatenate[CogT, ContextT, P], Coro[T]],
+            Callable[Concatenate[ContextT, P], Coro[T]],
         ]
     ],
     Group[CogT, P, T],
@@ -1731,8 +1731,8 @@ def group(
 ) -> Callable[
     [
         Union[
-            Callable[[Concatenate[CogT, ContextT, P]], Coro[Any]],
-            Callable[[Concatenate[ContextT, P]], Coro[Any]],
+            Callable[Concatenate[CogT, ContextT, P], Coro[Any]],
+            Callable[Concatenate[ContextT, P], Coro[Any]],
         ]
     ],
     GroupT,
@@ -1747,8 +1747,8 @@ def group(
 ) -> Callable[
     [
         Union[
-            Callable[[Concatenate[ContextT, P]], Coro[Any]],
-            Callable[[Concatenate[CogT, ContextT, P]], Coro[T]],
+            Callable[Concatenate[ContextT, P], Coro[Any]],
+            Callable[Concatenate[CogT, ContextT, P], Coro[T]],
         ]
     ],
     Union[Group[CogT, P, T], GroupT],

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1608,7 +1608,7 @@ def command(
     [
         Union[
             Callable[Concatenate[CogT, ContextT, P]], Coro[T],
-            CallableConcatenate[ContextT, P], Coro[T],
+            Callable[Concatenate[ContextT, P]], Coro[T],
         ]
     ],
     Command[CogT, P, T],


### PR DESCRIPTION
## Summary

Reverts #1435, as it is incorrect. 
Ref: https://docs.python.org/3/library/typing.html?highlight=concatenate#typing.Concatenate

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
