### PR TITLE
fix: owner_id showing None

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1163,6 +1163,13 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
         if self.auto_sync_commands:
             await self.sync_commands()
 
+        if not self.owner_id and not self.owner_ids:
+            app = await self.application_info()  # type: ignore
+            if app.team:
+                self.owner_ids = {m.id for m in app.team.members}
+            else:
+                self.owner_id = app.owner.id
+
     async def on_interaction(self, interaction):
         await self.process_application_commands(interaction)
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request fixes an issue where `owner_id` would return None and `owner_ids` would return `set()` instead of actually returning the owner id 

As a temporary fix i had to run `bot.is_owner(<id>)` to fix this 

This pull request now uses code from `is_owner()` to fetch the owner ids 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
