### PR TITLE
Add View.get_item shortcut method

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -52,6 +52,7 @@ from ..components import Component
 from ..components import SelectMenu as SelectComponent
 from ..components import _component_factory
 from .item import Item, ItemCallbackType
+from ..utils import get
 
 __all__ = ("View",)
 
@@ -311,6 +312,21 @@ class View:
         """Removes all items from the view."""
         self.children.clear()
         self.__weights.clear()
+
+    def get_item(self, custom_id: str) -> Optional[Item]:
+        """Get an item from the view by its ``custom_id``.
+
+        Parameters
+        -----------
+        custom_id: :class:`str`
+            The custom_id of the item to get
+
+        Returns
+        --------
+        Optional[:class:`Item`]
+            The item with the matching ``custom_id`` if it exists.
+        """
+        return get(self.children, custom_id=custom_id)
 
     async def interaction_check(self, interaction: Interaction) -> bool:
         """|coro|

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -314,7 +314,7 @@ class View:
         self.__weights.clear()
 
     def get_item(self, custom_id: str) -> Optional[Item]:
-        """Get an item from the view by its ``custom_id``.
+        """Get an item from the view by its ``custom_id``. Alias for `utils.get(view.children, custom_id=custom_id)`.
 
         Parameters
         -----------

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -314,7 +314,7 @@ class View:
         self.__weights.clear()
 
     def get_item(self, custom_id: str) -> Optional[Item]:
-        """Get an item from the view by its ``custom_id``. Alias for `utils.get(view.children, custom_id=custom_id)`.
+        """Get an item from the view with the given custom ID. Alias for `utils.get(view.children, custom_id=custom_id)`.
 
         Parameters
         -----------


### PR DESCRIPTION
## Summary
Adds a method to get an item from a View by its `custom_id`.
This is ultimately just a shortcut to `utils.get`, however it appears to be a rather common use case and as such is implemented for convenience.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
