### PR TITLE
fix: map received applied_tags to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ _No changes yet_
   `ext.bridge.Bot`. ([#1815](https://github.com/Pycord-Development/pycord/pull/1815))
 - Fixed an `AttributeError` in select relating to the select type.
   ([#1814](https://github.com/Pycord-Development/pycord/pull/1814))
+- Fix `Thread.applied_tags` always returning an empty list.
+  ([#1817](https://github.com/Pycord-Development/pycord/pull/1817))
 
 ## [2.3.1] - 2022-11-27
 

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -198,7 +198,9 @@ class Thread(Messageable, Hashable):
         self.member_count = data.get("member_count", None)
         self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
         self.total_message_sent = data.get("total_message_sent", None)
-        self._applied_tags: list[int] = [int(tag_id) for tag_id in data.get("applied_tags", [])]
+        self._applied_tags: list[int] = [
+            int(tag_id) for tag_id in data.get("applied_tags", [])
+        ]
 
         # Here, we try to fill in potentially missing data
         if thread := self.guild.get_thread(self.id) and data.pop("_invoke_flag", False):

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -198,7 +198,7 @@ class Thread(Messageable, Hashable):
         self.member_count = data.get("member_count", None)
         self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
         self.total_message_sent = data.get("total_message_sent", None)
-        self._applied_tags: list[int] = data.get("applied_tags", [])
+        self._applied_tags: list[int] = [int(tag_id) for tag_id in data.get("applied_tags", [])]
 
         # Here, we try to fill in potentially missing data
         if thread := self.guild.get_thread(self.id) and data.pop("_invoke_flag", False):


### PR DESCRIPTION
## Summary
Solves an issue where Thread.applied_tags returns an empty list no matter how many tags are applied because the IDs stored are of different variable types.

## Information
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
