### PR TITLE
docs: Remove reference to Github discussions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,6 @@ If you're having trouble with something, these resources might help.
 - Ask us and hang out with us in our :resource:`Discord <discord>` server.
 - If you're looking for something specific, try the :ref:`index <genindex>` or :ref:`searching <search>`.
 - Report bugs in the :resource:`issue tracker <issues>`.
-- Ask in our :resource:`GitHub discussions page <discussions>`.
 
 Manuals
 -------


### PR DESCRIPTION
## Summary

Remove reference to Github discussions for help on main page of Pycord docs.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
