### PR TITLE
Adjust original_message deprecation warning

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -325,7 +325,7 @@ class Interaction:
         self._original_response = message
         return message
 
-    @utils.deprecated("Interaction.original_response", "2.1")
+    @utils.deprecated("Interaction.original_response", "2.2")
     async def original_message(self):
         """An alias for :meth:`original_response`.
 
@@ -447,7 +447,7 @@ class Interaction:
 
         return message
 
-    @utils.deprecated("Interaction.edit_original_response", "2.1")
+    @utils.deprecated("Interaction.edit_original_response", "2.2")
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
 
@@ -505,7 +505,7 @@ class Interaction:
         else:
             await func
 
-    @utils.deprecated("Interaction.delete_original_response", "2.1")
+    @utils.deprecated("Interaction.delete_original_response", "2.2")
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
 


### PR DESCRIPTION
## Summary

The `original_message` methods in `Interaction` were deprecated in 2.2, not 2.1.

On another note, the deprecated methods raise a `RuntimeWarning` due to not awaiting the new `original_response` functions; should they instead use `@property` and not be called inside the function? E.g. `ApplicationContext.edit` https://github.com/Pycord-Development/pycord/blob/587874c1992ee2d739018543d4ec78a4367de203/discord/commands/context.py#L344-L347

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
