### PR TITLE
Clearly define button max label length

### DIFF
--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -64,7 +64,7 @@ class Button(Item[V]):
     disabled: :class:`bool`
         Whether the button is disabled or not.
     label: Optional[:class:`str`]
-        The label of the button, if any.
+        The label of the button, if any. Maximum of 80 chars.
     emoji: Optional[Union[:class:`.PartialEmoji`, :class:`.Emoji`, :class:`str`]]
         The emoji of the button, if available.
     row: Optional[:class:`int`]


### PR DESCRIPTION
Currently, to find the max for this argument, you have to look at official discord docs (which is what I did first), try it and get an error (slow and painful), or check the source code (which I also did), this just puts it in the docs so you can see straight away.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
