### PR TITLE
fix: Document Option.channel_types and properly support further channel types

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -134,6 +134,9 @@ class Option:
         The autocomplete handler for the option. Accepts an iterable of :class:`str`, a callable (sync or async)
         that takes a single argument of :class:`AutocompleteContext`, or a coroutine.
         Must resolve to an iterable of :class:`str`.
+    channel_types: Optional[List[:class:`discord.ChannelType`]]
+        A list of channel types that can be selected in this option.
+        Only applies to Options with an :attr:`input_type` of :class:`discord.abc.GuildChannel`.
 
         .. note::
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -29,7 +29,15 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal, Optional, Type, Union
 
 from ..abc import GuildChannel, Mentionable
-from ..channel import CategoryChannel, StageChannel, TextChannel, Thread, VoiceChannel, ForumChannel, DMChannel
+from ..channel import (
+    CategoryChannel,
+    DMChannel,
+    ForumChannel,
+    StageChannel,
+    TextChannel,
+    Thread,
+    VoiceChannel,
+)
 from ..enums import ChannelType
 from ..enums import Enum as DiscordEnum
 from ..enums import SlashCommandOptionType

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -134,13 +134,13 @@ class Option:
         The autocomplete handler for the option. Accepts an iterable of :class:`str`, a callable (sync or async)
         that takes a single argument of :class:`AutocompleteContext`, or a coroutine.
         Must resolve to an iterable of :class:`str`.
-    channel_types: Optional[List[:class:`discord.ChannelType`]]
-        A list of channel types that can be selected in this option.
-        Only applies to Options with an :attr:`input_type` of :class:`discord.abc.GuildChannel`.
 
         .. note::
 
             Does not validate the input value against the autocomplete results.
+    channel_types: Optional[List[:class:`discord.ChannelType`]]
+        A list of channel types that can be selected in this option.
+        Only applies to Options with an :attr:`input_type` of :class:`discord.abc.GuildChannel`.
     name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
         The name localizations for this option. The values of this should be ``"locale": "name"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -150,7 +150,7 @@ class Option:
             Does not validate the input value against the autocomplete results.
     channel_types: list[:class:`discord.ChannelType`] | None
         A list of channel types that can be selected in this option.
-        Only applies to Options with an :attr:`input_type` of :class:`discord.abc.GuildChannel`.
+        Only applies to Options with an :attr:`input_type` of :class:`discord.SlashCommandOptionType.channel`.
         If this argument is used, :attr:`input_type` will be ignored.
     name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
         The name localizations for this option. The values of this should be ``"locale": "name"``.

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -151,6 +151,7 @@ class Option:
     channel_types: Optional[List[:class:`discord.ChannelType`]]
         A list of channel types that can be selected in this option.
         Only applies to Options with an :attr:`input_type` of :class:`discord.abc.GuildChannel`.
+        If this argument is uses, :attr:`input_type` will be ignored.
     name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
         The name localizations for this option. The values of this should be ``"locale": "name"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -29,7 +29,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal, Optional, Type, Union
 
 from ..abc import GuildChannel, Mentionable
-from ..channel import CategoryChannel, StageChannel, TextChannel, Thread, VoiceChannel
+from ..channel import CategoryChannel, StageChannel, TextChannel, Thread, VoiceChannel, ForumChannel, DMChannel
 from ..enums import ChannelType
 from ..enums import Enum as DiscordEnum
 from ..enums import SlashCommandOptionType
@@ -73,6 +73,8 @@ CHANNEL_TYPE_MAP = {
     StageChannel: ChannelType.stage_voice,
     CategoryChannel: ChannelType.category,
     Thread: ChannelType.public_thread,
+    ForumChannel: ChannelType.forum,
+    DMChannel: ChannelType.private,
 }
 
 
@@ -227,11 +229,12 @@ class Option:
                                 self._raw_type = input_type.__args__  # type: ignore # Union.__args__
                             else:
                                 self._raw_type = (input_type,)
-                        self.channel_types = [
-                            CHANNEL_TYPE_MAP[t]
-                            for t in self._raw_type
-                            if t is not GuildChannel
-                        ]
+                        if not self.channel_types:
+                            self.channel_types = [
+                                CHANNEL_TYPE_MAP[t]
+                                for t in self._raw_type
+                                if t is not GuildChannel
+                            ]
         self.required: bool = (
             kwargs.pop("required", True) if "default" not in kwargs else False
         )

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -148,7 +148,7 @@ class Option:
         .. note::
 
             Does not validate the input value against the autocomplete results.
-    channel_types: Optional[List[:class:`discord.ChannelType`]]
+    channel_types: list[:class:`discord.ChannelType`] | None
         A list of channel types that can be selected in this option.
         Only applies to Options with an :attr:`input_type` of :class:`discord.abc.GuildChannel`.
         If this argument is used, :attr:`input_type` will be ignored.

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -151,7 +151,7 @@ class Option:
     channel_types: Optional[List[:class:`discord.ChannelType`]]
         A list of channel types that can be selected in this option.
         Only applies to Options with an :attr:`input_type` of :class:`discord.abc.GuildChannel`.
-        If this argument is uses, :attr:`input_type` will be ignored.
+        If this argument is used, :attr:`input_type` will be ignored.
     name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
         The name localizations for this option. The values of this should be ``"locale": "name"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -788,7 +788,7 @@ class SlashCommandOptionType(Enum):
             "ThreadOption",
             "Thread",
             "ForumChannel",
-            "DMChannel"
+            "DMChannel",
         ]:
             return cls.channel
         if datatype.__name__ == "Role":

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -787,6 +787,8 @@ class SlashCommandOptionType(Enum):
             "CategoryChannel",
             "ThreadOption",
             "Thread",
+            "ForumChannel",
+            "DMChannel"
         ]:
             return cls.channel
         if datatype.__name__ == "Role":


### PR DESCRIPTION
## Summary
- Finally documents `discord.Option.channel_types`
- Allows `input_type` to accept `discord.ForumChannel` and `discord.DMChannel`.
Ref. #1882 
- `channel_types` now *overrides* the `input_type`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
