### PR TITLE
fix(ext.bridge): fix groups missing parent attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ _No changes yet_
 
 ### Fixed
 
-- Fixed bridge groups missing the ``parent`` attribute. ([#1823](https://github.com/Pycord-Development/pycord/pull/1823))
+- Fixed bridge groups missing the `parent` attribute.
+  ([#1823](https://github.com/Pycord-Development/pycord/pull/1823))
 
 ## [2.3.2] - 2022-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,17 @@ _No changes yet_
 
 ### Fixed
 
+- Fixed bridge groups missing the ``parent`` attribute. ([#1823](https://github.com/Pycord-Development/pycord/pull/1823))
+
+## [2.3.2] - 2022-12-03
+
+### Fixed
+
 - Fixed another `AttributeError` relating to the new `bridge_commands` attribute on
   `ext.bridge.Bot`. ([#1815](https://github.com/Pycord-Development/pycord/pull/1815))
 - Fixed an `AttributeError` in select relating to the select type.
   ([#1814](https://github.com/Pycord-Development/pycord/pull/1814))
-- Fix `Thread.applied_tags` always returning an empty list.
+- Fixed `Thread.applied_tags` always returning an empty list.
   ([#1817](https://github.com/Pycord-Development/pycord/pull/1817))
 
 ## [2.3.1] - 2022-11-27

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -319,7 +319,7 @@ class BridgeCommandGroup(BridgeCommand):
             callback,
             ext_variant=(ext_var := BridgeExtGroup(callback, *args, **kwargs)),
             slash_variant=BridgeSlashGroup(callback, ext_var.name, *args, **kwargs),
-            parent=kwargs.pop("parent", None)
+            parent=kwargs.pop("parent", None),
         )
 
         self.subcommands: list[BridgeCommand] = []

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -311,12 +311,17 @@ class BridgeCommandGroup(BridgeCommand):
         If :func:`map_to` is used, the mapped slash command.
     """
 
+    ext_variant: BridgeExtGroup
+    slash_variant: BridgeSlashGroup
+
     def __init__(self, callback, *args, **kwargs):
-        self.ext_variant: BridgeExtGroup = BridgeExtGroup(callback, *args, **kwargs)
-        name = kwargs.pop("name", self.ext_variant.name)
-        self.slash_variant: BridgeSlashGroup = BridgeSlashGroup(
-            callback, name, *args, **kwargs
+        super().__init__(
+            callback,
+            ext_variant=(ext_var := BridgeExtGroup(callback, *args, **kwargs)),
+            slash_variant=BridgeSlashGroup(callback, ext_var.name, *args, **kwargs),
+            parent=kwargs.pop("parent", None)
         )
+
         self.subcommands: list[BridgeCommand] = []
 
         self.mapped: SlashCommand | None = None


### PR DESCRIPTION
## Summary
self-explanatory
Fix #1816

<details>
<summary>Test code used</summary>

```python
class Bot(bridge.Bot):
    def __init__(self):
        intents = discord.Intents.all()
        intents.presences = False
        super().__init__(
            intents=intents,
            command_prefix="::",
            case_insensitive=True,
            enable_debug_events=True,
            strip_after_prefix=True,
            description="something...",
            help_command=commands.DefaultHelpCommand()
        )

bot = Bot()
bot.load_extension("jishaku")

class Test(commands.Cog):
    @bridge.bridge_group(invoke_without_command=False)
    async def layer(self, ctx):
        await ctx.respond("hello!!!")

    @layer.command(invoke_without_command=False)
    async def one(self, ctx):
        await ctx.respond("All systems green")

bot.add_cog(Test())
```

</details>

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.