### PR TITLE
fix: migrating v2 formatting error

### DIFF
--- a/docs/migrating_to_v2.rst
+++ b/docs/migrating_to_v2.rst
@@ -126,7 +126,7 @@ Intents Changes
 
 :attr:`Intents.message_content` is now a privileged intent. Disabling it causes :attr:`Message.content`,
 :attr:`Message.embeds`, :attr:`Message.components`, and :attr:`Message.attachments` to be empty (an empty string
-or an empty array), directly causing :class:`ext.commands.Command`s to not run.
+or an empty array), directly causing :class:`ext.commands.Command` s to not run.
 See `here <https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ>`_ for more information.
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This is what is currently looks like:
<img width="798" alt="image" src="https://user-images.githubusercontent.com/89910983/206919863-22228633-4c3a-407d-8adf-9ba10d7dac65.png">



## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
