### PR TITLE
feat: Update AutoMod implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
-_No changes yet_
+### Added
+
+- Added new AutoMod trigger metadata properties `regex_patterns`, `allow_list`,
+  and `mention_total_limit`; and added the `mention_spam` trigger type.
+  ([#1809](https://github.com/Pycord-Development/pycord/pull/1809))
 
 ## [2.3.1] - 2022-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Added
 
-- Added new AutoMod trigger metadata properties `regex_patterns`, `allow_list`,
-  and `mention_total_limit`; and added the `mention_spam` trigger type.
+- Added new AutoMod trigger metadata properties `regex_patterns`, `allow_list`, and
+  `mention_total_limit`; and added the `mention_spam` trigger type.
   ([#1809](https://github.com/Pycord-Development/pycord/pull/1809))
 
 ## [2.3.1] - 2022-11-27

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -39,7 +39,10 @@ from .enums import (
 from .mixins import Hashable
 from .object import Object
 
-__all__ = ("AutoModRule", "AutoModAction",)
+__all__ = (
+    "AutoModRule",
+    "AutoModAction",
+)
 
 if TYPE_CHECKING:
     from .abc import Snowflake

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -185,14 +185,20 @@ class AutoModTriggerMetadata:
         A list of regex patterns to filter using Rust-flavored regex, which is not
         fully compatible with regex syntax supported by the builtin `re` module.
         Only for triggers of type :attr:`AutoModTriggerType.keyword`.
+
+        .. versionadded:: 2.4
     presets: List[:class:`AutoModKeywordPresetType`]
         A list of keyword presets to filter.
         Only for triggers of type :attr:`AutoModTriggerType.keyword_preset`.
     allow_list: List[:class:`str`]
         A list of substrings to allow, overriding keyword and regex matches.
         Only for triggers of type :attr:`AutoModTriggerType.keyword` and :attr:`AutoModTriggerType.keyword_preset`.
+
+        .. versionadded:: 2.4
     mention_total_limit: :class:`int`
         The total number of unique role and user mentions allowed.
+
+        .. versionadded:: 2.4
     """
 
     # maybe add a table of action types and attributes?

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -177,8 +177,14 @@ class AutoModTriggerMetadata:
     ----------
     keyword_filter: List[:class:`str`]
         A list of substrings to filter. Only for triggers of type :attr:`AutoModTriggerType.keyword`.
+    regex_patterns: List[:class:`str`]
+        A list of regex patterns to filter. Only for triggeres of type :attr:`AutoModTriggerType.keyword`.
     presets: List[:class:`AutoModKeywordPresetType`]
         A list of keyword presets to filter. Only for triggers of type :attr:`AutoModTriggerType.keyword_preset`.
+    allow_list: List[:class:`str`]
+        A list of substrings to allow, overriding keyword and regex matches. Only for triggeres of type :attr:`AutoModTriggerType.keyword` and :attr:`AutoModTriggerType.keyword_preset`.
+    mention_total_limit: :class:`int`
+        The total number of unique role and user mentions allowed.
     """
 
     # maybe add a table of action types and attributes?

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -39,7 +39,7 @@ from .enums import (
 from .mixins import Hashable
 from .object import Object
 
-__all__ = ("AutoModRule",)
+__all__ = ("AutoModRule", "AutoModAction",)
 
 if TYPE_CHECKING:
     from .abc import Snowflake
@@ -176,13 +176,18 @@ class AutoModTriggerMetadata:
     Attributes
     ----------
     keyword_filter: List[:class:`str`]
-        A list of substrings to filter. Only for triggers of type :attr:`AutoModTriggerType.keyword`.
+        A list of substrings to filter.
+        Only for triggers of type :attr:`AutoModTriggerType.keyword`.
     regex_patterns: List[:class:`str`]
-        A list of regex patterns to filter. Only for triggeres of type :attr:`AutoModTriggerType.keyword`.
+        A list of regex patterns to filter using Rust-flavored regex, which is not
+        fully compatible with regex syntax supported by the builtin `re` module.
+        Only for triggers of type :attr:`AutoModTriggerType.keyword`.
     presets: List[:class:`AutoModKeywordPresetType`]
-        A list of keyword presets to filter. Only for triggers of type :attr:`AutoModTriggerType.keyword_preset`.
+        A list of keyword presets to filter.
+        Only for triggers of type :attr:`AutoModTriggerType.keyword_preset`.
     allow_list: List[:class:`str`]
-        A list of substrings to allow, overriding keyword and regex matches. Only for triggeres of type :attr:`AutoModTriggerType.keyword` and :attr:`AutoModTriggerType.keyword_preset`.
+        A list of substrings to allow, overriding keyword and regex matches.
+        Only for triggers of type :attr:`AutoModTriggerType.keyword` and :attr:`AutoModTriggerType.keyword_preset`.
     mention_total_limit: :class:`int`
         The total number of unique role and user mentions allowed.
     """

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -186,25 +186,43 @@ class AutoModTriggerMetadata:
 
     __slots__ = (
         "keyword_filter",
+        "regex_patterns",
         "presets",
+        "allow_list",
+        "mention_total_limit"
     )
 
     def __init__(
         self,
         keyword_filter: list[str] = MISSING,
+        regex_patterns: list[str] = MISSING,
         presets: list[AutoModKeywordPresetType] = MISSING,
+        allow_list: list[str] = MISSING,
+        mention_total_limit: int = MISSING
     ):
         self.keyword_filter = keyword_filter
+        self.regex_patterns = regex_patterns
         self.presets = presets
+        self.allow_list = allow_list
+        self.mention_total_limit = mention_total_limit
 
     def to_dict(self) -> dict:
         data = {}
 
         if self.keyword_filter is not MISSING:
             data["keyword_filter"] = self.keyword_filter
+        
+        if self.regex_patterns is not MISSING:
+            data["regex_patterns"] = self.regex_patterns
 
         if self.presets is not MISSING:
             data["presets"] = [wordset.value for wordset in self.presets]
+        
+        if self.allow_list is not MISSING:
+            data["allow_list"] = self.allow_list
+        
+        if self.mention_total_limit is not MISSING:
+            data["mention_total_limit"] = self.mention_total_limit
 
         return data
 
@@ -214,18 +232,30 @@ class AutoModTriggerMetadata:
 
         if (keyword_filter := data.get("keyword_filter")) is not None:
             kwargs["keyword_filter"] = keyword_filter
+        
+        if (regex_patterns := data.get("regex_patterns")) is not None:
+            kwargs["regex_patterns"] = regex_patterns
 
         if (presets := data.get("presets")) is not None:
             kwargs["presets"] = [
                 try_enum(AutoModKeywordPresetType, wordset) for wordset in presets
             ]
+        
+        if (allow_list := data.get("allow_list")) is not None:
+            kwargs["allow_list"] = allow_list
+        
+        if (mention_total_limit := data.get("mention_total_limit")) is not None:
+            kwargs["mention_total_limit"] = mention_total_limit
 
         return cls(**kwargs)
 
     def __repr__(self) -> str:
         repr_attrs = (
             "keyword_filter",
+            "regex_patterns",
             "presets",
+            "allow_list",
+            "mention_total_limit"
         )
         inner = []
 

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -197,6 +197,7 @@ class AutoModTriggerMetadata:
         .. versionadded:: 2.4
     mention_total_limit: :class:`int`
         The total number of unique role and user mentions allowed.
+        Only for triggers of type :attr:`AutoModTriggerType.mention_spam`.
 
         .. versionadded:: 2.4
     """

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -195,7 +195,7 @@ class AutoModTriggerMetadata:
         "regex_patterns",
         "presets",
         "allow_list",
-        "mention_total_limit"
+        "mention_total_limit",
     )
 
     def __init__(
@@ -204,7 +204,7 @@ class AutoModTriggerMetadata:
         regex_patterns: list[str] = MISSING,
         presets: list[AutoModKeywordPresetType] = MISSING,
         allow_list: list[str] = MISSING,
-        mention_total_limit: int = MISSING
+        mention_total_limit: int = MISSING,
     ):
         self.keyword_filter = keyword_filter
         self.regex_patterns = regex_patterns
@@ -217,16 +217,16 @@ class AutoModTriggerMetadata:
 
         if self.keyword_filter is not MISSING:
             data["keyword_filter"] = self.keyword_filter
-        
+
         if self.regex_patterns is not MISSING:
             data["regex_patterns"] = self.regex_patterns
 
         if self.presets is not MISSING:
             data["presets"] = [wordset.value for wordset in self.presets]
-        
+
         if self.allow_list is not MISSING:
             data["allow_list"] = self.allow_list
-        
+
         if self.mention_total_limit is not MISSING:
             data["mention_total_limit"] = self.mention_total_limit
 
@@ -238,7 +238,7 @@ class AutoModTriggerMetadata:
 
         if (keyword_filter := data.get("keyword_filter")) is not None:
             kwargs["keyword_filter"] = keyword_filter
-        
+
         if (regex_patterns := data.get("regex_patterns")) is not None:
             kwargs["regex_patterns"] = regex_patterns
 
@@ -246,10 +246,10 @@ class AutoModTriggerMetadata:
             kwargs["presets"] = [
                 try_enum(AutoModKeywordPresetType, wordset) for wordset in presets
             ]
-        
+
         if (allow_list := data.get("allow_list")) is not None:
             kwargs["allow_list"] = allow_list
-        
+
         if (mention_total_limit := data.get("mention_total_limit")) is not None:
             kwargs["mention_total_limit"] = mention_total_limit
 
@@ -261,7 +261,7 @@ class AutoModTriggerMetadata:
             "regex_patterns",
             "presets",
             "allow_list",
-            "mention_total_limit"
+            "mention_total_limit",
         )
         inner = []
 

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -170,7 +170,7 @@ class AutoModAction:
 
 
 class AutoModTriggerMetadata:
-    """Represents a rule's trigger metadata, defining additional data used to determine when a rule triggers.
+    r"""Represents a rule's trigger metadata, defining additional data used to determine when a rule triggers.
 
     Depending on the trigger type, different metadata attributes will be used:
 
@@ -190,7 +190,7 @@ class AutoModTriggerMetadata:
 
     Each attribute has limits that may change based on the trigger type.
     See `here <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata-field-limits>`_
-    for information on attribute limits. 
+    for information on attribute limits.
 
     .. versionadded:: 2.0
 

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -42,6 +42,8 @@ from .object import Object
 __all__ = (
     "AutoModRule",
     "AutoModAction",
+    "AutoModActionMetadata",
+    "AutoModTriggerMetadata"
 )
 
 if TYPE_CHECKING:

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -43,7 +43,7 @@ __all__ = (
     "AutoModRule",
     "AutoModAction",
     "AutoModActionMetadata",
-    "AutoModTriggerMetadata"
+    "AutoModTriggerMetadata",
 )
 
 if TYPE_CHECKING:

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -170,9 +170,27 @@ class AutoModAction:
 
 
 class AutoModTriggerMetadata:
-    """Represents a rule's trigger metadata.
+    """Represents a rule's trigger metadata, defining additional data used to determine when a rule triggers.
 
-    Depending on the trigger type, different attributes will be used.
+    Depending on the trigger type, different metadata attributes will be used:
+
+    +-----------------------------+--------------------------------------------------------------------------------+
+    |   Attribute                 |   Trigger Types                                                                |
+    +=============================+================================================================================+
+    | :attr:`keyword_filter`      | :attr:`AutoModTriggerType.keyword`                                             |
+    +-----------------------------+--------------------------------------------------------------------------------+
+    | :attr:`regex_patterns`      | :attr:`AutoModTriggerType.keyword`                                             |
+    +-----------------------------+--------------------------------------------------------------------------------+
+    | :attr:`presets`             | :attr:`AutoModTriggerType.keyword_preset`                                      |
+    +-----------------------------+--------------------------------------------------------------------------------+
+    | :attr:`allow_list`          | :attr:`AutoModTriggerType.keyword`\, :attr:`AutoModTriggerType.keyword_preset` |
+    +-----------------------------+--------------------------------------------------------------------------------+
+    | :attr:`mention_total_limit` | :attr:`AutoModTriggerType.mention_spam`                                        |
+    +-----------------------------+--------------------------------------------------------------------------------+
+
+    Each attribute has limits that may change based on the trigger type.
+    See `here <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata-field-limits>`_
+    for information on attribute limits. 
 
     .. versionadded:: 2.0
 
@@ -180,30 +198,26 @@ class AutoModTriggerMetadata:
     ----------
     keyword_filter: List[:class:`str`]
         A list of substrings to filter.
-        Only for triggers of type :attr:`AutoModTriggerType.keyword`.
+
     regex_patterns: List[:class:`str`]
         A list of regex patterns to filter using Rust-flavored regex, which is not
         fully compatible with regex syntax supported by the builtin `re` module.
-        Only for triggers of type :attr:`AutoModTriggerType.keyword`.
 
         .. versionadded:: 2.4
+
     presets: List[:class:`AutoModKeywordPresetType`]
-        A list of keyword presets to filter.
-        Only for triggers of type :attr:`AutoModTriggerType.keyword_preset`.
+        A list of preset keyword sets to filter.
+
     allow_list: List[:class:`str`]
         A list of substrings to allow, overriding keyword and regex matches.
-        Only for triggers of type :attr:`AutoModTriggerType.keyword` and :attr:`AutoModTriggerType.keyword_preset`.
 
         .. versionadded:: 2.4
+
     mention_total_limit: :class:`int`
         The total number of unique role and user mentions allowed.
-        Only for triggers of type :attr:`AutoModTriggerType.mention_spam`.
 
         .. versionadded:: 2.4
     """
-
-    # maybe add a table of action types and attributes?
-    # wording for presets could change
 
     __slots__ = (
         "keyword_filter",

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -877,6 +877,7 @@ class AutoModTriggerType(Enum):
     """Automod trigger type"""
 
     keyword = 1
+    harmful_link = 2
     spam = 3
     keyword_preset = 4
     mention_spam = 5

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -877,7 +877,6 @@ class AutoModTriggerType(Enum):
     """Automod trigger type"""
 
     keyword = 1
-    harmful_link = 2
     spam = 3
     keyword_preset = 4
     mention_spam = 5

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -880,6 +880,7 @@ class AutoModTriggerType(Enum):
     harmful_link = 2
     spam = 3
     keyword_preset = 4
+    mention_spam = 5
 
 
 class AutoModEventType(Enum):

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -464,7 +464,9 @@ class AutoModActionExecutionEvent:
     def __init__(self, state: ConnectionState, data: AutoModActionExecution) -> None:
         self.action: AutoModAction = AutoModAction.from_dict(data["action"])
         self.rule_id: int = int(data["rule_id"])
-        self.rule_trigger_type: AutoModTriggerType = try_enum(AutoModTriggerType, int(data["rule_trigger_type"]))
+        self.rule_trigger_type: AutoModTriggerType = try_enum(
+            AutoModTriggerType, int(data["rule_trigger_type"])
+        )
         self.guild_id: int = int(data["guild_id"])
         self.guild: Guild | None = state._get_guild(self.guild_id)
         self.user_id: int = int(data["user_id"])

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -411,6 +411,8 @@ class AutoModActionExecutionEvent:
         The ID of the rule that the action belongs to.
     rule_trigger_type: :class:`AutoModTriggerType`
         The category of trigger the rule belongs to.
+
+        .. versionadded:: 2.4
     guild_id: :class:`int`
         The ID of the guild that the action was executed in.
     guild: Optional[:class:`Guild`]

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING
 
-from .automod import AutoModAction
+from .automod import AutoModAction, AutoModTriggerType
 from .enums import ChannelType, try_enum
 
 if TYPE_CHECKING:
@@ -443,6 +443,7 @@ class AutoModActionExecutionEvent:
     __slots__ = (
         "action",
         "rule_id",
+        "rule_trigger_type",
         "guild_id",
         "guild",
         "user_id",
@@ -461,6 +462,7 @@ class AutoModActionExecutionEvent:
     def __init__(self, state: ConnectionState, data: AutoModActionExecution) -> None:
         self.action: AutoModAction = AutoModAction.from_dict(data["action"])
         self.rule_id: int = int(data["rule_id"])
+        self.rule_trigger_type: AutoModTriggerType = try_enum(AutoModTriggerType, int(data["rule_trigger_type"]))
         self.guild_id: int = int(data["guild_id"])
         self.guild: Guild | None = state._get_guild(self.guild_id)
         self.user_id: int = int(data["user_id"])

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -409,6 +409,8 @@ class AutoModActionExecutionEvent:
         The action that was executed.
     rule_id: :class:`int`
         The ID of the rule that the action belongs to.
+    rule_trigger_type: :class:`AutoModTriggerType`
+        The category of trigger the rule belongs to.
     guild_id: :class:`int`
         The ID of the guild that the action was executed in.
     guild: Optional[:class:`Guild`]

--- a/discord/types/automod.py
+++ b/discord/types/automod.py
@@ -27,7 +27,7 @@ from typing import Literal
 from .._typed_dict import NotRequired, TypedDict
 from .snowflake import Snowflake
 
-AutoModTriggerType = Literal[1, 2, 3, 4, 5]
+AutoModTriggerType = Literal[1, 3, 4, 5]
 
 AutoModEventType = Literal[1]
 
@@ -38,7 +38,10 @@ AutoModKeywordPresetType = Literal[1, 2, 3]
 
 class AutoModTriggerMetadata(TypedDict, total=False):
     keyword_filter: list[str]
+    regex_patterns: list[str]
     presets: list[AutoModKeywordPresetType]
+    allow_list: list[str]
+    mention_total_limit: int
 
 
 class AutoModActionMetadata(TypedDict, total=False):

--- a/discord/types/automod.py
+++ b/discord/types/automod.py
@@ -27,7 +27,7 @@ from typing import Literal
 from .._typed_dict import NotRequired, TypedDict
 from .snowflake import Snowflake
 
-AutoModTriggerType = Literal[1, 3, 4, 5]
+AutoModTriggerType = Literal[1, 2, 3, 4, 5]
 
 AutoModEventType = Literal[1]
 

--- a/discord/types/automod.py
+++ b/discord/types/automod.py
@@ -27,7 +27,7 @@ from typing import Literal
 from .._typed_dict import NotRequired, TypedDict
 from .snowflake import Snowflake
 
-AutoModTriggerType = Literal[1, 2, 3, 4]
+AutoModTriggerType = Literal[1, 2, 3, 4, 5]
 
 AutoModEventType = Literal[1]
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1867,3 +1867,90 @@ of :class:`enum.Enum`.
     .. attribute:: guild_only
 
         Represents a scheduled event that is only available to members inside the guild.
+
+.. class:: AutoModTriggerType
+
+    Represents an AutoMod trigger type.
+
+    .. versionadded:: 2.0
+
+    .. attribute:: keyword
+
+        Represents a keyword rule trigger, which are customizable by a guild.
+
+        Possible attributes for :class:`AutoModTriggerMetadata`:
+
+        - :attr:`~AutoModTriggerMetadata.keyword_filter`
+        - :attr:`~AutoModTriggerMetadata.regex_patterns`
+        - :attr:`~AutoModTriggerMetadata.allow_list`
+
+    .. attribute:: keyword_preset
+
+        Represents a preset keyword rule trigger.
+
+        Possible attributes for :class:`AutoModTriggerMetadata`:
+
+        - :attr:`~AutoModTriggerMetadata.presets`
+        - :attr:`~AutoModTriggerMetadata.allow_list`
+
+    .. attribute:: spam
+
+        Represents the spam rule trigger.
+
+        There are no possible attributes for :class:`AutoModTriggerMetadata`.
+
+    .. attribute:: mention_spam
+
+        Represents a mention spam keyword rule trigger.
+
+        Possible attributes for :class:`AutoModTriggerMetadata`:
+
+        - :attr:`~AutoModTriggerMetadata.mention_total_limit`
+
+        .. versionadded:: 2.3
+
+.. class:: AutoModEventType
+
+    Represents an AutoMod event type.
+
+    .. versionadded:: 2.0
+
+    .. attribute:: message_send
+
+        Represents a message send AutoMod event.
+
+.. class:: AutoModActionType
+
+    Represents the type of action AutoMod is performing.
+
+    .. versionadded:: 2.0
+
+    .. attribute:: block_message
+
+        Represents a block message action.
+
+    .. attribute:: send_alert_message
+
+        Represents a send alert message action.
+
+    .. attribute:: timeout
+
+        Represents a timeout action.
+
+.. class:: AutoModKeywordPresetType
+
+    Represents an AutoMod keyword preset type.
+
+    .. versionadded:: 2.0
+
+    .. attribute:: profanity
+
+        Represents the profanity keyword preset rule.
+
+    .. attribute:: sexual_content
+
+        Represents the sexual content keyword preset rule.
+
+    .. attribute:: slurs
+
+        Represents the slurs keyword preset rule.

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1909,6 +1909,13 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.4
 
+    .. attribute:: harmful_link
+
+        Represents a harmful link rule trigger.
+
+        .. deprecated:: 2.4
+            Removed by Discord and merged into `spam`.
+
 .. class:: AutoModEventType
 
     Represents an AutoMod event type.

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1907,7 +1907,7 @@ of :class:`enum.Enum`.
 
         - :attr:`~AutoModTriggerMetadata.mention_total_limit`
 
-        .. versionadded:: 2.3
+        .. versionadded:: 2.4
 
 .. class:: AutoModEventType
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1914,7 +1914,7 @@ of :class:`enum.Enum`.
         Represents a harmful link rule trigger.
 
         .. deprecated:: 2.4
-            Removed by Discord and merged into `spam`.
+            Removed by Discord and merged into :attr:`spam`.
 
 .. class:: AutoModEventType
 

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -159,6 +159,18 @@ AutoMod
 .. autoclass:: AutoModAction()
     :members:
 
+.. attributetable:: AutoModTriggerMetadata
+
+.. autoclass:: AutoModTriggerMetadata()
+    :members:
+
+.. attributetable:: AutoModActionMetadata
+
+.. autoclass:: AutoModActionMetadata()
+    :members:
+
+
+
 Invites
 ~~~~~~~
 

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -159,17 +159,15 @@ AutoMod
 .. autoclass:: AutoModAction()
     :members:
 
-.. attributetable:: AutoModTriggerMetadata
-
-.. autoclass:: AutoModTriggerMetadata()
-    :members:
-
 .. attributetable:: AutoModActionMetadata
 
 .. autoclass:: AutoModActionMetadata()
     :members:
 
+.. attributetable:: AutoModTriggerMetadata
 
+.. autoclass:: AutoModTriggerMetadata()
+    :members:
 
 Invites
 ~~~~~~~

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -146,9 +146,17 @@ Guild
 .. autoclass:: Template()
     :members:
 
+AutoMod
+~~~~~~~
+
 .. attributetable:: AutoModRule
 
 .. autoclass:: AutoModRule()
+    :members:
+
+.. attributetable:: AutoModAction
+
+.. autoclass:: AutoModAction()
     :members:
 
 Invites


### PR DESCRIPTION
## Summary

Since the original implementation of the AutoMod API (during the AutoMod beta), the API has been repeatedly changed. This pull request changes the following:

- Adds the trigger type (`rule_trigger_type`) to `AutoModActionExecutionEvent`, which seems to have been forgotten.
- Adds newer properties to AutoMod trigger metadata (ex. `regex_patterns`, `allow_list`).
- Adds the `mention_spam` trigger type enum value.
- **Removes** the `harmful_link` enum value from `AutoModTriggerType`, as Discord merged the filter with `spam` early in the beta.
- Updates the documentation to include all AutoMod classes and enums, along with the updates above.

I apologize about the improper commit messages, as I read the guidelines 3 months too late.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
