### PR TITLE
Remove unnecessary instance check in autocomplete

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -756,20 +756,19 @@ class ApplicationCommandMixin(ABC):
         await self.invoke_application_command(ctx)
 
     async def on_application_command_auto_complete(self, interaction: Interaction, command: ApplicationCommand) -> None:
-        if isinstance(command, SlashCommand):
-            async def callback() -> None:
-                ctx = await self.get_autocomplete_context(interaction)
-                ctx.command = command
-                return await command.invoke_autocomplete_callback(ctx)
+        async def callback() -> None:
+            ctx = await self.get_autocomplete_context(interaction)
+            ctx.command = command
+            return await command.invoke_autocomplete_callback(ctx)
 
-            autocomplete_task = self._bot.loop.create_task(callback())
-            try:
-                await self._bot.wait_for("application_command_auto_complete", check=lambda i, c: c == command, timeout=3)
-            except asyncio.TimeoutError:
-                return
-            else:
-                if not autocomplete_task.done():
-                    autocomplete_task.cancel()
+        autocomplete_task = self._bot.loop.create_task(callback())
+        try:
+            await self._bot.wait_for("application_command_auto_complete", check=lambda i, c: c == command, timeout=3)
+        except asyncio.TimeoutError:
+            return
+        else:
+            if not autocomplete_task.done():
+                autocomplete_task.cancel()
 
     def slash_command(self, **kwargs):
         """A shortcut decorator that invokes :func:`command` and adds it to


### PR DESCRIPTION
## Summary

Fixes #1630 

The autocomplete hooks recently had typechecking applied, which would only pass if a command was specifically a `Command`. Currently, sub-commands are an instance of `SlashCommandGroup`. Because of this, the check would fail, and autocomplete Options in subcommands would fail to execute. 

Note that `ApplicationCommand` also encompasses Bridged commands and Context (Message/User) commands. I'm happy to update this PR to change typechecking for `(Command, SlashCommandGroup)` if needed, but this is better than having subcommand autocomplete being broken.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] I have searched the open pull requests for duplicates.
- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
