### PR TITLE
feat: Move additional event handler functionality to `Client`

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1130,7 +1130,6 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
 
     def __init__(self, description=None, *args, **options):
         super().__init__(*args, **options)
-        self.extra_events = {}  # TYPE: Dict[str, List[CoroFunc]]
         self.__cogs = {}  # TYPE: Dict[str, Cog]
         self.__extensions = {}  # TYPE: Dict[str, types.ModuleType]
         self._checks = []  # TYPE: List[Check]
@@ -1178,9 +1177,6 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
 
         This only fires if you do not specify any listeners for command error.
         """
-        if self.extra_events.get("on_application_command_error", None):
-            return
-
         command = context.command
         if command and command.has_error_handler():
             return
@@ -1295,102 +1291,6 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
 
         # type-checker doesn't distinguish between functions and methods
         return await async_all(f(ctx) for f in data)  # type: ignore
-
-    # listener registration
-
-    def add_listener(self, func: CoroFunc, name: str = MISSING) -> None:
-        """The non decorator alternative to :meth:`.listen`.
-
-        Parameters
-        ----------
-        func: :ref:`coroutine <coroutine>`
-            The function to call.
-        name: :class:`str`
-            The name of the event to listen for. Defaults to ``func.__name__``.
-
-        Example
-        -------
-
-        .. code-block:: python3
-
-            async def on_ready(): pass
-            async def my_message(message): pass
-
-            bot.add_listener(on_ready)
-            bot.add_listener(my_message, 'on_message')
-        """
-        name = func.__name__ if name is MISSING else name
-
-        if not asyncio.iscoroutinefunction(func):
-            raise TypeError("Listeners must be coroutines")
-
-        if name in self.extra_events:
-            self.extra_events[name].append(func)
-        else:
-            self.extra_events[name] = [func]
-
-    def remove_listener(self, func: CoroFunc, name: str = MISSING) -> None:
-        """Removes a listener from the pool of listeners.
-
-        Parameters
-        ----------
-        func
-            The function that was used as a listener to remove.
-        name: :class:`str`
-            The name of the event we want to remove. Defaults to
-            ``func.__name__``.
-        """
-
-        name = func.__name__ if name is MISSING else name
-
-        if name in self.extra_events:
-            try:
-                self.extra_events[name].remove(func)
-            except ValueError:
-                pass
-
-    def listen(self, name: str = MISSING) -> Callable[[CFT], CFT]:
-        """A decorator that registers another function as an external
-        event listener. Basically this allows you to listen to multiple
-        events from different places e.g. such as :func:`.on_ready`
-
-        The functions being listened to must be a :ref:`coroutine <coroutine>`.
-
-        Raises
-        ------
-        TypeError
-            The function being listened to is not a coroutine.
-
-        Example
-        -------
-
-        .. code-block:: python3
-
-            @bot.listen()
-            async def on_message(message):
-                print('one')
-
-            # in some other file...
-
-            @bot.listen('on_message')
-            async def my_message(message):
-                print('two')
-
-        Would print one and two in an unspecified order.
-        """
-
-        def decorator(func: CFT) -> CFT:
-            self.add_listener(func, name)
-            return func
-
-        return decorator
-
-    def dispatch(self, event_name: str, *args: Any, **kwargs: Any) -> None:
-        # super() will resolve to Client
-        super().dispatch(event_name, *args, **kwargs)  # type: ignore
-        ev = f"on_{event_name}"
-        for event in self.extra_events.get(ev, []):
-            self._schedule_event(event, ev, *args, **kwargs)  # type: ignore
 
     def before_invoke(self, coro):
         """A decorator that registers a coroutine as a pre-invoke hook.

--- a/discord/client.py
+++ b/discord/client.py
@@ -1180,7 +1180,7 @@ class Client:
         _log.debug(
             "%s has successfully been registered as a handler for event %s",
             func.__name__,
-            name
+            name,
         )
 
     def remove_listener(self, func: Coro, name: str = MISSING) -> None:

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -7,9 +7,12 @@ Event Reference
 
 This section outlines the different types of events listened by :class:`Client`.
 
-There are two ways to register an event, the first way is through the use of
+There are 3 ways to register an event, the first way is through the use of
 :meth:`Client.event`. The second way is through subclassing :class:`Client` and
-overriding the specific events. For example: ::
+overriding the specific events. The third way is through the use of :meth:`Client.listen`, which can be used to assign multiple
+event handlers instead of only one like in :meth:`Client.event`. For example: 
+
+.. code-block:: python
 
     import discord
 
@@ -20,6 +23,21 @@ overriding the specific events. For example: ::
 
             if message.content.startswith('$hello'):
                 await message.channel.send('Hello World!')
+
+
+    intents = discord.Intents.default()
+    intents.message_content = True # Needed to see message content
+    client = MyClient(intents=intents)
+
+    # Overrides the 'on_message' method defined in MyClient
+    @client.event
+    async def on_message(message: discord.Message):
+        print(f"Received {message.content}")
+    
+    # Assigns an ADDITIONAL handler
+    @client.listen()
+    async def on_message(message: discord.Message):
+        print(f"Received {message.content}")
 
 
 If an event handler raises an exception, :func:`on_error` will be called

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -13,6 +13,7 @@ overriding the specific events. The third way is through the use of :meth:`Clien
 event handlers instead of only one like in :meth:`Client.event`. For example: 
 
 .. code-block:: python
+    :emphasize-lines: 17, 22
 
     import discord
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@ pytest-asyncio~=0.20.3
 # pytest-order~=1.0.1
 mypy~=0.991
 coverage~=7.1
-pre-commit==3.0.2
+pre-commit==3.0.4
 codespell==2.2.2
 bandit==1.7.4
 flake8==6.0.0


### PR DESCRIPTION
## Summary
The pull request introduces changes proposed in #1906 .
<!-- What is this pull request for? Does it fix any issues? -->
It allows the user to register multiple ``on_`` event handlers inside the ``Client`` objects instead of just in``Bot``. 

```py
import discord
import secret


class MyClient(discord.Client):
    async def on_ready(self):
        print("Default handler")


intents = discord.Intents.default()
intents.message_content = True
client = MyClient(intents=intents)


@client.event # Override the default handler
async def on_ready():
    print(f"Handler 1: {client.user.name} has logged in!")

@client.listen # Additional handler
async def on_ready():
    print(f"Handler 2: {client.user.name} has logged in!")

@client.listen("on_ready") # Additional handler
async def ready_handler():
    print(f"Handler 3: {client.user.name} has logged in!")

@client.listen("on_ready") # Additional handler
async def ready_handler():
    print(f"Handler 4: {client.user.name} has logged in!")

@client.listen()
async def on_message(message: discord.Message):
    print(f"Received message {message.content}")


@client.listen("on_guild_channel_update")
async def channel_updated(prev: discord.ChannelType, curr:discord.ChannelType):
    print(prev.name, curr.name)

client.run(secret.TOKEN)
```

Also add support to allow ``@listen`` without ``()`` at the end.
```py
import discord
import secret

bot = discord.Bot()

@bot.listen()
async def on_ready():
    print(f"Handler 1: {bot.user.name} has logged in!")

@bot.listen # <-------- No ()
async def on_ready():
    print(f"Handler 2: {bot.user.name} has logged in!")

bot.run(secret.TOKEN)
```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
