### PR TITLE
docs: Remove Table of Contents from FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,8 +9,6 @@ Frequently Asked Questions
 This is a list of Frequently Asked Questions regarding using ``Pycord`` and its extension modules. Feel free to suggest a
 new question or submit one via pull requests.
 
-.. contents:: Questions
-    :local:
 
 Coroutines
 ----------


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Removes the table of contents that caused an error to be displayed
![Screenshot 2022-11-23 at 1 23 02 AM](https://user-images.githubusercontent.com/92863779/203408530-e51cb8ee-63aa-4c11-b7da-b1879b055b31.png)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
