### PR TITLE
chore: use correct aiohttp extra in requirements/speed.txt

### DIFF
--- a/requirements/speed.txt
+++ b/requirements/speed.txt
@@ -1,2 +1,2 @@
 orjson>=3.5.4
-aiohttp[speed]
+aiohttp[speedups]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

aiohttp does not have an extra called "speed", but does have one called "speedups"

https://github.com/aio-libs/aiohttp/blob/v3.8.3/setup.cfg#L67-L71

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
