### PR TITLE
fix(ext.bridge): bridge groups failing

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -178,12 +178,9 @@ class CogMeta(type):
                 if elem in listeners:
                     del listeners[elem]
 
-                try:
-                    if getattr(value, "parent") is not None and isinstance(value, ApplicationCommand):
-                        # Skip commands if they are a part of a group
-                        continue
-                except AttributeError:
-                    pass
+                if getattr(value, "parent", None) and isinstance(value, ApplicationCommand):
+                    # Skip commands if they are a part of a group
+                    continue
 
                 is_static_method = isinstance(value, staticmethod)
                 if is_static_method:
@@ -195,10 +192,8 @@ class CogMeta(type):
                         raise TypeError(no_bot_cog.format(base, elem))
                     commands[elem] = value
 
-                try:
-                    # a test to see if this value is a BridgeCommand
-                    getattr(value, "add_to")
-
+                # a test to see if this value is a BridgeCommand
+                if hasattr(value, "add_to") and not getattr(value, "parent", None):
                     if is_static_method:
                         raise TypeError(f"Command in method {base}.{elem!r} must not be staticmethod.")
                     if elem.startswith(("cog_", "bot_")):
@@ -206,9 +201,6 @@ class CogMeta(type):
 
                     commands[f"ext_{elem}"] = value.ext_variant
                     commands[f"application_{elem}"] = value.slash_variant
-                except AttributeError:
-                    # we are confident that the value is not a Bridge Command
-                    pass
 
                 if inspect.iscoroutinefunction(value):
                     try:

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -87,6 +87,7 @@ class BridgeSlashGroup(SlashCommandGroup):
     def __init__(self, callback, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.callback = callback
+        self.__original_kwargs__["callback"] = callback
         self.__command = None
 
     async def _invoke(self, ctx: BridgeApplicationContext) -> None:
@@ -107,6 +108,7 @@ class BridgeExtGroup(BridgeExtCommand, Group):
     """A subclass of :class:`.ext.commands.Group` that is used for bridge commands."""
     pass
 
+
 class BridgeCommand:
     """Compatibility class between prefixed-based commands and slash commands.
 
@@ -122,10 +124,13 @@ class BridgeCommand:
     callback: Callable[[:class:`.BridgeContext`, ...], Awaitable[Any]]
         The callback to invoke when the command is executed. The first argument will be a :class:`BridgeContext`,
         and any additional arguments will be passed to the callback. This callback must be a coroutine.
+    parent: Optional[:class:`.BridgeCommandGroup`]:
+        Parent of the BridgeCommand.
     kwargs: Optional[Dict[:class:`str`, Any]]
         Keyword arguments that are directly passed to the respective command constructors. (:class:`.SlashCommand` and :class:`.ext.commands.Command`)
     """
     def __init__(self, callback, **kwargs):
+        self.parent = kwargs.pop("parent")
         self.slash_variant: BridgeSlashCommand = kwargs.pop("slash_variant", None) or BridgeSlashCommand(callback, **kwargs)
         self.ext_variant: BridgeExtCommand = kwargs.pop("ext_variant", None) or BridgeExtCommand(callback, **kwargs)
 
@@ -295,8 +300,8 @@ class BridgeCommandGroup(BridgeCommand):
         """
         def wrap(callback):
             slash = self.slash_variant.command(*args, **filter_params(kwargs, brief="description"), cls=BridgeSlashCommand)(callback)
-            ext = self.ext_variant.command(*args, **filter_params(kwargs, description="brief"), cls=BridgeExtGroup)(callback)
-            command = BridgeCommand(callback, slash_variant=slash, ext_variant=ext)
+            ext = self.ext_variant.command(*args, **filter_params(kwargs, description="brief"), cls=BridgeExtCommand)(callback)
+            command = BridgeCommand(callback, parent=self, slash_variant=slash, ext_variant=ext)
             self.subcommands.append(command)
             return command
 

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -130,7 +130,7 @@ class BridgeCommand:
         Keyword arguments that are directly passed to the respective command constructors. (:class:`.SlashCommand` and :class:`.ext.commands.Command`)
     """
     def __init__(self, callback, **kwargs):
-        self.parent = kwargs.pop("parent")
+        self.parent = kwargs.pop("parent", None)
         self.slash_variant: BridgeSlashCommand = kwargs.pop("slash_variant", None) or BridgeSlashCommand(callback, **kwargs)
         self.ext_variant: BridgeExtCommand = kwargs.pop("ext_variant", None) or BridgeExtCommand(callback, **kwargs)
 


### PR DESCRIPTION
## Summary
Fix #1629

Bridge group commands fail because
1. SlashCommandGroups don't have a callback parameter
2. Cogs took the variants of the subcommands of the [bridge] group (e.g. BridgeGroup.subcommands[0].slash_variant) as regular commands which also breaks everything

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.