### PR TITLE
[ext.bridge] Permission decorators and invoke function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1655](https://github.com/Pycord-Development/pycord/pull/1655))
 - `delete_message_seconds` parameter in ban methods. ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
 - New `View.get_item()` method. ([#1659](https://github.com/Pycord-Development/pycord/pull/1659))
+- Permissions support for bridge commands. ([#1642](https://github.com/Pycord-Development/pycord/pull/1642))
+- New `BridgeCommand.invoke()` method. ([#1642](https://github.com/Pycord-Development/pycord/pull/1642))
 
 ### Deprecated
 - The `delete_message_days` parameter in ban methods is now deprecated. Please use `delete_message_seconds` instead.

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -244,7 +244,7 @@ class CogMeta(type):
                 # ignore bridge commands
                 cmd = getattr(new_cls, command.callback.__name__, None)
                 if hasattr(cmd, "add_to"):
-                    setattr(cmd, f"{name_filter(command).replace('app', 'slash')}_variant", command)  # hacker man
+                    setattr(cmd, f"{name_filter(command).replace('app', 'slash')}_variant", command)
                 else:
                     setattr(new_cls, command.callback.__name__, command)
 

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -201,9 +201,8 @@ class CogMeta(type):
 
                     commands[f"ext_{elem}"] = value.ext_variant
                     commands[f"app_{elem}"] = value.slash_variant
-                    if hasattr(value, "subcommands"):
-                        for cmd in value.subcommands:
-                            commands[f"ext_{cmd.ext_variant.qualified_name}"] = cmd.ext_variant
+                    for cmd in getattr(value, "subcommands", []):
+                        commands[f"ext_{cmd.ext_variant.qualified_name}"] = cmd.ext_variant
 
                 if inspect.iscoroutinefunction(value):
                     try:
@@ -232,7 +231,7 @@ class CogMeta(type):
         # r.e type ignore, type-checker complains about overriding a ClassVar
         new_cls.__cog_commands__ = tuple(c._update_copy(cmd_attrs) for c in new_cls.__cog_commands__)  # type: ignore
 
-        lookup = {f"app_{cmd.qualified_name}" if isinstance(cmd, ApplicationCommand) else f"ext_{cmd.qualified_name}": cmd for cmd in new_cls.__cog_commands__}
+        lookup = {f"{'app' if isinstance(command, ApplicationCommand) else 'ext'}_{cmd.qualified_name}": cmd for cmd in new_cls.__cog_commands__}
 
         # Update the Command instances dynamically as well
         for command in new_cls.__cog_commands__:

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -31,6 +31,7 @@ import pathlib
 import sys
 import types
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -55,6 +56,10 @@ from .commands import (
     SlashCommandGroup,
     _BaseCommand,
 )
+
+if TYPE_CHECKING:
+    from .ext.bridge import BridgeCommand
+
 
 __all__ = (
     "CogMeta",
@@ -195,20 +200,16 @@ class CogMeta(type):
                         raise TypeError(no_bot_cog.format(base, elem))
                     commands[elem] = value
 
-                try:
-                    # a test to see if this value is a BridgeCommand
-                    getattr(value, "add_to")
-
+                # a test to see if this value is a BridgeCommand
+                if hasattr(value, "add_to"):
+                    value: BridgeCommand
                     if is_static_method:
                         raise TypeError(f"Command in method {base}.{elem!r} must not be staticmethod.")
                     if elem.startswith(("cog_", "bot_")):
                         raise TypeError(no_bot_cog.format(base, elem))
 
-                    commands[f"ext_{elem}"] = value.get_ext_command()
-                    commands[f"application_{elem}"] = value.get_application_command()
-                except AttributeError:
-                    # we are confident that the value is not a Bridge Command
-                    pass
+                    commands[f"ext_{elem}"] = value.ext_variant
+                    commands[f"application_{elem}"] = value.slash_variant
 
                 if inspect.iscoroutinefunction(value):
                     try:

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -201,8 +201,9 @@ class CogMeta(type):
 
                     commands[f"ext_{elem}"] = value.ext_variant
                     commands[f"app_{elem}"] = value.slash_variant
-                    for cmd in value.subcommands:
-                        commands[f"ext_{cmd.ext_variant.qualified_name}"] = cmd.ext_variant
+                    if hasattr(value, "subcommands"):
+                        for cmd in value.subcommands:
+                            commands[f"ext_{cmd.ext_variant.qualified_name}"] = cmd.ext_variant
 
                 if inspect.iscoroutinefunction(value):
                     try:

--- a/discord/commands/permissions.py
+++ b/discord/commands/permissions.py
@@ -95,7 +95,7 @@ def guild_only() -> Callable:
         @bot.slash_command()
         @guild_only()
         async def test(ctx):
-            await ctx.respond('You\'re in a guild.')
+            await ctx.respond("You're in a guild.")
 
     """
 

--- a/discord/commands/permissions.py
+++ b/discord/commands/permissions.py
@@ -104,6 +104,7 @@ def guild_only() -> Callable:
             command.guild_only = True
         else:
             command.__guild_only__ = True
+
         return command
 
     return inner

--- a/discord/ext/bridge/context.py
+++ b/discord/ext/bridge/context.py
@@ -35,9 +35,7 @@ from discord.webhook import WebhookMessage
 from ..commands import Context
 
 if TYPE_CHECKING:
-    #from .core import BridgeCommand
-    from ...commands import ApplicationCommand
-    from ..commands import Command
+    from .core import BridgeSlashCommand, BridgeExtCommand
 
 
 __all__ = ("BridgeContext", "BridgeExtContext", "BridgeApplicationContext")
@@ -82,7 +80,7 @@ class BridgeContext(ABC):
         ...
 
     @overload
-    async def invoke(self, command: Union[BridgeApplicationContext, BridgeExtContext], *args, **kwargs) -> None:
+    async def invoke(self, command: Union[BridgeSlashCommand, BridgeExtCommand], *args, **kwargs) -> None:
         ...
 
     async def respond(

--- a/discord/ext/bridge/context.py
+++ b/discord/ext/bridge/context.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, overload, Optional, Union
 
 from discord.commands import ApplicationContext
 from discord.interactions import Interaction, InteractionMessage
@@ -35,7 +35,7 @@ from discord.webhook import WebhookMessage
 from ..commands import Context
 
 if TYPE_CHECKING:
-    from .core import BridgeCommand
+    #from .core import BridgeCommand
     from ...commands import ApplicationCommand
     from ..commands import Command
 
@@ -81,8 +81,8 @@ class BridgeContext(ABC):
     async def _edit(self, *args, **kwargs) -> Union[InteractionMessage, Message]:
         ...
 
-    @abstractmethod
-    async def invoke(self, command: Union[ApplicationCommand, Command, BridgeCommand], *args, **kwargs) -> None:
+    @overload
+    async def invoke(self, command: Union[BridgeApplicationContext, BridgeExtContext], *args, **kwargs) -> None:
         ...
 
     async def respond(
@@ -157,11 +157,6 @@ class BridgeApplicationContext(BridgeContext, ApplicationContext):
     async def _edit(self, *args, **kwargs) -> InteractionMessage:
         return await self._get_super("edit")(*args, **kwargs)
 
-    async def invoke(self, command: Union[ApplicationCommand, BridgeCommand], /, *args, **kwargs):
-        if hasattr(command, "slash_variant"):
-            return self.invoke(command.slash_variant)
-        return super().invoke(command, *args, **kwargs)
-
 
 class BridgeExtContext(BridgeContext, Context):
     """
@@ -206,8 +201,3 @@ class BridgeExtContext(BridgeContext, Context):
         """
         if self._original_response_message:
             await self._original_response_message.delete(delay=delay, reason=reason)
-
-    async def invoke(self, command: Union[Command, BridgeCommand], /, *args, **kwargs):
-        if hasattr(command, "ext_variant"):
-            return self.invoke(command.ext_variant)
-        return super().invoke(command, *args, **kwargs)

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -431,7 +431,7 @@ def has_permissions(**perms: Dict[str, bool]):
         from ..commands import has_permissions
 
         func = has_permissions(**perms)(func)
-        perms = Permissions(**perms)
+        _perms = Permissions(**perms)
         if isinstance(func, ApplicationCommand):
             func.default_member_permissions = perms
         else:

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -339,7 +339,7 @@ def bridge_group(**kwargs):
     Parameters
     ----------
     kwargs: Optional[Dict[:class:`str`, Any]]
-        Keyword arguments that are directly passed to the respective command constructors. (:class:`.SlashCommandGroup` and :class:`.ext.commands.Group`)
+        Keyword arguments that are directly passed to the respective command constructors (:class:`.SlashCommandGroup` and :class:`.ext.commands.Group`).
     """
     def decorator(callback):
         return BridgeCommandGroup(callback, **kwargs)
@@ -387,10 +387,10 @@ def map_to(name, description = None):
 
 
 def guild_only():
-    """Intended to work with :class:`ApplicationCommand` and :class:`BridgeCommand`, adds a :func:`~ext.commands.check`
+    """Intended to work with :class:`.ApplicationCommand` and :class:`BridgeCommand`, adds a :func:`~ext.commands.check`
     that locks the command to only run in guilds, and also registers the command as guild only client-side (on discord).
 
-    Basically a utility function that wraps both :func:`~ext.commands.guild_only` and :func:`permissions.guild_only`.
+    Basically a utility function that wraps both :func:`discord.ext.commands.guild_only` and :func:`discord.commands.guild_only`.
     """
     def predicate(callback: Callable):
         callback.__guild_only__ = True
@@ -403,12 +403,12 @@ def guild_only():
 
 
 def has_permissions(**perms: bool):
-    """Intended to work with :class:`SlashCommand` and :class:`BridgeCommand`, adds a
+    """Intended to work with :class:`.SlashCommand` and :class:`BridgeCommand`, adds a
     :func:`~ext.commands.check` that locks the command to be run by people with certain
     permissions inside guilds, and also registers the command as locked behind said permissions.
 
-    Basically a utility function that wraps both :func:`~ext.commands.has_permission`
-    and :func:`permissions.default_permissions`.
+    Basically a utility function that wraps both :func:`discord.ext.commands.has_permissions`
+    and :func:`discord.commands.default_permissions`.
 
     Parameters
     ----------

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -326,7 +326,7 @@ def bridge_command(**kwargs):
     kwargs: Optional[Dict[:class:`str`, Any]]
         Keyword arguments that are directly passed to the respective command constructors. (:class:`.SlashCommand` and :class:`.ext.commands.Command`)
     """
-    def decorator(callback: Callable):
+    def decorator(callback):
         return BridgeCommand(callback, **kwargs)
 
     return decorator
@@ -340,7 +340,7 @@ def bridge_group(**kwargs):
     kwargs: Optional[Dict[:class:`str`, Any]]
         Keyword arguments that are directly passed to the respective command constructors. (:class:`.SlashCommandGroup` and :class:`.ext.commands.Group`)
     """
-    def decorator(callback: Callable):
+    def decorator(callback):
         return BridgeCommandGroup(callback, **kwargs)
 
     return decorator
@@ -378,7 +378,7 @@ def map_to(name, description = None):
         The new description of the mapped command.
     """
 
-    def decorator(callback: Callable):
+    def decorator(callback):
         callback.__custom_map_to__ = {"name": name, "description": description}
         return callback
 

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -58,7 +58,7 @@ __all__ = (
     "BridgeSlashGroup",
     "map_to",
     "guild_only",
-    "has_permissions"
+    "has_permissions",
 )
 
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -2096,7 +2096,7 @@ def has_permissions(**perms: bool) -> Callable[[T], T]:
 
     Parameters
     ------------
-    perms
+    \*\*perms: Dict[:class:`str`, :class:`bool`]
         An argument list of permissions to check for.
 
     Example

--- a/docs/ext/bridge/api.rst
+++ b/docs/ext/bridge/api.rst
@@ -51,9 +51,6 @@ BridgeCommand
 .. autoclass:: discord.ext.bridge.BridgeCommand
     :members:
 
-.. automethod:: discord.ext.bridge.bridge_command()
-    :decorator:
-
 BridgeCommandGroup
 ~~~~~~~~~~~~~~~~~~~
 
@@ -62,10 +59,21 @@ BridgeCommandGroup
 .. autoclass:: discord.ext.bridge.BridgeCommandGroup
     :members:
 
+Decorators
+~~~~~~~~~~~
+.. automethod:: discord.ext.bridge.bridge_command()
+    :decorator:
+
 .. automethod:: discord.ext.bridge.bridge_group()
     :decorator:
 
 .. automethod:: discord.ext.bridge.map_to()
+    :decorator:
+
+.. automethod:: discord.ext.bridge.guild_only()
+    :decorator:
+
+.. automethod:: discord.ext.bridge.has_permissions()
     :decorator:
 
 Command Subclasses


### PR DESCRIPTION
## Summary
- A `guild_only` and `has_permissions` decorator that can be used for both app and bridge commands for "frontend" *and* "backend" validation.
- Allow BridgeCommand to be directly invoked (e.g.
```py
@bridge.bridge_command()
async def a_command(self, ctx):
    await other_bridge_cmd.invoke(ctx, ...)
```

## Information

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.