### PR TITLE
build: update changelog link to docs page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]
 Homepage = "https://pycord.dev"
-Changelog = "https://github.com/Pycord-Development/pycord/blob/master/CHANGELOG.md"
+Changelog = "https://docs.pycord.dev/en/master/changelog.html"
 Source = "https://github.com/Pycord-Development/pycord"
 Documentation = "https://docs.pycord.dev"
 Tracker = "https://github.com/Pycord-Development/pycord/issues"


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Previously, the changelog link was set to the source file on our github. However, the docs version is better styled and ultimately has the same content, so this uses that instead.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
