### PR TITLE
feat: Add support for nsfw commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - New select types `user`, `role`, `mentionable`, and `channel` - Along with their
   respective types and shortcut decorators.
   ([#1702](https://github.com/Pycord-Development/pycord/pull/1702))
+- Added support for age-restricted (NSFW) commands.
+  ([#1775](https://github.com/Pycord-Development/pycord/pull/1775))
 
 ### Fixed
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -275,6 +275,7 @@ class ApplicationCommandMixin(ABC):
                 as_dict = cmd.to_dict()
                 to_check = {
                     "dm_permission": None,
+                    "nsfw": None,
                     "default_member_permissions": None,
                     "name": None,
                     "description": None,

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -222,9 +222,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         self.guild_only: bool | None = getattr(
             func, "__guild_only__", kwargs.get("guild_only", None)
         )
-        self.nsfw: bool | None = getattr(
-            func, "__nsfw__", kwargs.get("nsfw", None)
-        )
+        self.nsfw: bool | None = getattr(func, "__nsfw__", kwargs.get("nsfw", None))
 
     def __repr__(self) -> str:
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -222,6 +222,9 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         self.guild_only: bool | None = getattr(
             func, "__guild_only__", kwargs.get("guild_only", None)
         )
+        self.nsfw: bool | None = getattr(
+            func, "__nsfw__", kwargs.get("nsfw", None)
+        )
 
     def __repr__(self) -> str:
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"
@@ -629,6 +632,8 @@ class SlashCommand(ApplicationCommand):
         Returns a string that allows you to mention the slash command.
     guild_only: :class:`bool`
         Whether the command should only be usable inside a guild.
+    nsfw: :class:`bool`
+        Whether the command should be restricted to 18+ channels and users.
     default_member_permissions: :class:`~discord.Permissions`
         The default permissions a member needs to be able to run the command.
     cog: Optional[:class:`Cog`]
@@ -849,6 +854,9 @@ class SlashCommand(ApplicationCommand):
         if self.guild_only is not None:
             as_dict["dm_permission"] = not self.guild_only
 
+        if self.nsfw is not None:
+            as_dict["nsfw"] = self.nsfw
+
         if self.default_member_permissions is not None:
             as_dict[
                 "default_member_permissions"
@@ -1060,6 +1068,8 @@ class SlashCommandGroup(ApplicationCommand):
         isn't one.
     guild_only: :class:`bool`
         Whether the command should only be usable inside a guild.
+    nsfw: :class:`bool`
+        Whether the command should be restricted to 18+ channels and users.
     default_member_permissions: :class:`~discord.Permissions`
         The default permissions a member needs to be able to run the command.
     checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]
@@ -1132,6 +1142,7 @@ class SlashCommandGroup(ApplicationCommand):
             "default_member_permissions", None
         )
         self.guild_only: bool | None = kwargs.get("guild_only", None)
+        self.nsfw: bool | None = kwargs.get("nsfw", None)
 
         self.name_localizations: dict[str, str] | None = kwargs.get(
             "name_localizations", None
@@ -1160,6 +1171,9 @@ class SlashCommandGroup(ApplicationCommand):
 
         if self.guild_only is not None:
             as_dict["dm_permission"] = not self.guild_only
+
+        if self.nsfw is not None:
+            as_dict["nsfw"] = self.nsfw
 
         if self.default_member_permissions is not None:
             as_dict[
@@ -1208,6 +1222,8 @@ class SlashCommandGroup(ApplicationCommand):
             This will be a global command if ``None`` is passed.
         guild_only: :class:`bool`
             Whether the command should only be usable inside a guild.
+        nsfw: :class:`bool`
+            Whether the command should be restricted to 18+ channels and users.
         default_member_permissions: :class:`~discord.Permissions`
             The default permissions a member needs to be able to run the command.
         checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]
@@ -1377,6 +1393,8 @@ class ContextMenuCommand(ApplicationCommand):
         The ids of the guilds where this command will be registered.
     guild_only: :class:`bool`
         Whether the command should only be usable inside a guild.
+    nsfw: :class:`bool`
+        Whether the command should be restricted to 18+ channels and users.
     default_member_permissions: :class:`~discord.Permissions`
         The default permissions a member needs to be able to run the command.
     cog: Optional[:class:`Cog`]
@@ -1475,6 +1493,9 @@ class ContextMenuCommand(ApplicationCommand):
 
         if self.guild_only is not None:
             as_dict["dm_permission"] = not self.guild_only
+
+        if self.nsfw is not None:
+            as_dict["nsfw"] = self.nsfw
 
         if self.default_member_permissions is not None:
             as_dict[

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -632,6 +632,7 @@ class SlashCommand(ApplicationCommand):
         Whether the command should only be usable inside a guild.
     nsfw: :class:`bool`
         Whether the command should be restricted to 18+ channels and users.
+        Apps intending to be listed in the App Directory cannot have NSFW commands.
     default_member_permissions: :class:`~discord.Permissions`
         The default permissions a member needs to be able to run the command.
     cog: Optional[:class:`Cog`]
@@ -1068,6 +1069,7 @@ class SlashCommandGroup(ApplicationCommand):
         Whether the command should only be usable inside a guild.
     nsfw: :class:`bool`
         Whether the command should be restricted to 18+ channels and users.
+        Apps intending to be listed in the App Directory cannot have NSFW commands.
     default_member_permissions: :class:`~discord.Permissions`
         The default permissions a member needs to be able to run the command.
     checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]
@@ -1222,6 +1224,7 @@ class SlashCommandGroup(ApplicationCommand):
             Whether the command should only be usable inside a guild.
         nsfw: :class:`bool`
             Whether the command should be restricted to 18+ channels and users.
+            Apps intending to be listed in the App Directory cannot have NSFW commands.
         default_member_permissions: :class:`~discord.Permissions`
             The default permissions a member needs to be able to run the command.
         checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]
@@ -1393,6 +1396,7 @@ class ContextMenuCommand(ApplicationCommand):
         Whether the command should only be usable inside a guild.
     nsfw: :class:`bool`
         Whether the command should be restricted to 18+ channels and users.
+        Apps intending to be listed in the App Directory cannot have NSFW commands.
     default_member_permissions: :class:`~discord.Permissions`
         The default permissions a member needs to be able to run the command.
     cog: Optional[:class:`Cog`]

--- a/discord/commands/permissions.py
+++ b/discord/commands/permissions.py
@@ -28,11 +28,7 @@ from typing import Callable
 from ..permissions import Permissions
 from .core import ApplicationCommand
 
-__all__ = (
-    "default_permissions",
-    "guild_only",
-    "is_nsfw"
-)
+__all__ = ("default_permissions", "guild_only", "is_nsfw")
 
 
 def default_permissions(**perms: bool) -> Callable:
@@ -109,6 +105,7 @@ def guild_only() -> Callable:
         return command
 
     return inner
+
 
 def is_nsfw() -> Callable:
     """A decorator that limits the usage of a slash command to 18+ channels and users.

--- a/discord/commands/permissions.py
+++ b/discord/commands/permissions.py
@@ -111,7 +111,7 @@ def is_nsfw() -> Callable:
     """A decorator that limits the usage of a slash command to 18+ channels and users.
     In guilds, the command will only be able to be used in channels marked as NSFW.
     In DMs, users must have opted into age-restricted commands via privacy settings.
-    
+
     Note that apps intending to be listed in the App Directory cannot have NSFW commands.
 
     Example

--- a/discord/commands/permissions.py
+++ b/discord/commands/permissions.py
@@ -31,6 +31,7 @@ from .core import ApplicationCommand
 __all__ = (
     "default_permissions",
     "guild_only",
+    "is_nsfw"
 )
 
 
@@ -104,6 +105,34 @@ def guild_only() -> Callable:
             command.guild_only = True
         else:
             command.__guild_only__ = True
+
+        return command
+
+    return inner
+
+def is_nsfw() -> Callable:
+    """A decorator that limits the usage of a slash command to 18+ channels and users.
+    In guilds, the command will only be able to be used in channels marked as NSFW.
+    In DMs, users must have opted into age-restricted commands via privacy settings.
+
+    Example
+    -------
+
+    .. code-block:: python3
+
+        from discord import is_nsfw
+
+        @bot.slash_command()
+        @is_nsfw()
+        async def test(ctx):
+            await ctx.respond("This command is age restricted.")
+    """
+
+    def inner(command: Callable):
+        if isinstance(command, ApplicationCommand):
+            command.nsfw = True
+        else:
+            command.__nsfw__ = True
 
         return command
 

--- a/discord/commands/permissions.py
+++ b/discord/commands/permissions.py
@@ -111,6 +111,8 @@ def is_nsfw() -> Callable:
     """A decorator that limits the usage of a slash command to 18+ channels and users.
     In guilds, the command will only be able to be used in channels marked as NSFW.
     In DMs, users must have opted into age-restricted commands via privacy settings.
+    
+    Note that apps intending to be listed in the App Directory cannot have NSFW commands.
 
     Example
     -------

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -68,7 +68,7 @@ __all__ = (
     "map_to",
     "guild_only",
     "has_permissions",
-    "is_nsfw"
+    "is_nsfw",
 )
 
 
@@ -447,7 +447,6 @@ def is_nsfw():
     .. warning::
 
         In DMs, the prefixed-based command will always run as the user's privacy settings cannot be checked directly.
-
     """
 
     def predicate(func: Callable | ApplicationCommand):

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -68,6 +68,7 @@ __all__ = (
     "map_to",
     "guild_only",
     "has_permissions",
+    "is_nsfw"
 )
 
 
@@ -433,6 +434,31 @@ def guild_only():
         from ..commands import guild_only
 
         return guild_only()(func)
+
+    return predicate
+
+
+def is_nsfw():
+    """Intended to work with :class:`.ApplicationCommand` and :class:`BridgeCommand`, adds a :func:`~ext.commands.check`
+    that locks the command to only run in nsfw contexts, and also registers the command as nsfw client-side (on discord).
+
+    Basically a utility function that wraps both :func:`discord.ext.commands.is_nsfw` and :func:`discord.commands.is_nsfw`.
+
+    .. warning::
+
+        In DMs, the prefixed-based command will always run as the user's privacy settings cannot be checked directly.
+
+    """
+
+    def predicate(func: Callable | ApplicationCommand):
+        if isinstance(func, ApplicationCommand):
+            func.nsfw = True
+        else:
+            func.__nsfw__ = True
+
+        from ..commands import is_nsfw
+
+        return is_nsfw()(func)
 
     return predicate
 

--- a/docs/api/application_commands.rst
+++ b/docs/api/application_commands.rst
@@ -13,6 +13,9 @@ Command Permission Decorators
 .. autofunction:: discord.commands.guild_only
     :decorator:
 
+.. autofunction:: discord.commands.is_nsfw
+    :decorator:
+
 
 Commands
 --------

--- a/docs/ext/bridge/api.rst
+++ b/docs/ext/bridge/api.rst
@@ -73,6 +73,9 @@ Decorators
 .. automethod:: discord.ext.bridge.guild_only()
     :decorator:
 
+.. automethod:: discord.ext.bridge.is_nsfw()
+    :decorator:
+
 .. automethod:: discord.ext.bridge.has_permissions()
     :decorator:
 


### PR DESCRIPTION
## Summary

Implements discord/discord-api-docs#5617
Officially releases on the 16th, but it's seemingly functional.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
