### PR TITLE
fix: creating automod rules & automod docs

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -152,7 +152,7 @@ class AutoModAction:
     def to_dict(self) -> dict:
         return {
             "type": self.type.value,
-            "metadata": self.metadata,
+            "metadata": self.metadata.to_dict(),
         }
 
     @classmethod

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -424,9 +424,9 @@ class AutoModRule(Hashable):
             The new actions to perform when the rule is triggered.
         enabled: :class:`bool`
             Whether this rule is enabled.
-        exempt_roles: List[:class:`Snowflake`]
+        exempt_roles: List[:class:`abc.Snowflake`]
             The roles that will be exempt from this rule.
-        exempt_channels: List[:class:`Snowflake`]
+        exempt_channels: List[:class:`abc.Snowflake`]
             The channels that will be exempt from this rule.
         reason: Optional[:class:`str`]
             The reason for editing this rule. Shows up in the audit log.


### PR DESCRIPTION
## Summary

Fixes creating auto moderation rules and fixes some doc references
Other documentation fixes are in #1809

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
