### PR TITLE
Fix issue #1805

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -81,13 +81,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = MissingField
+    name: str = MISSING
     aliases: list[str] = field(default_factory=list)
-    attribute: str = MissingField
-    annotation: Any = MissingField
-    default: Any = MissingField
-    max_args: int = MissingField
-    override: bool = MissingField
+    attribute: str = MISSING
+    annotation: Any = MISSING
+    default: Any = MISSING
+    max_args: int = MISSING
+    override: bool = MISSING
     cast_to_dict: bool = False
 
     @property


### PR DESCRIPTION
## Summary

Fixes the `commands.FlagConverter` bug in the stable release, solved #1805 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
