### PR TITLE
Add brief Attribute to BridgeSlashCommand

### DIFF
--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -329,12 +329,12 @@ class BridgeCommandGroup(BridgeCommand):
         def wrap(callback):
             slash = self.slash_variant.command(
                 *args,
-                **filter_params(kwargs, brief="description"),
+                **kwargs,
                 cls=BridgeSlashCommand,
             )(callback)
             ext = self.ext_variant.command(
                 *args,
-                **filter_params(kwargs, description="brief"),
+                **kwargs,
                 cls=BridgeExtCommand,
             )(callback)
             command = BridgeCommand(

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -75,7 +75,7 @@ class BridgeSlashCommand(SlashCommand):
     """A subclass of :class:`.SlashCommand` that is used for bridge commands."""
 
     def __init__(self, func, **kwargs):
-        kwargs = filter_params(kwargs, brief="description")
+        self.brief = kwargs.pop('brief', None)
         super().__init__(func, **kwargs)
 
 
@@ -83,7 +83,6 @@ class BridgeExtCommand(Command):
     """A subclass of :class:`.ext.commands.Command` that is used for bridge commands."""
 
     def __init__(self, func, **kwargs):
-        kwargs = filter_params(kwargs, description="brief")
         super().__init__(func, **kwargs)
 
     async def transform(self, ctx: Context, param: inspect.Parameter) -> Any:

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -75,7 +75,7 @@ class BridgeSlashCommand(SlashCommand):
     """A subclass of :class:`.SlashCommand` that is used for bridge commands."""
 
     def __init__(self, func, **kwargs):
-        self.brief = kwargs.pop('brief', None)
+        self.brief = kwargs.pop("brief", None)
         super().__init__(func, **kwargs)
 
 


### PR DESCRIPTION
## Summary

Fixes #1619.

When tackling the issue at hand, I found in the source code that in the bridged prefixed commands, it actually removes the value of the description and switches it over to the brief. And so if we add a brief in the command, the description would replace the brief to its value. (see lines)
https://github.com/Pycord-Development/pycord/blob/fe495224d92171aafff45d5a12c0f4cd67413d1a/discord/ext/bridge/core.py#L82-L86

So it's either we remove briefs altogether in bridge commands or add briefs for bridged slash commands. I went for the latter.

I also saw in the source for bridged slash commands that apparently, if you have a brief in the command, it would mark it as a description instead? this would also cause problems if the user simply puts both a brief and description which further justifies why I chose the latter. (see lines)
https://github.com/Pycord-Development/pycord/blob/fe495224d92171aafff45d5a12c0f4cd67413d1a/discord/ext/bridge/core.py#L74-L78

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
