### PR TITLE
fix: SlashCommandGroup.walk_commands() error

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1317,13 +1317,15 @@ class SlashCommandGroup(ApplicationCommand):
         ctx.interaction.data = option
         await command.invoke_autocomplete_callback(ctx)
 
-    def walk_commands(self) -> Generator[SlashCommand, None, None]:
-        """An iterator that recursively walks through all slash commands in this group.
+    def walk_commands(self) -> Generator[SlashCommand | SlashCommandGroup, None, None]:
+        """An iterator that recursively walks through all slash commands and groups in this group.
 
         Yields
         ------
         :class:`.SlashCommand`
             A slash command from the group.
+        :class:`.SlashCommandGroup`
+            A nested slash command group from the group.
         """
         for command in self.subcommands:
             if isinstance(command, SlashCommandGroup):

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1322,10 +1322,8 @@ class SlashCommandGroup(ApplicationCommand):
 
         Yields
         ------
-        :class:`.SlashCommand`
-            A slash command from the group.
-        :class:`.SlashCommandGroup`
-            A nested slash command group from the group.
+        :class:`.SlashCommand` | :class:`.SlashCommandGroup`
+            A nested slash command or slash command group from the group.
         """
         for command in self.subcommands:
             if isinstance(command, SlashCommandGroup):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Stops `SlashCommandGroup.walk_commands()` from returning `SlashCommandGroup`s.

When `SlashCommandGroup`s have other `SlashCommandGroup`s as subcommands, they are also yielded in `SlashCommandGroup.walk_commands()`, even though only `SlashCommand`s should be yielded from `walk_commands()`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
