### PR TITLE
Pin cchardet version and add qualifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ speed = [
     "orjson>=3.5.4",
     "aiodns>=1.1",
     "Brotlipy",
-    "cchardet",
+    # cchardet does not support 3.10+, see https://github.com/PyYoshi/cChardet/pull/78
+    "cchardet>=2.1.5,<=2.1.7; python_version<'3.10'",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
cchardet does not support python 3.10, see PyYoshi/cChardet#78.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
