### PR TITLE
fix: '_io.BytesIO' object has no attribute 'name' in paginator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1859](https://github.com/Pycord-Development/pycord/pull/1859))
 
 ### Fixed
-- Fixed a bug in `Page.update_files` where file objects stored in memory were causing an `AttributeError`. ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
+
+- Fixed a bug in `Page.update_files` where file objects stored in memory were causing an
+  `AttributeError`. ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
 
 ## [2.3.2] - 2022-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Changed `EmbeddedActivity` values to update accordingly with the new activities.
   ([#1859](https://github.com/Pycord-Development/pycord/pull/1859))
-- Changed the returned value, docstring and fixed a bug where types other than
-  `io.BufferedReader` in `Page.update_files` were throwing `AttributeError`.
-  ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
+
+### Fixed
+- Fixed a bug in `Page.update_files` where file objects stored in memory were causing an `AttributeError`. ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
 
 ## [2.3.2] - 2022-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,14 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 - Added new `EmbeddedActivity` values.
   ([#1859](https://github.com/Pycord-Development/pycord/pull/1859))
-- Updated the returned value, docstring and fixed a bug where types other than
-  `io.BufferedReader` in `Page.update_files` were throwing `AttributeError`.
-  ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
 
 ### Changed
 
 - Changed `EmbeddedActivity` values to update accordingly with the new activities.
   ([#1859](https://github.com/Pycord-Development/pycord/pull/1859))
+- Changed the returned value, docstring and fixed a bug where types other than
+  `io.BufferedReader` in `Page.update_files` were throwing `AttributeError`.
+  ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
 
 ## [2.3.2] - 2022-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 - Added new `EmbeddedActivity` values.
   ([#1859](https://github.com/Pycord-Development/pycord/pull/1859))
+- Updated the returned value, docstring and fixed a bug where types other than
+  `io.BufferedReader` in `Page.update_files` were throwing `AttributeError`.
+  ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
 
 ### Changed
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -166,7 +166,7 @@ class Page:
             The interaction associated with the callback, if any.
         """
 
-    def update_files(self) -> Optional[List[discord.File]]:
+    def update_files(self) -> list[discord.File] | None:
         """Re-opens and reads new file contents for local files if they were updated.
         Typically used when the page is changed.
         """

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+from __future__ import annotations
+
 from io import BufferedReader
 from typing import Dict, List, Optional, Union
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -167,7 +167,7 @@ class Page:
         """
 
     def update_files(self) -> Optional[List[discord.File]]:
-        """If possible, it updates the files associated with the page by re-uploading them.
+        """Re-opens and reads new file contents for local files if they were updated.
         Typically used when the page is changed.
         """
         for file in self._files:

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -21,8 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-from typing import Dict, List, Optional, Union
 from io import BufferedReader
+from typing import Dict, List, Optional, Union
 
 import discord
 from discord.ext.bridge import BridgeContext

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from io import BufferedReader
-from typing import Dict, List, Optional, Union
+from typing import List
 
 import discord
 from discord.ext.bridge import BridgeContext

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -68,7 +68,7 @@ class PaginatorButton(discord.ui.Button):
         self,
         button_type: str,
         label: str = None,
-        emoji: Union[str, discord.Emoji, discord.PartialEmoji] = None,
+        emoji: str | discord.Emoji | discord.PartialEmoji = None,
         style: discord.ButtonStyle = discord.ButtonStyle.green,
         disabled: bool = False,
         custom_id: str = None,
@@ -85,7 +85,7 @@ class PaginatorButton(discord.ui.Button):
         )
         self.button_type = button_type
         self.label = label if label or emoji else button_type.capitalize()
-        self.emoji: Union[str, discord.Emoji, discord.PartialEmoji] = emoji
+        self.emoji: str | discord.Emoji | discord.PartialEmoji = emoji
         self.style = style
         self.disabled = disabled
         self.loop_label = self.label if not loop_label else loop_label
@@ -142,10 +142,10 @@ class Page:
 
     def __init__(
         self,
-        content: Optional[str] = None,
-        embeds: Optional[List[Union[List[discord.Embed], discord.Embed]]] = None,
-        custom_view: Optional[discord.ui.View] = None,
-        files: Optional[List[discord.File]] = None,
+        content: str | None = None,
+        embeds: list[list[discord.Embed] | discord.Embed] | None = None,
+        custom_view: discord.ui.View | None = None,
+        files: list[discord.File] | None = None,
         **kwargs,
     ):
         if content is None and embeds is None:
@@ -157,7 +157,7 @@ class Page:
         self._custom_view = custom_view
         self._files = files or []
 
-    async def callback(self, interaction: Optional[discord.Interaction] = None):
+    async def callback(self, interaction: discord.Interaction | None = None):
         """|coro|
 
         The coroutine associated to a specific page. If `Paginator.page_action()` is used, this coroutine is called.
@@ -185,42 +185,42 @@ class Page:
         return self._files
 
     @property
-    def content(self) -> Optional[str]:
+    def content(self) -> str | None:
         """Gets the content for the page."""
         return self._content
 
     @content.setter
-    def content(self, value: Optional[str]):
+    def content(self, value: str | None):
         """Sets the content for the page."""
         self._content = value
 
     @property
-    def embeds(self) -> Optional[List[Union[List[discord.Embed], discord.Embed]]]:
+    def embeds(self) -> list[list[discord.Embed] | discord.Embed] | None:
         """Gets the embeds for the page."""
         return self._embeds
 
     @embeds.setter
-    def embeds(self, value: Optional[List[Union[List[discord.Embed], discord.Embed]]]):
+    def embeds(self, value: list[list[discord.Embed] | discord.Embed] | None):
         """Sets the embeds for the page."""
         self._embeds = value
 
     @property
-    def custom_view(self) -> Optional[discord.ui.View]:
+    def custom_view(self) -> discord.ui.View | None:
         """Gets the custom view assigned to the page."""
         return self._custom_view
 
     @custom_view.setter
-    def custom_view(self, value: Optional[discord.ui.View]):
+    def custom_view(self, value: discord.ui.View | None):
         """Assigns a custom view to be shown when the page is displayed."""
         self._custom_view = value
 
     @property
-    def files(self) -> Optional[List[discord.File]]:
+    def files(self) -> list[discord.File] | None:
         """Gets the files associated with the page."""
         return self._files
 
     @files.setter
-    def files(self, value: Optional[List[discord.File]]):
+    def files(self, value: list[discord.File] | None):
         """Sets the files associated with the page."""
         self._files = value
 
@@ -277,32 +277,28 @@ class PageGroup:
 
     def __init__(
         self,
-        pages: Union[
-            List[str], List[Page], List[Union[List[discord.Embed], discord.Embed]]
-        ],
+        pages: (list[str] | list[Page] | list[list[discord.Embed] | discord.Embed]),
         label: str,
-        description: Optional[str] = None,
-        emoji: Union[str, discord.Emoji, discord.PartialEmoji] = None,
-        default: Optional[bool] = None,
-        show_disabled: Optional[bool] = None,
-        show_indicator: Optional[bool] = None,
-        author_check: Optional[bool] = None,
-        disable_on_timeout: Optional[bool] = None,
-        use_default_buttons: Optional[bool] = None,
+        description: str | None = None,
+        emoji: str | discord.Emoji | discord.PartialEmoji = None,
+        default: bool | None = None,
+        show_disabled: bool | None = None,
+        show_indicator: bool | None = None,
+        author_check: bool | None = None,
+        disable_on_timeout: bool | None = None,
+        use_default_buttons: bool | None = None,
         default_button_row: int = 0,
-        loop_pages: Optional[bool] = None,
-        custom_view: Optional[discord.ui.View] = None,
-        timeout: Optional[float] = None,
-        custom_buttons: Optional[List[PaginatorButton]] = None,
-        trigger_on_display: Optional[bool] = None,
+        loop_pages: bool | None = None,
+        custom_view: discord.ui.View | None = None,
+        timeout: float | None = None,
+        custom_buttons: list[PaginatorButton] | None = None,
+        trigger_on_display: bool | None = None,
     ):
         self.label = label
-        self.description: Optional[str] = description
-        self.emoji: Union[str, discord.Emoji, discord.PartialEmoji] = emoji
-        self.pages: Union[
-            List[str], List[Union[List[discord.Embed], discord.Embed]]
-        ] = pages
-        self.default: Optional[bool] = default
+        self.description: str | None = description
+        self.emoji: str | discord.Emoji | discord.PartialEmoji = emoji
+        self.pages: (list[str] | list[list[discord.Embed] | discord.Embed]) = pages
+        self.default: bool | None = default
         self.show_disabled = show_disabled
         self.show_indicator = show_indicator
         self.author_check = author_check
@@ -312,7 +308,7 @@ class PageGroup:
         self.loop_pages = loop_pages
         self.custom_view: discord.ui.View = custom_view
         self.timeout: float = timeout
-        self.custom_buttons: List = custom_buttons
+        self.custom_buttons: list = custom_buttons
         self.trigger_on_display = trigger_on_display
 
 
@@ -380,12 +376,12 @@ class Paginator(discord.ui.View):
 
     def __init__(
         self,
-        pages: Union[
-            List[PageGroup],
-            List[Page],
-            List[str],
-            List[Union[List[discord.Embed], discord.Embed]],
-        ],
+        pages: (
+            list[PageGroup]
+            | list[Page]
+            | list[str]
+            | list[list[discord.Embed] | discord.Embed]
+        ),
         show_disabled: bool = True,
         show_indicator=True,
         show_menu=False,
@@ -395,24 +391,24 @@ class Paginator(discord.ui.View):
         use_default_buttons=True,
         default_button_row: int = 0,
         loop_pages=False,
-        custom_view: Optional[discord.ui.View] = None,
-        timeout: Optional[float] = 180.0,
-        custom_buttons: Optional[List[PaginatorButton]] = None,
-        trigger_on_display: Optional[bool] = None,
+        custom_view: discord.ui.View | None = None,
+        timeout: float | None = 180.0,
+        custom_buttons: list[PaginatorButton] | None = None,
+        trigger_on_display: bool | None = None,
     ) -> None:
         super().__init__(timeout=timeout)
         self.timeout: float = timeout
-        self.pages: Union[
-            List[PageGroup],
-            List[str],
-            List[Page],
-            List[Union[List[discord.Embed], discord.Embed]],
-        ] = pages
+        self.pages: (
+            list[PageGroup]
+            | list[str]
+            | list[Page]
+            | list[list[discord.Embed] | discord.Embed]
+        ) = pages
         self.current_page = 0
-        self.menu: Optional[PaginatorMenu] = None
+        self.menu: PaginatorMenu | None = None
         self.show_menu = show_menu
         self.menu_placeholder = menu_placeholder
-        self.page_groups: Optional[List[PageGroup]] = None
+        self.page_groups: list[PageGroup] | None = None
         self.default_page_group: int = 0
 
         if all(isinstance(pg, PageGroup) for pg in pages):
@@ -423,13 +419,13 @@ class Paginator(discord.ui.View):
                 if pg.default:
                     self.default_page_group = self.page_groups.index(pg)
                     break
-            self.pages: List[Page] = self.get_page_group_content(
+            self.pages: list[Page] = self.get_page_group_content(
                 self.page_groups[self.default_page_group]
             )
 
         self.page_count = max(len(self.pages) - 1, 0)
         self.buttons = {}
-        self.custom_buttons: List = custom_buttons
+        self.custom_buttons: list = custom_buttons
         self.show_disabled = show_disabled
         self.show_indicator = show_indicator
         self.disable_on_timeout = disable_on_timeout
@@ -438,7 +434,7 @@ class Paginator(discord.ui.View):
         self.loop_pages = loop_pages
         self.custom_view: discord.ui.View = custom_view
         self.trigger_on_display = trigger_on_display
-        self.message: Union[discord.Message, discord.WebhookMessage, None] = None
+        self.message: discord.Message | discord.WebhookMessage | None = None
 
         if self.custom_buttons and not self.use_default_buttons:
             for button in custom_buttons:
@@ -454,28 +450,27 @@ class Paginator(discord.ui.View):
 
     async def update(
         self,
-        pages: Optional[
-            Union[
-                List[PageGroup],
-                List[Page],
-                List[str],
-                List[Union[List[discord.Embed], discord.Embed]],
-            ]
-        ] = None,
-        show_disabled: Optional[bool] = None,
-        show_indicator: Optional[bool] = None,
-        show_menu: Optional[bool] = None,
-        author_check: Optional[bool] = None,
-        menu_placeholder: Optional[str] = None,
-        disable_on_timeout: Optional[bool] = None,
-        use_default_buttons: Optional[bool] = None,
-        default_button_row: Optional[int] = None,
-        loop_pages: Optional[bool] = None,
-        custom_view: Optional[discord.ui.View] = None,
-        timeout: Optional[float] = None,
-        custom_buttons: Optional[List[PaginatorButton]] = None,
-        trigger_on_display: Optional[bool] = None,
-        interaction: Optional[discord.Interaction] = None,
+        pages: None
+        | (
+            list[PageGroup]
+            | list[Page]
+            | list[str]
+            | list[list[discord.Embed] | discord.Embed]
+        ) = None,
+        show_disabled: bool | None = None,
+        show_indicator: bool | None = None,
+        show_menu: bool | None = None,
+        author_check: bool | None = None,
+        menu_placeholder: str | None = None,
+        disable_on_timeout: bool | None = None,
+        use_default_buttons: bool | None = None,
+        default_button_row: int | None = None,
+        loop_pages: bool | None = None,
+        custom_view: discord.ui.View | None = None,
+        timeout: float | None = None,
+        custom_buttons: list[PaginatorButton] | None = None,
+        trigger_on_display: bool | None = None,
+        interaction: discord.Interaction | None = None,
     ):
         """Updates the existing :class:`Paginator` instance with the provided options.
 
@@ -519,14 +514,12 @@ class Paginator(discord.ui.View):
         """
 
         # Update pages and reset current_page to 0 (default)
-        self.pages: Union[
-            List[PageGroup],
-            List[str],
-            List[Page],
-            List[Union[List[discord.Embed], discord.Embed]],
-        ] = (
-            pages if pages is not None else self.pages
-        )
+        self.pages: (
+            list[PageGroup]
+            | list[str]
+            | list[Page]
+            | list[list[discord.Embed] | discord.Embed]
+        ) = (pages if pages is not None else self.pages)
         self.show_menu = show_menu if show_menu is not None else self.show_menu
         if pages is not None and all(isinstance(pg, PageGroup) for pg in pages):
             self.page_groups = self.pages if self.show_menu else None
@@ -536,7 +529,7 @@ class Paginator(discord.ui.View):
                 if pg.default:
                     self.default_page_group = self.page_groups.index(pg)
                     break
-            self.pages: List[Page] = self.get_page_group_content(
+            self.pages: list[Page] = self.get_page_group_content(
                 self.page_groups[self.default_page_group]
             )
         self.page_count = max(len(self.pages) - 1, 0)
@@ -602,9 +595,7 @@ class Paginator(discord.ui.View):
     async def disable(
         self,
         include_custom: bool = False,
-        page: Optional[
-            Union[str, Page, Union[List[discord.Embed], discord.Embed]]
-        ] = None,
+        page: None | (str | Page | list[discord.Embed] | discord.Embed) = None,
     ) -> None:
         """Stops the paginator, disabling all of its components.
 
@@ -635,9 +626,7 @@ class Paginator(discord.ui.View):
     async def cancel(
         self,
         include_custom: bool = False,
-        page: Optional[
-            Union[str, Page, Union[List[discord.Embed], discord.Embed]]
-        ] = None,
+        page: None | (str | Page | list[discord.Embed] | discord.Embed) = None,
     ) -> None:
         """Cancels the paginator, removing all of its components from the message.
 
@@ -667,7 +656,7 @@ class Paginator(discord.ui.View):
             await self.message.edit(view=self)
 
     async def goto_page(
-        self, page_number: int = 0, *, interaction: Optional[discord.Interaction] = None
+        self, page_number: int = 0, *, interaction: discord.Interaction | None = None
     ) -> None:
         """Updates the paginator message to show the specified page number.
 
@@ -810,7 +799,7 @@ class Paginator(discord.ui.View):
             )
         self.buttons.pop(button_type)
 
-    def update_buttons(self) -> Dict:
+    def update_buttons(self) -> dict:
         """Updates the display state of the buttons (disabled/hidden)
 
         Returns
@@ -884,13 +873,13 @@ class Paginator(discord.ui.View):
         for item in custom_view.children:
             self.add_item(item)
 
-    def get_page_group_content(self, page_group: PageGroup) -> List[Page]:
+    def get_page_group_content(self, page_group: PageGroup) -> list[Page]:
         """Returns a converted list of `Page` objects for the given page group based on the content of its pages."""
         return [self.get_page_content(page) for page in page_group.pages]
 
     @staticmethod
     def get_page_content(
-        page: Union[Page, str, discord.Embed, List[discord.Embed]]
+        page: Page | str | discord.Embed | list[discord.Embed],
     ) -> Page:
         """Converts a page into a :class:`Page` object based on its content."""
         if isinstance(page, Page):
@@ -914,9 +903,7 @@ class Paginator(discord.ui.View):
                 " embeds, a file, or a list of files."
             )
 
-    async def page_action(
-        self, interaction: Optional[discord.Interaction] = None
-    ) -> None:
+    async def page_action(self, interaction: discord.Interaction | None = None) -> None:
         """Triggers the callback associated with the current page, if any.
 
         Parameters
@@ -932,14 +919,13 @@ class Paginator(discord.ui.View):
     async def send(
         self,
         ctx: Context,
-        target: Optional[discord.abc.Messageable] = None,
-        target_message: Optional[str] = None,
-        reference: Optional[
-            Union[discord.Message, discord.MessageReference, discord.PartialMessage]
-        ] = None,
-        allowed_mentions: Optional[discord.AllowedMentions] = None,
-        mention_author: Optional[bool] = None,
-        delete_after: Optional[float] = None,
+        target: discord.abc.Messageable | None = None,
+        target_message: str | None = None,
+        reference: None
+        | (discord.Message | discord.MessageReference | discord.PartialMessage) = None,
+        allowed_mentions: discord.AllowedMentions | None = None,
+        mention_author: bool | None = None,
+        delete_after: float | None = None,
     ) -> discord.Message:
         """Sends a message with the paginated items.
 
@@ -1034,10 +1020,10 @@ class Paginator(discord.ui.View):
     async def edit(
         self,
         message: discord.Message,
-        suppress: Optional[bool] = None,
-        allowed_mentions: Optional[discord.AllowedMentions] = None,
-        delete_after: Optional[float] = None,
-    ) -> Optional[discord.Message]:
+        suppress: bool | None = None,
+        allowed_mentions: discord.AllowedMentions | None = None,
+        delete_after: float | None = None,
+    ) -> discord.Message | None:
         """Edits an existing message to replace it with the paginator contents.
 
         .. note::
@@ -1073,7 +1059,7 @@ class Paginator(discord.ui.View):
 
         self.update_buttons()
 
-        page: Union[Page, str, discord.Embed, List[discord.Embed]] = self.pages[
+        page: Page | str | discord.Embed | list[discord.Embed] = self.pages[
             self.current_page
         ]
         page_content: Page = self.get_page_content(page)
@@ -1101,11 +1087,11 @@ class Paginator(discord.ui.View):
 
     async def respond(
         self,
-        interaction: Union[discord.Interaction, BridgeContext],
+        interaction: discord.Interaction | BridgeContext,
         ephemeral: bool = False,
-        target: Optional[discord.abc.Messageable] = None,
+        target: discord.abc.Messageable | None = None,
         target_message: str = "Paginator sent!",
-    ) -> Union[discord.Message, discord.WebhookMessage]:
+    ) -> discord.Message | discord.WebhookMessage:
         """Sends an interaction response or followup with the paginated items.
 
         Parameters
@@ -1150,7 +1136,7 @@ class Paginator(discord.ui.View):
 
         self.update_buttons()
 
-        page: Union[Page, str, discord.Embed, List[discord.Embed]] = self.pages[
+        page: Page | str | discord.Embed | list[discord.Embed] = self.pages[
             self.current_page
         ]
         page_content: Page = self.get_page_content(page)
@@ -1234,12 +1220,12 @@ class PaginatorMenu(discord.ui.Select):
 
     def __init__(
         self,
-        page_groups: List[PageGroup],
-        placeholder: Optional[str] = None,
-        custom_id: Optional[str] = None,
+        page_groups: list[PageGroup],
+        placeholder: str | None = None,
+        custom_id: str | None = None,
     ):
         self.page_groups = page_groups
-        self.paginator: Optional[Paginator] = None
+        self.paginator: Paginator | None = None
         opts = [
             discord.SelectOption(
                 label=page_group.label,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -22,6 +22,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 from typing import Dict, List, Optional, Union
+from io import BufferedReader
 
 import discord
 from discord.ext.bridge import BridgeContext
@@ -166,10 +167,12 @@ class Page:
         """
 
     def update_files(self) -> Optional[List[discord.File]]:
-        """Updates the files associated with the page by re-uploading them.
+        """If possible, it updates the files associated with the page by re-uploading them.
         Typically used when the page is changed.
         """
         for file in self._files:
+            if not isinstance(file.fp, BufferedReader):
+                continue
             with open(file.fp.name, "rb") as fp:  # type: ignore
                 self._files[self._files.index(file)] = discord.File(
                     fp,  # type: ignore


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix issue with `discord/ext/pages/pagination.py` update function while using e.g. `io.BytesIO`.
Files that cannot be updated are skipped.

[Discord forum post](https://discord.com/channels/881207955029110855/1062602760899543070/1062602760899543070)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
