### PR TITLE
Fixed images sending as 0 bytes in paginator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fixed a bug in `Page.update_files` where `io.BytesIO` files didn't send properly more than once.
+
 - Fixed a bug in `Page.update_files` where file objects stored in memory were causing an
   `AttributeError`. ([#1869](https://github.com/Pycord-Development/pycord/pull/1869))
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -173,15 +173,22 @@ class Page:
         Typically used when the page is changed.
         """
         for file in self._files:
-            if not isinstance(file.fp, BufferedReader):
-                continue
-            with open(file.fp.name, "rb") as fp:  # type: ignore
+            if not isinstance(file.fp, io.BufferedReader):
+                file.fp.seek(0)
                 self._files[self._files.index(file)] = discord.File(
-                    fp,  # type: ignore
+                    file.fp,  # type: ignore
                     filename=file.filename,
                     description=file.description,
                     spoiler=file.spoiler,
                 )
+            else:
+                with open(file.fp.name, "rb") as fp:  # type: ignore
+                    self._files[self._files.index(file)] = discord.File(
+                        fp,  # type: ignore
+                        filename=file.filename,
+                        description=file.description,
+                        spoiler=file.spoiler,
+                    )
         return self._files
 
     @property


### PR DESCRIPTION
## Summary

This fixes a bug where if a page is viewed more than once, the image wouldn't be displayed except the first time.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
