### PR TITLE
Fixes to SlashCommand.mention using qualified_id

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -589,7 +589,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         This is the root parent ID. For example, in ``/one two three``
         the qualified ID would return ``one.id``.
         """
-        if getattr(self, "parent", None) is not None:
+        if self.id is None:
             return self.parent.qualified_id
         return self.id
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -582,6 +582,17 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         else:
             return self.name
 
+    @property
+    def qualified_id(self) -> int:
+        """:class:`int`: Retrieves the fully qualified command ID.
+
+        This is the root parent ID. For example, in ``/one two three``
+        the qualified ID would return ``one.id``.
+        """
+        if getattr(self, "parent", None) is not None:
+            return self.parent.qualified_id
+        return self.id
+
     def to_dict(self) -> dict[str, Any]:
         raise NotImplementedError
 
@@ -823,7 +834,7 @@ class SlashCommand(ApplicationCommand):
 
     @property
     def mention(self) -> str:
-        return f"</{self.qualified_name}:{self.id}>"
+        return f"</{self.qualified_name}:{self.qualified_id}>"
 
     def to_dict(self) -> dict:
         as_dict = {


### PR DESCRIPTION
## Summary

Currently, mentions in groups are broken as subcommands do not have an ID. As such, `qualified_id` is implemented to return the parent ID and then implemented in `mention`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
