### PR TITLE
feat(ext.pages): Add `use_styled_buttons`

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -255,7 +255,7 @@ class PageGroup:
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
     use_styled_buttons: :class:`bool`
-        The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used
+        The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
     loop_pages: :class:`bool`

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -255,7 +255,7 @@ class PageGroup:
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
     use_styled_buttons: :class:`bool`
-        The same as ``use_default_buttons`` but uses emojis for labels
+        The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
     loop_pages: :class:`bool`
@@ -340,6 +340,7 @@ class Paginator(discord.ui.View):
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
     use_styled_buttons: :class:`bool`
+        The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
     loop_pages: :class:`bool`
@@ -509,7 +510,7 @@ class Paginator(discord.ui.View):
         use_default_buttons: :class:`bool`
             Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
         use_styled_buttons: :class:`bool`
-            The same as ``use_default_buttons`` but uses emojis for labels
+            The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used
         default_button_row: Optional[:class:`int`]
             The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
         loop_pages: :class:`bool`

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -796,7 +796,8 @@ class Paginator(discord.ui.View):
             self.add_button(button)
 
     def add_styled_buttons(self):
-        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels"""
+        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels .. versionadded:: 2.4
+        """
         default_buttons = [
             PaginatorButton(
                 "first",

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -254,8 +254,10 @@ class PageGroup:
         Whether the buttons get disabled when the paginator view times out.
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
-    use_styled_buttons: :class:`bool` .. versionadded:: 2.4
+    use_styled_buttons: :class:`bool`
         The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
+        
+        .. versionadded:: 2.4
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
     loop_pages: :class:`bool`

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -254,7 +254,7 @@ class PageGroup:
         Whether the buttons get disabled when the paginator view times out.
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
-    use_styled_buttons: :class:`bool`
+    use_styled_buttons: :class:`bool` .. versionadded:: 2.4
         The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
@@ -339,7 +339,7 @@ class Paginator(discord.ui.View):
         Whether the buttons get disabled when the paginator view times out.
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
-    use_styled_buttons: :class:`bool`
+    use_styled_buttons: :class:`bool` .. versionadded:: 2.4
         The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
@@ -509,7 +509,7 @@ class Paginator(discord.ui.View):
             Whether the buttons get disabled when the paginator view times out.
         use_default_buttons: :class:`bool`
             Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
-        use_styled_buttons: :class:`bool`
+        use_styled_buttons: :class:`bool` .. versionadded:: 2.4
             The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
         default_button_row: Optional[:class:`int`]
             The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -510,7 +510,7 @@ class Paginator(discord.ui.View):
         use_default_buttons: :class:`bool`
             Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
         use_styled_buttons: :class:`bool`
-            The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used
+            The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
         default_button_row: Optional[:class:`int`]
             The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
         loop_pages: :class:`bool`

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -256,7 +256,7 @@ class PageGroup:
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
     use_styled_buttons: :class:`bool`
         The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
-        
+
         .. versionadded:: 2.4
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -341,8 +341,9 @@ class Paginator(discord.ui.View):
         Whether the buttons get disabled when the paginator view times out.
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
-    use_styled_buttons: :class:`bool` .. versionadded:: 2.4
+    use_styled_buttons: :class:`bool`
         The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
+        .. versionadded:: 2.4
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
     loop_pages: :class:`bool`
@@ -511,8 +512,9 @@ class Paginator(discord.ui.View):
             Whether the buttons get disabled when the paginator view times out.
         use_default_buttons: :class:`bool`
             Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
-        use_styled_buttons: :class:`bool` .. versionadded:: 2.4
+        use_styled_buttons: :class:`bool`
             The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
+            .. versionadded:: 2.4
         default_button_row: Optional[:class:`int`]
             The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
         loop_pages: :class:`bool`
@@ -798,7 +800,9 @@ class Paginator(discord.ui.View):
             self.add_button(button)
 
     def add_styled_buttons(self):
-        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels .. versionadded:: 2.4"""
+        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels
+        .. versionadded:: 2.4
+        """
         default_buttons = [
             PaginatorButton(
                 "first",

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -445,7 +445,11 @@ class Paginator(discord.ui.View):
         if self.custom_buttons and not self.use_default_buttons:
             for button in custom_buttons:
                 self.add_button(button)
-        elif not self.custom_buttons and not self.use_styled_buttons and self.use_default_buttons:
+        elif (
+            not self.custom_buttons
+            and not self.use_styled_buttons
+            and self.use_default_buttons
+        ):
             self.add_default_buttons()
         elif self.use_styled_buttons:
             self.add_styled_buttons()
@@ -791,8 +795,7 @@ class Paginator(discord.ui.View):
             self.add_button(button)
 
     def add_styled_buttons(self):
-        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels
-        """
+        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels"""
         default_buttons = [
             PaginatorButton(
                 "first",

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -796,8 +796,7 @@ class Paginator(discord.ui.View):
             self.add_button(button)
 
     def add_styled_buttons(self):
-        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels .. versionadded:: 2.4
-        """
+        """Adds the default paginator buttons like ``.add_default_Buttons`` but uses emojis for labels .. versionadded:: 2.4"""
         default_buttons = [
             PaginatorButton(
                 "first",

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -340,7 +340,7 @@ class Paginator(discord.ui.View):
     use_default_buttons: :class:`bool`
         Whether to use the default buttons (i.e. ``first``, ``prev``, ``page_indicator``, ``next``, ``last``)
     use_styled_buttons: :class:`bool`
-        The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used
+        The same as ``use_default_buttons`` but uses emojis for labels, overwrites ``use_default_buttons`` when used.
     default_button_row: :class:`int`
         The row where the default paginator buttons are displayed. Has no effect if custom buttons are used.
     loop_pages: :class:`bool`

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -806,13 +806,13 @@ class Paginator(discord.ui.View):
         default_buttons = [
             PaginatorButton(
                 "first",
-                label="⏮",
+                emoji="⏮",
                 style=discord.ButtonStyle.blurple,
                 row=self.default_button_row,
             ),
             PaginatorButton(
                 "prev",
-                label="◀",
+                emoji="◀",
                 style=discord.ButtonStyle.red,
                 loop_label="↪",
                 row=self.default_button_row,
@@ -825,14 +825,14 @@ class Paginator(discord.ui.View):
             ),
             PaginatorButton(
                 "next",
-                label="▶",
+                emoji="▶",
                 style=discord.ButtonStyle.green,
                 loop_label="↩",
                 row=self.default_button_row,
             ),
             PaginatorButton(
                 "last",
-                label="⏭",
+                emoji="⏭",
                 style=discord.ButtonStyle.blurple,
                 row=self.default_button_row,
             ),


### PR DESCRIPTION
## Summary

Adds ``use_styled_buttons`` in `ext.pages.Paginator` which essentially styles buttons with emojis by using a single parameter. Overwrites ``use_default_buttons`` when used in the Paginator `__init__`. 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
