### PR TITLE
fix: Update release_level parameters

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -44,9 +44,9 @@ def show_version() -> None:
 
     version_info = discord.version_info
     entries.append(
-        "- py-cord v{0.major}.{0.minor}.{0.micro}-{0.releaselevel}".format(version_info)
+        "- py-cord v{0.major}.{0.minor}.{0.micro}-{0.release_level}".format(version_info)
     )
-    if version_info.releaselevel != "final":
+    if version_info.release_level != "final":
         pkg = pkg_resources.get_distribution("py-cord")
         if pkg:
             entries.append(f"    - py-cord pkg_resources: v{pkg.version}")

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -44,7 +44,9 @@ def show_version() -> None:
 
     version_info = discord.version_info
     entries.append(
-        "- py-cord v{0.major}.{0.minor}.{0.micro}-{0.release_level}".format(version_info)
+        "- py-cord v{0.major}.{0.minor}.{0.micro}-{0.release_level}".format(
+            version_info
+        )
     )
     if version_info.release_level != "final":
         pkg = pkg_resources.get_distribution("py-cord")


### PR DESCRIPTION
This gets rid of deprecation warnings when running `python -m discord -v`

This is my first time contributing, please let me know if I have possibly make a mistake in this PR

Signed-off-by: Revnoplex <62947003+Revnoplex@users.noreply.github.com>

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x ] I have searched the open pull requests for duplicates.
- [x ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
