### PR TITLE
feat(docs): warning on overriding on_connect

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -645,7 +645,16 @@ class ApplicationCommandMixin(ABC):
         register all commands.
 
         By default, this coroutine is called inside the :func:`.on_connect` event. If you choose to override the
-        :func:`.on_connect` event, then you should invoke this coroutine as well.
+        :func:`.on_connect` event, then you should invoke this coroutine as well such as the follwing:
+
+        .. code-block:: python
+
+            @bot.event
+            async def on_connect():
+                if bot.auto_sync_commands:
+                    await bot.sync_commands()
+                print(f"{bot.user.name} connected.")
+
 
         .. note::
             If you remove all guild commands from a particular guild, the library may not be able to detect and update

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -655,7 +655,6 @@ class ApplicationCommandMixin(ABC):
                     await bot.sync_commands()
                 print(f"{bot.user.name} connected.")
 
-
         .. note::
             If you remove all guild commands from a particular guild, the library may not be able to detect and update
             the commands accordingly, as it would have to individually check for each guild. To force the library to

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1500,7 +1500,7 @@ class Bot(BotBase, Client):
 
         .. versionadded:: 2.0
     auto_sync_commands: :class:`bool`
-        Whether to automatically sync slash commands. This will call sync_commands in on_connect, and in
+        Whether to automatically sync slash commands. This will call :meth:`~.Bot.sync_commands` in :func:`discord.on_connect`, and in
         :attr:`.process_application_commands` if the command is not found. Defaults to ``True``.
 
         .. versionadded:: 2.0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -575,7 +575,7 @@ Connection
     .. warning::
 
         Overriding this event will not call :meth:`Bot.sync_commands`.
-        As a result, :class:`ApplicationCommand`s will not be registered.
+        As a result, :class:`ApplicationCommand` will not be registered.
 
 .. function:: on_shard_connect(shard_id)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -572,6 +572,11 @@ Connection
 
     The warnings on :func:`on_ready` also apply.
 
+    .. warning::
+
+        Overriding this event will not call :meth:`Bot.sync_commands`.
+        As a result, :class:`ApplicationCommand`s will not be registered.
+
 .. function:: on_shard_connect(shard_id)
 
     Similar to :func:`on_connect` except used by :class:`AutoShardedClient`


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
It adds a warning on the documentation about overriding `on_connect`. Also fixes a few related broken references.

Preview: https://pycord-squid-branch.readthedocs.io/en/latest/api.html#discord.Bot.auto_sync_commands
https://pycord-squid-branch.readthedocs.io/en/latest/api.html#discord.on_connect


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
