### PR TITLE
Add Docstring to Enum for Option descriptions, issue 1510

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -178,7 +178,8 @@ class Option:
         enum_choices = []
         input_type_is_class = isinstance(input_type, type)
         if input_type_is_class and issubclass(input_type, (Enum, DiscordEnum)):
-            description = inspect.getdoc(input_type)
+            if description is None:
+                description = inspect.getdoc(input_type)
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__
             if all(isinstance(elem.value, value_class) for elem in enum_choices):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -210,6 +210,7 @@ else:
 
 
 class ChannelType(Enum):
+    """Channel type"""
     text = 0
     private = 1
     voice = 2
@@ -228,6 +229,7 @@ class ChannelType(Enum):
 
 
 class MessageType(Enum):
+    """Message type"""
     default = 0
     recipient_add = 1
     recipient_remove = 2
@@ -256,6 +258,7 @@ class MessageType(Enum):
 
 
 class VoiceRegion(Enum):
+    """Voice region"""
     us_west = "us-west"
     us_east = "us-east"
     us_south = "us-south"
@@ -285,6 +288,7 @@ class VoiceRegion(Enum):
 
 
 class SpeakingState(Enum):
+    """Speaking state"""
     none = 0
     voice = 1
     soundshare = 2
@@ -298,6 +302,7 @@ class SpeakingState(Enum):
 
 
 class VerificationLevel(Enum, comparable=True):
+    """Verification level"""
     none = 0
     low = 1
     medium = 2
@@ -309,6 +314,7 @@ class VerificationLevel(Enum, comparable=True):
 
 
 class ContentFilter(Enum, comparable=True):
+    """Content Filter"""
     disabled = 0
     no_role = 1
     all_members = 2
@@ -318,6 +324,7 @@ class ContentFilter(Enum, comparable=True):
 
 
 class Status(Enum):
+    """Status"""
     online = "online"
     offline = "offline"
     idle = "idle"
@@ -331,6 +338,7 @@ class Status(Enum):
 
 
 class DefaultAvatar(Enum):
+    """Default avatar"""
     blurple = 0
     grey = 1
     gray = 1
@@ -343,17 +351,20 @@ class DefaultAvatar(Enum):
 
 
 class NotificationLevel(Enum, comparable=True):
+    """Notification level"""
     all_messages = 0
     only_mentions = 1
 
 
 class AuditLogActionCategory(Enum):
+    """Audit log action category"""
     create = 1
     delete = 2
     update = 3
 
 
 class AuditLogAction(Enum):
+    """Audit log action"""
     guild_update = 1
     channel_create = 10
     channel_update = 11
@@ -505,6 +516,7 @@ class AuditLogAction(Enum):
 
 
 class UserFlags(Enum):
+    """User flags"""
     staff = 1
     partner = 2
     hypesquad = 4
@@ -529,6 +541,7 @@ class UserFlags(Enum):
 
 
 class ActivityType(Enum):
+    """Activity type"""
     unknown = -1
     playing = 0
     streaming = 1
@@ -542,17 +555,20 @@ class ActivityType(Enum):
 
 
 class TeamMembershipState(Enum):
+    """Team membership state"""
     invited = 1
     accepted = 2
 
 
 class WebhookType(Enum):
+    """Webhook Type"""
     incoming = 1
     channel_follower = 2
     application = 3
 
 
 class ExpireBehaviour(Enum):
+    """Expire Behaviour"""
     remove_role = 0
     kick = 1
 
@@ -561,11 +577,13 @@ ExpireBehavior = ExpireBehaviour
 
 
 class StickerType(Enum):
+    """Sticker type"""
     standard = 1
     guild = 2
 
 
 class StickerFormatType(Enum):
+    """Sticker format Type"""
     png = 1
     apng = 2
     lottie = 3
@@ -581,12 +599,14 @@ class StickerFormatType(Enum):
 
 
 class InviteTarget(Enum):
+    """Invite target"""
     unknown = 0
     stream = 1
     embedded_application = 2
 
 
 class InteractionType(Enum):
+    """Interaction type"""
     ping = 1
     application_command = 2
     component = 3
@@ -595,6 +615,7 @@ class InteractionType(Enum):
 
 
 class InteractionResponseType(Enum):
+    """Interaction response type"""
     pong = 1
     # ack = 2 (deprecated)
     # channel_message = 3 (deprecated)
@@ -607,6 +628,7 @@ class InteractionResponseType(Enum):
 
 
 class VideoQualityMode(Enum):
+    """Video quality mode"""
     auto = 1
     full = 2
 
@@ -615,6 +637,7 @@ class VideoQualityMode(Enum):
 
 
 class ComponentType(Enum):
+    """Component type"""
     action_row = 1
     button = 2
     select = 3
@@ -625,6 +648,7 @@ class ComponentType(Enum):
 
 
 class ButtonStyle(Enum):
+    """Button style"""
     primary = 1
     secondary = 2
     success = 3
@@ -644,6 +668,7 @@ class ButtonStyle(Enum):
 
 
 class InputTextStyle(Enum):
+    """Input text style"""
     short = 1
     singleline = 1
     paragraph = 2
@@ -652,6 +677,7 @@ class InputTextStyle(Enum):
 
 
 class ApplicationType(Enum):
+    """Application type"""
     game = 1
     music = 2
     ticketed_events = 3
@@ -659,12 +685,14 @@ class ApplicationType(Enum):
 
 
 class StagePrivacyLevel(Enum):
+    """Stage privacy level"""
     # public = 1 (deprecated)
     closed = 2
     guild_only = 2
 
 
 class NSFWLevel(Enum, comparable=True):
+    """NSFW level"""
     default = 0
     explicit = 1
     safe = 2
@@ -672,6 +700,7 @@ class NSFWLevel(Enum, comparable=True):
 
 
 class SlashCommandOptionType(Enum):
+    """Slash command option type"""
     sub_command = 1
     sub_command_group = 2
     string = 3
@@ -743,6 +772,7 @@ class SlashCommandOptionType(Enum):
 
 
 class EmbeddedActivity(Enum):
+    """Embedded activity"""
     awkword = 879863881349087252
     betrayal = 773336526917861400
     checkers_in_the_park = 832013003968348200
@@ -777,6 +807,7 @@ class EmbeddedActivity(Enum):
 
 
 class ScheduledEventStatus(Enum):
+    """Scheduled event status"""
     scheduled = 1
     active = 2
     completed = 3
@@ -788,6 +819,7 @@ class ScheduledEventStatus(Enum):
 
 
 class ScheduledEventPrivacyLevel(Enum):
+    """Scheduled event privacy level"""
     guild_only = 2
 
     def __int__(self):
@@ -795,12 +827,14 @@ class ScheduledEventPrivacyLevel(Enum):
 
 
 class ScheduledEventLocationType(Enum):
+    """Scheduled event location type"""
     stage_instance = 1
     voice = 2
     external = 3
 
 
 class AutoModTriggerType(Enum):
+    """Automod trigger type"""
     keyword = 1
     harmful_link = 2
     spam = 3
@@ -808,16 +842,19 @@ class AutoModTriggerType(Enum):
 
 
 class AutoModEventType(Enum):
+    """Automod event type"""
     message_send = 1
 
 
 class AutoModActionType(Enum):
+    """Automod action type"""
     block_message = 1
     send_alert_message = 2
     timeout = 3
 
 
 class AutoModKeywordPresetType(Enum):
+    """Automod keyword preset type"""
     profanity = 1
     sexual_content = 2
     slurs = 3

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -211,6 +211,7 @@ else:
 
 class ChannelType(Enum):
     """Channel type"""
+
     text = 0
     private = 1
     voice = 2
@@ -230,6 +231,7 @@ class ChannelType(Enum):
 
 class MessageType(Enum):
     """Message type"""
+
     default = 0
     recipient_add = 1
     recipient_remove = 2
@@ -259,6 +261,7 @@ class MessageType(Enum):
 
 class VoiceRegion(Enum):
     """Voice region"""
+
     us_west = "us-west"
     us_east = "us-east"
     us_south = "us-south"
@@ -289,6 +292,7 @@ class VoiceRegion(Enum):
 
 class SpeakingState(Enum):
     """Speaking state"""
+
     none = 0
     voice = 1
     soundshare = 2
@@ -303,6 +307,7 @@ class SpeakingState(Enum):
 
 class VerificationLevel(Enum, comparable=True):
     """Verification level"""
+
     none = 0
     low = 1
     medium = 2
@@ -315,6 +320,7 @@ class VerificationLevel(Enum, comparable=True):
 
 class ContentFilter(Enum, comparable=True):
     """Content Filter"""
+
     disabled = 0
     no_role = 1
     all_members = 2
@@ -325,6 +331,7 @@ class ContentFilter(Enum, comparable=True):
 
 class Status(Enum):
     """Status"""
+
     online = "online"
     offline = "offline"
     idle = "idle"
@@ -339,6 +346,7 @@ class Status(Enum):
 
 class DefaultAvatar(Enum):
     """Default avatar"""
+
     blurple = 0
     grey = 1
     gray = 1
@@ -352,12 +360,14 @@ class DefaultAvatar(Enum):
 
 class NotificationLevel(Enum, comparable=True):
     """Notification level"""
+
     all_messages = 0
     only_mentions = 1
 
 
 class AuditLogActionCategory(Enum):
     """Audit log action category"""
+
     create = 1
     delete = 2
     update = 3
@@ -365,6 +375,7 @@ class AuditLogActionCategory(Enum):
 
 class AuditLogAction(Enum):
     """Audit log action"""
+
     guild_update = 1
     channel_create = 10
     channel_update = 11
@@ -517,6 +528,7 @@ class AuditLogAction(Enum):
 
 class UserFlags(Enum):
     """User flags"""
+
     staff = 1
     partner = 2
     hypesquad = 4
@@ -542,6 +554,7 @@ class UserFlags(Enum):
 
 class ActivityType(Enum):
     """Activity type"""
+
     unknown = -1
     playing = 0
     streaming = 1
@@ -556,12 +569,14 @@ class ActivityType(Enum):
 
 class TeamMembershipState(Enum):
     """Team membership state"""
+
     invited = 1
     accepted = 2
 
 
 class WebhookType(Enum):
     """Webhook Type"""
+
     incoming = 1
     channel_follower = 2
     application = 3
@@ -569,6 +584,7 @@ class WebhookType(Enum):
 
 class ExpireBehaviour(Enum):
     """Expire Behaviour"""
+
     remove_role = 0
     kick = 1
 
@@ -578,12 +594,14 @@ ExpireBehavior = ExpireBehaviour
 
 class StickerType(Enum):
     """Sticker type"""
+
     standard = 1
     guild = 2
 
 
 class StickerFormatType(Enum):
     """Sticker format Type"""
+
     png = 1
     apng = 2
     lottie = 3
@@ -600,6 +618,7 @@ class StickerFormatType(Enum):
 
 class InviteTarget(Enum):
     """Invite target"""
+
     unknown = 0
     stream = 1
     embedded_application = 2
@@ -607,6 +626,7 @@ class InviteTarget(Enum):
 
 class InteractionType(Enum):
     """Interaction type"""
+
     ping = 1
     application_command = 2
     component = 3
@@ -616,6 +636,7 @@ class InteractionType(Enum):
 
 class InteractionResponseType(Enum):
     """Interaction response type"""
+
     pong = 1
     # ack = 2 (deprecated)
     # channel_message = 3 (deprecated)
@@ -629,6 +650,7 @@ class InteractionResponseType(Enum):
 
 class VideoQualityMode(Enum):
     """Video quality mode"""
+
     auto = 1
     full = 2
 
@@ -638,6 +660,7 @@ class VideoQualityMode(Enum):
 
 class ComponentType(Enum):
     """Component type"""
+
     action_row = 1
     button = 2
     select = 3
@@ -649,6 +672,7 @@ class ComponentType(Enum):
 
 class ButtonStyle(Enum):
     """Button style"""
+
     primary = 1
     secondary = 2
     success = 3
@@ -669,6 +693,7 @@ class ButtonStyle(Enum):
 
 class InputTextStyle(Enum):
     """Input text style"""
+
     short = 1
     singleline = 1
     paragraph = 2
@@ -678,6 +703,7 @@ class InputTextStyle(Enum):
 
 class ApplicationType(Enum):
     """Application type"""
+
     game = 1
     music = 2
     ticketed_events = 3
@@ -686,6 +712,7 @@ class ApplicationType(Enum):
 
 class StagePrivacyLevel(Enum):
     """Stage privacy level"""
+
     # public = 1 (deprecated)
     closed = 2
     guild_only = 2
@@ -693,6 +720,7 @@ class StagePrivacyLevel(Enum):
 
 class NSFWLevel(Enum, comparable=True):
     """NSFW level"""
+
     default = 0
     explicit = 1
     safe = 2
@@ -701,6 +729,7 @@ class NSFWLevel(Enum, comparable=True):
 
 class SlashCommandOptionType(Enum):
     """Slash command option type"""
+
     sub_command = 1
     sub_command_group = 2
     string = 3
@@ -773,6 +802,7 @@ class SlashCommandOptionType(Enum):
 
 class EmbeddedActivity(Enum):
     """Embedded activity"""
+
     awkword = 879863881349087252
     betrayal = 773336526917861400
     checkers_in_the_park = 832013003968348200
@@ -808,6 +838,7 @@ class EmbeddedActivity(Enum):
 
 class ScheduledEventStatus(Enum):
     """Scheduled event status"""
+
     scheduled = 1
     active = 2
     completed = 3
@@ -820,6 +851,7 @@ class ScheduledEventStatus(Enum):
 
 class ScheduledEventPrivacyLevel(Enum):
     """Scheduled event privacy level"""
+
     guild_only = 2
 
     def __int__(self):
@@ -828,6 +860,7 @@ class ScheduledEventPrivacyLevel(Enum):
 
 class ScheduledEventLocationType(Enum):
     """Scheduled event location type"""
+
     stage_instance = 1
     voice = 2
     external = 3
@@ -835,6 +868,7 @@ class ScheduledEventLocationType(Enum):
 
 class AutoModTriggerType(Enum):
     """Automod trigger type"""
+
     keyword = 1
     harmful_link = 2
     spam = 3
@@ -843,11 +877,13 @@ class AutoModTriggerType(Enum):
 
 class AutoModEventType(Enum):
     """Automod event type"""
+
     message_send = 1
 
 
 class AutoModActionType(Enum):
     """Automod action type"""
+
     block_message = 1
     send_alert_message = 2
     timeout = 3
@@ -855,6 +891,7 @@ class AutoModActionType(Enum):
 
 class AutoModKeywordPresetType(Enum):
     """Automod keyword preset type"""
+
     profanity = 1
     sexual_content = 2
     slurs = 3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1600,61 +1600,61 @@ of :class:`enum.Enum`.
 
     .. attribute:: text
 
-        A text channel. Value = 0.
+        A text channel.
 
     .. attribute:: voice
 
-        A voice channel. Value = 2.
+        A voice channel.
 
     .. attribute:: private
 
-        A private text channel. Also called a direct message. Value = 1.
+        A private text channel. Also called a direct message.
 
     .. attribute:: group
 
-        A private group text channel. Value = 3.
+        A private group text channel.
 
     .. attribute:: category
 
-        A category channel. Value = 4.
+        A category channel.
 
     .. attribute:: news
 
-        A guild news channel. Value = 5.
+        A guild news channel.
 
     .. attribute:: stage_voice
 
-        A guild stage voice channel. Value = 13.
+        A guild stage voice channel.
 
         .. versionadded:: 1.7
 
     .. attribute:: news_thread
 
-        A news thread. Value = 10.
+        A news thread.
 
         .. versionadded:: 2.0
 
     .. attribute:: public_thread
 
-        A public thread. Value = 11.
+        A public thread.
 
         .. versionadded:: 2.0
 
     .. attribute:: private_thread
 
-        A private thread. Value = 12.
+        A private thread.
 
         .. versionadded:: 2.0
 
     .. attribute:: directory
 
-        A guild directory entry, used in hub guilds, currently in experiment. Value = 14.
+        A guild directory entry, used in hub guilds, currently in experiment.
 
         .. versionadded:: 2.0
 
     .. attribute:: forum
 
-        User can only write in threads, similar functionality to a forum, currently in experiment. Value = 15.
+        User can only write in threads, similar functionality to a forum, currently in experiment.
 
         .. versionadded:: 2.0
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1595,61 +1595,61 @@ of :class:`enum.Enum`.
 
     .. attribute:: text
 
-        A text channel.
+        A text channel. Value = 0.
 
     .. attribute:: voice
 
-        A voice channel.
+        A voice channel. Value = 2.
 
     .. attribute:: private
 
-        A private text channel. Also called a direct message.
+        A private text channel. Also called a direct message. Value = 1.
 
     .. attribute:: group
 
-        A private group text channel.
+        A private group text channel. Value = 3.
 
     .. attribute:: category
 
-        A category channel.
+        A category channel. Value = 4.
 
     .. attribute:: news
 
-        A guild news channel.
+        A guild news channel. Value = 5.
 
     .. attribute:: stage_voice
 
-        A guild stage voice channel.
+        A guild stage voice channel. Value = 13.
 
         .. versionadded:: 1.7
 
     .. attribute:: news_thread
 
-        A news thread
+        A news thread. Value = 10.
 
         .. versionadded:: 2.0
 
     .. attribute:: public_thread
 
-        A public thread
+        A public thread. Value = 11.
 
         .. versionadded:: 2.0
 
     .. attribute:: private_thread
 
-        A private thread
+        A private thread. Value = 12.
 
         .. versionadded:: 2.0
 
     .. attribute:: directory
 
-        A guild directory entry, used in hub guilds, currently in experiment.
+        A guild directory entry, used in hub guilds, currently in experiment. Value = 14.
 
         .. versionadded:: 2.0
 
     .. attribute:: forum
 
-        User can only write in threads, similar functionality to a forum, currently in experiment.
+        User can only write in threads, similar functionality to a forum, currently in experiment. Value = 15.
 
         .. versionadded:: 2.0
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Hacktoberfest pull request.
For closing Issue #1510. Beyond adding small details to the docs, also adding docstrings to the Enum classes so that if an Option tries to reference them, it'll have a description by default, but also changing the Option behavior so that if the dev includes a description text when calling Option, the docstring from Enums won't override that description text.

Fixes this behavior ("No description provided"): 
![image](https://user-images.githubusercontent.com/76178990/195999724-3b676553-4030-47ca-8282-292895c79caa.png)


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
