### PR TITLE
docs: Adding two new example scripts for dynamic menu generation

### DIFF
--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -1,0 +1,91 @@
+import discord
+
+
+bot = discord.Bot()
+
+# Defines a custom user specific dynamic dropdown
+# that the user can choose. The callback function
+# in the class is strictly to prevent the dreaded
+# interaction failed. The results are returned to
+# the calling function for further processing.
+
+
+def external_user_specific_list_function(discord_id):
+    #Replace this example with whatever your source is
+    #for the users dynamically generated items
+    users_menu_items = []
+    for i in range(5):
+        users_menu_items.append(f'Item #{i + 1}) - Dynamically Generated for <@{discord_id}>')
+        i += 1
+    return users_menu_items
+
+
+
+class Dropdown(discord.ui.Select):
+    def __init__(self, interaction):
+        # In this example, we are passing in the interaction object from the calling interaction.
+        self.value = None
+        self.interaction = interaction
+        self.discord_user = interaction.user.id
+        self.users_menu_items = external_user_specific_list_function(self.discord_user)
+        options = [discord.SelectOption(label=menu_item) for menu_item in self.users_menu_items]
+        #Label only in this example. But you could return a list of lists to populate other tags as well.
+        #i.e. for [discord.SelectOption(label=menu_item[0], description=menu_item[1]) for menu_item in self.users_menu_items]
+
+        # The placeholder is what will be shown when no option is selected.
+        # The min and max values indicate we can only pick one of the three options.
+        # The options parameter, contents shown above, define the dropdown options.
+        super().__init__(
+            placeholder="Choose your a menu item...",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        self.value = self.values[0]
+        await interaction.response.send_message(content='Menu Item Selected...', ephemeral=True, delete_after=3) #could make 0 so it dissapears immediately
+        self.view.disable_all_items()
+        self.view.stop()
+
+
+# Defines a simple View that allows the user to use the Select menu.
+class DropdownView(discord.ui.View):
+    def __init__(self, interaction, *args, **kwargs) -> None:
+        super().__init__(Dropdown(interaction))
+
+        # Uses the one-liner from example in dropdown.py
+        # Passes the interaction object from calling interaction
+
+
+
+
+@bot.slash_command(
+    name = "dynamic_menu",
+    description = "Dynamic Menu Command"
+)
+async def user_dynamic_menu(interaction: discord.Interaction):
+    """Sends a message with our dropdown that contains colour options."""
+    await interaction.response.defer(ephemeral=True)
+    view = DropdownView(interaction)
+    await interaction.followup.send(view=view)
+    await view.wait()
+    # Waits for a menu selection
+    selected_menu_item = view.children[0].value
+    # selected menu item is stored in selected_menu_item variable for further processing
+    await interaction.followup.send(content=f'You Selected {selected_menu_item}')
+    # In this example, we send a follow up message displaying the selected item
+    return
+
+
+
+
+@bot.event
+async def on_ready():
+    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
+    print("------")
+
+
+
+
+bot.run(input('Please provide your bot token: '))

--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -24,8 +24,6 @@ def external_user_specific_list_function(discord_id):
 class Dropdown(discord.ui.Select):
     def __init__(self, interaction):
         # In this example, we are passing in the interaction object from the calling interaction.
-        self.value = None
-        self.interaction = interaction
         self.discord_user = interaction.user.id
         self.users_menu_items = external_user_specific_list_function(self.discord_user)
         options = [

--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -67,7 +67,7 @@ async def user_dynamic_menu(ctx: discord.ApplicationContext):
     """Sends a message with our dropdown that contains colour options."""
     await ctx.defer(ephemeral=True)
     view = DropdownView(interaction)
-    await interaction.followup.send(view=view)
+    await ctx.followup.send(view=view)
     await view.wait()
     # Waits for a menu selection
     selected_menu_item = view.children[0].value

--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -74,7 +74,6 @@ async def user_dynamic_menu(interaction: discord.Interaction):
     # selected menu item is stored in selected_menu_item variable for further processing
     await interaction.followup.send(content=f"You Selected {selected_menu_item}")
     # In this example, we send a follow up message displaying the selected item
-    return
 
 
 @bot.event

--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -65,7 +65,7 @@ class DropdownView(discord.ui.View):
 @bot.slash_command(name="dynamic_menu", description="Dynamic Menu Command")
 async def user_dynamic_menu(ctx: discord.ApplicationContext):
     """Sends a message with our dropdown that contains colour options."""
-    await interaction.response.defer(ephemeral=True)
+    await ctx.defer(ephemeral=True)
     view = DropdownView(interaction)
     await interaction.followup.send(view=view)
     await view.wait()

--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -80,4 +80,4 @@ async def on_ready():
     print("------")
 
 
-bot.run(input("Please provide your bot token: "))
+bot.run("token")

--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -63,7 +63,7 @@ class DropdownView(discord.ui.View):
 
 
 @bot.slash_command(name="dynamic_menu", description="Dynamic Menu Command")
-async def user_dynamic_menu(interaction: discord.Interaction):
+async def user_dynamic_menu(ctx: discord.ApplicationContext):
     """Sends a message with our dropdown that contains colour options."""
     await interaction.response.defer(ephemeral=True)
     view = DropdownView(interaction)

--- a/examples/views/dynamic_user_dropdown.py
+++ b/examples/views/dynamic_user_dropdown.py
@@ -1,6 +1,5 @@
 import discord
 
-
 bot = discord.Bot()
 
 # Defines a custom user specific dynamic dropdown
@@ -11,14 +10,15 @@ bot = discord.Bot()
 
 
 def external_user_specific_list_function(discord_id):
-    #Replace this example with whatever your source is
-    #for the users dynamically generated items
+    # Replace this example with whatever your source is
+    # for the users dynamically generated items
     users_menu_items = []
     for i in range(5):
-        users_menu_items.append(f'Item #{i + 1}) - Dynamically Generated for <@{discord_id}>')
+        users_menu_items.append(
+            f"Item #{i + 1}) - Dynamically Generated for <@{discord_id}>"
+        )
         i += 1
     return users_menu_items
-
 
 
 class Dropdown(discord.ui.Select):
@@ -28,9 +28,11 @@ class Dropdown(discord.ui.Select):
         self.interaction = interaction
         self.discord_user = interaction.user.id
         self.users_menu_items = external_user_specific_list_function(self.discord_user)
-        options = [discord.SelectOption(label=menu_item) for menu_item in self.users_menu_items]
-        #Label only in this example. But you could return a list of lists to populate other tags as well.
-        #i.e. for [discord.SelectOption(label=menu_item[0], description=menu_item[1]) for menu_item in self.users_menu_items]
+        options = [
+            discord.SelectOption(label=menu_item) for menu_item in self.users_menu_items
+        ]
+        # Label only in this example. But you could return a list of lists to populate other tags as well.
+        # i.e. for [discord.SelectOption(label=menu_item[0], description=menu_item[1]) for menu_item in self.users_menu_items]
 
         # The placeholder is what will be shown when no option is selected.
         # The min and max values indicate we can only pick one of the three options.
@@ -44,7 +46,9 @@ class Dropdown(discord.ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         self.value = self.values[0]
-        await interaction.response.send_message(content='Menu Item Selected...', ephemeral=True, delete_after=3) #could make 0 so it dissapears immediately
+        await interaction.response.send_message(
+            content="Menu Item Selected...", ephemeral=True, delete_after=3
+        )  # could make 0 so it dissapears immediately
         self.view.disable_all_items()
         self.view.stop()
 
@@ -58,12 +62,7 @@ class DropdownView(discord.ui.View):
         # Passes the interaction object from calling interaction
 
 
-
-
-@bot.slash_command(
-    name = "dynamic_menu",
-    description = "Dynamic Menu Command"
-)
+@bot.slash_command(name="dynamic_menu", description="Dynamic Menu Command")
 async def user_dynamic_menu(interaction: discord.Interaction):
     """Sends a message with our dropdown that contains colour options."""
     await interaction.response.defer(ephemeral=True)
@@ -73,11 +72,9 @@ async def user_dynamic_menu(interaction: discord.Interaction):
     # Waits for a menu selection
     selected_menu_item = view.children[0].value
     # selected menu item is stored in selected_menu_item variable for further processing
-    await interaction.followup.send(content=f'You Selected {selected_menu_item}')
+    await interaction.followup.send(content=f"You Selected {selected_menu_item}")
     # In this example, we send a follow up message displaying the selected item
     return
-
-
 
 
 @bot.event
@@ -86,6 +83,4 @@ async def on_ready():
     print("------")
 
 
-
-
-bot.run(input('Please provide your bot token: '))
+bot.run(input("Please provide your bot token: "))

--- a/examples/views/dynamic_user_dropdown_async.py
+++ b/examples/views/dynamic_user_dropdown_async.py
@@ -1,0 +1,93 @@
+import discord
+import asyncio
+import asyncinit
+
+
+bot = discord.Bot()
+
+# Identical to dynamic_user_dropdown.py but
+# includes the ability to use an asynchronous function
+# for your dynamic menu generating function
+# You'll need asyncinit | pip install asyncinit==0.2.4
+
+async def external_user_specific_list_function(discord_id):
+    #Replace this example with whatever your source is
+    #for the users dynamically generated items
+    users_menu_items = []
+    await asyncio.sleep(.1)
+    for i in range(5):
+        users_menu_items.append(f'Item #{i + 1}) - Dynamically Generated for <@{discord_id}>')
+        i += 1
+    return users_menu_items
+
+
+@asyncinit
+class Dropdown(discord.ui.Select):
+    async def __init__(self, interaction):
+        # In this example, we are passing in the interaction object from the calling interaction.
+        self.value = None
+        self.interaction = interaction
+        self.discord_user = interaction.user.id
+        self.users_menu_items = await external_user_specific_list_function(self.discord_user)
+        options = [discord.SelectOption(label=menu_item) for menu_item in self.users_menu_items]
+        #Label only in this example. But you could return a list of lists to populate other tags as well.
+        #i.e. for [discord.SelectOption(label=menu_item[0], description=menu_item[1]) for menu_item in self.users_menu_items]
+
+        # The placeholder is what will be shown when no option is selected.
+        # The min and max values indicate we can only pick one of the three options.
+        # The options parameter, contents shown above, define the dropdown options.
+        super().__init__(
+            placeholder="Choose your a menu item...",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        self.value = self.values[0]
+        await interaction.response.send_message(content='Menu Item Selected...', ephemeral=True, delete_after=3) #could make 0 so it dissapears immediately
+        self.view.disable_all_items()
+        self.view.stop()
+
+
+# Defines a simple View that allows the user to use the Select menu.
+@asyncinit
+class DropdownView(discord.ui.View):
+    async def __init__(self, interaction, *args, **kwargs) -> None:
+        super().__init__(await Dropdown(interaction))
+
+        # Uses the one-liner from example in dropdown.py
+        # Passes the interaction object from calling interaction
+
+
+
+
+@bot.slash_command(
+    name = "dynamic_menu",
+    description = "Dynamic Menu Command"
+)
+async def user_dynamic_menu(interaction: discord.Interaction):
+    """Sends a message with our dropdown that contains colour options."""
+    await interaction.response.defer(ephemeral=True)
+    view = await DropdownView(interaction)
+    await interaction.followup.send(view=view)
+    await view.wait()
+    # Waits for a menu selection
+    selected_menu_item = view.children[0].value
+    # selected menu item is stored in selected_menu_item variable for further processing
+    await interaction.followup.send(content=f'You Selected {selected_menu_item}')
+    # In this example, we send a follow up message displaying the selected item
+    return
+
+
+
+
+@bot.event
+async def on_ready():
+    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
+    print("------")
+
+
+
+
+bot.run(input('Please provide your bot token: '))

--- a/examples/views/dynamic_user_dropdown_async.py
+++ b/examples/views/dynamic_user_dropdown_async.py
@@ -1,6 +1,6 @@
 import asyncio
 
-import asyncinit
+from asyncinit import asyncinit
 
 import discord
 

--- a/examples/views/dynamic_user_dropdown_async.py
+++ b/examples/views/dynamic_user_dropdown_async.py
@@ -1,7 +1,8 @@
-import discord
 import asyncio
+
 import asyncinit
 
+import discord
 
 bot = discord.Bot()
 
@@ -10,13 +11,16 @@ bot = discord.Bot()
 # for your dynamic menu generating function
 # You'll need asyncinit | pip install asyncinit==0.2.4
 
+
 async def external_user_specific_list_function(discord_id):
-    #Replace this example with whatever your source is
-    #for the users dynamically generated items
+    # Replace this example with whatever your source is
+    # for the users dynamically generated items
     users_menu_items = []
-    await asyncio.sleep(.1)
+    await asyncio.sleep(0.1)
     for i in range(5):
-        users_menu_items.append(f'Item #{i + 1}) - Dynamically Generated for <@{discord_id}>')
+        users_menu_items.append(
+            f"Item #{i + 1}) - Dynamically Generated for <@{discord_id}>"
+        )
         i += 1
     return users_menu_items
 
@@ -28,10 +32,14 @@ class Dropdown(discord.ui.Select):
         self.value = None
         self.interaction = interaction
         self.discord_user = interaction.user.id
-        self.users_menu_items = await external_user_specific_list_function(self.discord_user)
-        options = [discord.SelectOption(label=menu_item) for menu_item in self.users_menu_items]
-        #Label only in this example. But you could return a list of lists to populate other tags as well.
-        #i.e. for [discord.SelectOption(label=menu_item[0], description=menu_item[1]) for menu_item in self.users_menu_items]
+        self.users_menu_items = await external_user_specific_list_function(
+            self.discord_user
+        )
+        options = [
+            discord.SelectOption(label=menu_item) for menu_item in self.users_menu_items
+        ]
+        # Label only in this example. But you could return a list of lists to populate other tags as well.
+        # i.e. for [discord.SelectOption(label=menu_item[0], description=menu_item[1]) for menu_item in self.users_menu_items]
 
         # The placeholder is what will be shown when no option is selected.
         # The min and max values indicate we can only pick one of the three options.
@@ -45,7 +53,9 @@ class Dropdown(discord.ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         self.value = self.values[0]
-        await interaction.response.send_message(content='Menu Item Selected...', ephemeral=True, delete_after=3) #could make 0 so it dissapears immediately
+        await interaction.response.send_message(
+            content="Menu Item Selected...", ephemeral=True, delete_after=3
+        )  # could make 0 so it dissapears immediately
         self.view.disable_all_items()
         self.view.stop()
 
@@ -60,12 +70,7 @@ class DropdownView(discord.ui.View):
         # Passes the interaction object from calling interaction
 
 
-
-
-@bot.slash_command(
-    name = "dynamic_menu",
-    description = "Dynamic Menu Command"
-)
+@bot.slash_command(name="dynamic_menu", description="Dynamic Menu Command")
 async def user_dynamic_menu(interaction: discord.Interaction):
     """Sends a message with our dropdown that contains colour options."""
     await interaction.response.defer(ephemeral=True)
@@ -75,11 +80,9 @@ async def user_dynamic_menu(interaction: discord.Interaction):
     # Waits for a menu selection
     selected_menu_item = view.children[0].value
     # selected menu item is stored in selected_menu_item variable for further processing
-    await interaction.followup.send(content=f'You Selected {selected_menu_item}')
+    await interaction.followup.send(content=f"You Selected {selected_menu_item}")
     # In this example, we send a follow up message displaying the selected item
     return
-
-
 
 
 @bot.event
@@ -88,6 +91,4 @@ async def on_ready():
     print("------")
 
 
-
-
-bot.run(input('Please provide your bot token: '))
+bot.run(input("Please provide your bot token: "))


### PR DESCRIPTION
## Summary

This pull request is to add two new example scripts for dynamically generated drop down menus.  There is an example for synchronously, and asynchronously generated content.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [X] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
