### PR TITLE
fix(ext.bridge): name being passed twice in groups

### DIFF
--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -277,7 +277,8 @@ class BridgeCommandGroup(BridgeCommand):
     """
     def __init__(self, callback, *args, **kwargs):
         self.ext_variant: BridgeExtGroup = BridgeExtGroup(callback, *args, **kwargs)
-        self.slash_variant: BridgeSlashGroup = BridgeSlashGroup(callback, self.ext_variant.name, *args, **kwargs)
+        name = kwargs.pop("name", self.ext_variant.name)
+        self.slash_variant: BridgeSlashGroup = BridgeSlashGroup(callback, name, *args, **kwargs)
         self.subcommands: List[BridgeCommand] = []
 
         self.mapped: Optional[SlashCommand] = None


### PR DESCRIPTION
## Summary
Fix #1628

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
