### PR TITLE
feat: Add possibility to start bot via async context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Added
 
+- Added possibility to start bot via async context manager.
+  ([#1801](https://github.com/Pycord-Development/pycord/pull/1801))
 - Added new events `on_bridge_command`, `on_bridge_command_completion`, and
   `on_bridge_command_error`.
   ([#1916](https://github.com/Pycord-Development/pycord/pull/1916))

--- a/discord/client.py
+++ b/discord/client.py
@@ -253,6 +253,22 @@ class Client:
             VoiceClient.warn_nacl = False
             _log.warning("PyNaCl is not installed, voice will NOT be supported")
 
+    async def __aenter__(self) -> Client:
+        loop = asyncio.get_running_loop()
+        self.loop = loop
+        self.http.loop = loop
+        self._connection.loop = loop
+
+        self._ready = asyncio.Event()
+
+        return self
+
+    async def __aexit__(self) -> None:
+        if not self.is_closed():
+            await self.close()
+
+    # internals
+
     def _get_websocket(
         self, guild_id: int | None = None, *, shard_id: int | None = None
     ) -> DiscordWebSocket:

--- a/discord/client.py
+++ b/discord/client.py
@@ -31,6 +31,7 @@ import signal
 import sys
 import traceback
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator, Sequence, TypeVar
+from types import TracebackType
 
 import aiohttp
 
@@ -263,7 +264,11 @@ class Client:
 
         return self
 
-    async def __aexit__(self) -> None:
+    async def __aexit__(self,
+        exc_t: BaseException | None,
+        exc_v: BaseException | None,
+        exc_tb: TracebackType | None
+    ) -> None:
         if not self.is_closed():
             await self.close()
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -30,8 +30,8 @@ import logging
 import signal
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator, Sequence, TypeVar
 from types import TracebackType
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator, Sequence, TypeVar
 
 import aiohttp
 
@@ -264,10 +264,11 @@ class Client:
 
         return self
 
-    async def __aexit__(self,
+    async def __aexit__(
+        self,
         exc_t: BaseException | None,
         exc_v: BaseException | None,
-        exc_tb: TracebackType | None
+        exc_tb: TracebackType | None,
     ) -> None:
         if not self.is_closed():
             await self.close()

--- a/examples/basic_async_bot.py
+++ b/examples/basic_async_bot.py
@@ -3,7 +3,6 @@ import asyncio
 import discord
 from discord.ext import commands
 
-
 bot = commands.Bot(
     command_prefix=commands.when_mentioned_or("!"),
     intents=discord.Intents.default(),

--- a/examples/basic_async_bot.py
+++ b/examples/basic_async_bot.py
@@ -1,0 +1,30 @@
+import asyncio
+
+import discord
+from discord.ext import commands
+
+
+bot = commands.Bot(
+    command_prefix=commands.when_mentioned_or("!"),
+    intents=discord.Intents.default(),
+)
+
+
+@bot.event
+async def on_ready():
+    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
+    print("------")
+
+
+@bot.slash_command(guild_ids=[...])  # Create a slash command.
+async def hello(ctx: discord.ApplicationContext):
+    """Say hello to the bot"""  # The command description can be supplied as the docstring
+    await ctx.respond(f"Hello {ctx.author.mention}!")
+
+
+async def main():
+    async with bot:
+        await bot.start("TOKEN")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

This is a feature pull request. It allowes you to start the bot via an async context manager.

Till now you were able to subclass `Bot` with something like

```py
class MyBot(commands.Bot):
    def __init__(self, **kwargs: Any):
        super().__init__(
            **kwargs,
        )
        [...]

MyBot().run("token")
```

Now you can also start the bot via an async context manager
```py
async with MyBot(**kwargs) as bot:
    await bot.start("token")
```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
