### PR TITLE
Fix errors that will occur in python3.11

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -31,7 +31,7 @@ import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterator, Literal, Pattern, TypeVar, Union
 
-from discord.utils import MISSING, maybe_coroutine, resolve_annotation
+from discord.utils import MISSING, MissingField, maybe_coroutine, resolve_annotation
 
 from .converter import run_converters
 from .errors import (
@@ -81,13 +81,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = MISSING
+    name: str = MissingField
     aliases: list[str] = field(default_factory=list)
-    attribute: str = MISSING
-    annotation: Any = MISSING
-    default: Any = MISSING
-    max_args: int = MISSING
-    override: bool = MISSING
+    attribute: str = MissingField
+    annotation: Any = MissingField
+    default: Any = MissingField
+    max_args: int = MissingField
+    override: bool = MissingField
     cast_to_dict: bool = False
 
     @property

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -38,6 +38,7 @@ import unicodedata
 import warnings
 from base64 import b64encode
 from bisect import bisect_left
+from dataclasses import field
 from inspect import isawaitable as _isawaitable
 from inspect import signature as _signature
 from operator import attrgetter
@@ -114,6 +115,11 @@ class _MissingSentinel:
 
 
 MISSING: Any = _MissingSentinel()
+# As of 3.11, directly setting a dataclass field to MISSING causes a ValueError. Using
+# field(default=MISSING) produces the same error, but passing a lambda to
+# default_factory produces the same behavior as default=MISSING and does not raise an
+# error.
+MissingField = field(default_factory=lambda: MISSING)
 
 
 class _cached_property:


### PR DESCRIPTION
## Summary

Fix errors that will occur in python3.11 and decorator not use function name

## Information

<!-- Put an x inside [ ] to check it, like so: [x -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
