### PR TITLE
Remove dapi server from links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,4 +141,3 @@ Useful Links
 - `Learn how to create Discord bots with Pycord <https://guide.pycord.dev>`_
 - `Our Official Discord Server <https://pycord.dev/discord>`_
 - `Official Discord Developers Server <https://discord.gg/discord-developers>`_
-- `Unofficial Discord API Server <https://discord.gg/discord-api>`_


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The Unofficial Discord API server has made their stance on Pycord clear: Our library is not and will never be welcome in the server. Hence, there is no reason for us to include it in our README.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
