### PR TITLE
Add more fields to `AppInfo`

### DIFF
--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -1,8 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2015-2021 Rapptz
-Copyright (c) 2021-present Pycord Development
+Copyright (c) 2015-present Rapptz
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -25,11 +24,17 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import List, Optional, TypedDict
+from typing import TypedDict, List, Optional
+from typing_extensions import NotRequired
 
-from .snowflake import Snowflake
-from .team import Team
 from .user import User
+from .team import Team
+from .snowflake import Snowflake
+
+
+class InstallParams(TypedDict):
+    scopes: List[str]
+    permissions: str
 
 
 class BaseAppInfo(TypedDict):
@@ -41,25 +46,25 @@ class BaseAppInfo(TypedDict):
     description: str
 
 
-class _AppInfoOptional(TypedDict, total=False):
-    team: Team
-    guild_id: Snowflake
-    primary_sku_id: Snowflake
-    slug: str
-    terms_of_service_url: str
-    privacy_policy_url: str
-    hook: bool
-    max_participants: int
-
-
-class AppInfo(BaseAppInfo, _AppInfoOptional):
+class AppInfo(BaseAppInfo):
     rpc_origins: List[str]
     owner: User
     bot_public: bool
     bot_require_code_grant: bool
+    team: NotRequired[Team]
+    guild_id: NotRequired[Snowflake]
+    primary_sku_id: NotRequired[Snowflake]
+    slug: NotRequired[str]
+    terms_of_service_url: NotRequired[str]
+    privacy_policy_url: NotRequired[str]
+    hook: NotRequired[bool]
+    max_participants: NotRequired[int]
+    tags: NotRequired[List[str]]
+    install_params: NotRequired[InstallParams]
+    custom_install_url: NotRequired[str]
 
 
-class _PartialAppInfoOptional(TypedDict, total=False):
+class PartialAppInfo(BaseAppInfo, total=False):
     rpc_origins: List[str]
     cover_image: str
     hook: bool
@@ -69,5 +74,6 @@ class _PartialAppInfoOptional(TypedDict, total=False):
     flags: int
 
 
-class PartialAppInfo(_PartialAppInfoOptional, BaseAppInfo):
-    pass
+class GatewayAppInfo(TypedDict):
+    id: Snowflake
+    flags: int


### PR DESCRIPTION
## Summary

Steal `appinfo.py` from [discord.py](https://github.com/Rapptz/discord.py/blob/master/discord/appinfo.py).

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
