### PR TITLE
Add raw_mention utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `proxy` and `proxy_auth` params to many Webhook related methods.
   ([#1655](https://github.com/Pycord-Development/pycord/pull/1655))
 - `delete_message_seconds` parameter in ban methods. ([#1557](https://github.com/Pycord-Development/pycord/pull/1557))
+- New `raw_mentions`, `raw_role_mentions` and `raw_channel_mentions` functions in `discord.utils`.
+  ([#1658](https://github.com/Pycord-Development/pycord/pull/1658))
 
 ### Deprecated
 - The `delete_message_days` parameter in ban methods is now deprecated. Please use `delete_message_seconds` instead.

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -947,7 +947,7 @@ def raw_mentions(text: str) -> List[int]:
     List[:class:`int`]
         A list of user IDs found in the string.
     """
-    return [int(x) for x in re.findall(r"<@!?([0-9]{15,20})>", text)]
+    return [int(x) for x in re.findall(r"<@!?([0-9]+)>", text)]
 
 def raw_channel_mentions(text: str) -> List[int]:
     """Returns a list of channel IDs matching ``<@#channel_id>`` in the string.
@@ -962,7 +962,7 @@ def raw_channel_mentions(text: str) -> List[int]:
     List[:class:`int`]
         A list of channel IDs found in the string.
     """
-    return [int(x) for x in re.findall(r"<#([0-9]{15,20})>", text)]
+    return [int(x) for x in re.findall(r"<#([0-9]+)>", text)]
 
 def raw_role_mentions(text: str) -> List[int]:
     """Returns a list of role IDs matching ``<@&role_id>`` in the string.
@@ -977,7 +977,7 @@ def raw_role_mentions(text: str) -> List[int]:
     List[:class:`int`]
         A list of role IDs found in the string.
     """
-    return [int(x) for x in re.findall(r"<@&([0-9]{15,20})>", text)]
+    return [int(x) for x in re.findall(r"<@&([0-9]+)>", text)]
 
 def _chunk(iterator: Iterator[T], max_size: int) -> Iterator[List[T]]:
     ret = []

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -88,6 +88,9 @@ __all__ = (
     "remove_markdown",
     "escape_markdown",
     "escape_mentions",
+    "raw_mentions",
+    "raw_channel_mentions",
+    "raw_role_mentions",
     "as_chunks",
     "format_dt",
     "basic_autocomplete",
@@ -931,6 +934,50 @@ def escape_mentions(text: str) -> str:
     """
     return re.sub(r"@(everyone|here|[!&]?[0-9]{17,20})", "@\u200b\\1", text)
 
+def raw_mentions(text: str) -> List[int]:
+    """Returns a list of user IDs matching ``<@user_id>`` in the string.
+
+    Parameters
+    -----------
+    text: :class:`str`
+        The string to get user mentions from.
+
+    Returns
+    --------
+    List[:class:`int`]
+        A list of user IDs found in the string.
+    """
+    return [int(x) for x in re.findall(r"<@!?([0-9]{15,20})>", text)]
+
+def raw_channel_mentions(text: str) -> List[int]:
+    """Returns a list of channel IDs matching ``<@#channel_id>`` in the string.
+
+    Parameters
+    -----------
+    text: :class:`str`
+        The string to get channel mentions from.
+
+    Returns
+    --------
+    List[:class:`int`]
+        A list of channel IDs found in the string.
+    """
+    return [int(x) for x in re.findall(r"<#([0-9]{15,20})>", text)]
+
+def raw_role_mentions(text: str) -> List[int]:
+    """Returns a list of role IDs matching ``<@&role_id>`` in the string.
+
+    Parameters
+    -----------
+    text: :class:`str`
+        The string to get role mentions from.
+
+    Returns
+    --------
+    List[:class:`int`]
+        A list of role IDs found in the string.
+    """
+    return [int(x) for x in re.findall(r"<@&([0-9]{15,20})>", text)]
 
 def _chunk(iterator: Iterator[T], max_size: int) -> Iterator[List[T]]:
     ret = []


### PR DESCRIPTION
## Summary
Reimplements the various `raw_mentions` properties from `discord.Message` under `discord.utils`. `Message.raw_mentions` can't be used with regular strings, which is an increasing use case with slash commands.

Also considering a followup commit for automatically converting them (e.g. `resolve_mentions`?) as counterparts to `Message.mentions`, `Message.channel_mentions` and `Message.role_mentions` but not sure where to implement. Possibly under Guild?
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
