### PR TITLE
feat: add silent parameter to Messageable.send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 - Added new `EmbeddedActivity` values.
   ([#1859](https://github.com/Pycord-Development/pycord/pull/1859))
-- Added new `suppress_notifications` to `MessageFlags.
+- Added new `suppress_notifications` to `MessageFlags`.
   ([#1912](https://github.com/Pycord-Development/pycord/pull/1912))
 
 ### Changed

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1321,6 +1321,7 @@ class Messageable:
         mention_author: bool = ...,
         view: View = ...,
         suppress: bool = ...,
+        silent: bool = ...,
     ) -> Message:
         ...
 
@@ -1340,6 +1341,7 @@ class Messageable:
         mention_author: bool = ...,
         view: View = ...,
         suppress: bool = ...,
+        silent: bool = ...,
     ) -> Message:
         ...
 
@@ -1359,6 +1361,7 @@ class Messageable:
         mention_author: bool = ...,
         view: View = ...,
         suppress: bool = ...,
+        silent: bool = ...,
     ) -> Message:
         ...
 
@@ -1378,6 +1381,7 @@ class Messageable:
         mention_author: bool = ...,
         view: View = ...,
         suppress: bool = ...,
+        silent: bool = ...,
     ) -> Message:
         ...
 
@@ -1398,6 +1402,7 @@ class Messageable:
         mention_author=None,
         view=None,
         suppress=None,
+        silent=None,
     ):
         """|coro|
 
@@ -1471,6 +1476,10 @@ class Messageable:
             .. versionadded:: 2.0
         suppress: :class:`bool`
             Whether to suppress embeds for the message.
+        slient: :class:`bool`
+            Whether to suppress push and desktop notifications for the message.
+
+            .. versionadded:: 2.4
 
         Returns
         -------
@@ -1510,11 +1519,10 @@ class Messageable:
                 )
             embeds = [embed.to_dict() for embed in embeds]
 
-        flags = (
-            MessageFlags.suppress_embeds.flag
-            if suppress
-            else MessageFlags.DEFAULT_VALUE
-        )
+        flags = MessageFlags(
+            suppress_embeds=bool(suppress),
+            suppress_notifications=bool(silent),
+        ).value
 
         if stickers is not None:
             stickers = [sticker.id for sticker in stickers]

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -379,7 +379,7 @@ class MessageFlags(BaseFlags):
     def loading(self):
         """:class:`bool`: Returns ``True`` if the source message is deferred.
 
-        The user sees a 'thinking' state
+        The user sees a 'thinking' state.
 
         .. versionadded:: 2.0
         """
@@ -395,9 +395,9 @@ class MessageFlags(BaseFlags):
 
     @flag_value
     def suppress_notifications(self):
-        """:class:`bool`: Returns ``True`` if the source message does not trigger push and desktop notifications
+        """:class:`bool`: Returns ``True`` if the source message does not trigger push and desktop notifications.
 
-        The user will still receive a mention
+        Users will still receive mentions.
 
         .. versionadded:: 2.4
         """


### PR DESCRIPTION
## Summary
Adds a parameter called `silent` which applies the `MessageFlags.suppress_notifications` flag.
Also fixes minor inconsistencies in flag documentation.

## Information
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
