### PR TITLE
fix: properly store advanced version_info data

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -44,11 +44,9 @@ def show_version() -> None:
 
     version_info = discord.version_info
     entries.append(
-        "- py-cord v{0.major}.{0.minor}.{0.micro}-{0.release_level}".format(
-            version_info
-        )
+        "- py-cord v{0.major}.{0.minor}.{0.micro}-{0.releaselevel}".format(version_info)
     )
-    if version_info.release_level != "final":
+    if version_info.releaselevel != "final":
         pkg = pkg_resources.get_distribution("py-cord")
         if pkg:
             entries.append(f"    - py-cord pkg_resources: v{pkg.version}")

--- a/discord/_version.py
+++ b/discord/_version.py
@@ -81,7 +81,7 @@ class VersionInfo(NamedTuple):
         _advanced = value
 
     @property
-    @deprecated("release_level", "2.4")
+    @deprecated("releaselevel", "2.4")
     def release_level(self) -> Literal["alpha", "beta", "candidate", "final"]:
         return self.releaselevel
 

--- a/discord/_version.py
+++ b/discord/_version.py
@@ -24,10 +24,12 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
+import datetime
 import re
 import warnings
-from datetime import date
 from importlib.metadata import PackageNotFoundError, version
+
+from ._typed_dict import TypedDict
 
 __all__ = ("__version__", "VersionInfo", "version_info")
 
@@ -54,20 +56,54 @@ except PackageNotFoundError:
         )
 
 
+class AdvancedVersionInfo(TypedDict):
+    serial: int
+    build: int | None
+    commit: str | None
+    date: datetime.date | None
+
+
 class VersionInfo(NamedTuple):
     major: int
     minor: int
     micro: int
-    release_level: Literal["alpha", "beta", "candidate", "final"]
-    serial: int
-    build: int | None = None
-    commit: str | None = None
-    date: date | None = None
+    releaselevel: Literal["alpha", "beta", "candidate", "final"]
+
+    # We can't set instance attributes on a NamedTuple, so we have to use a
+    # global variable to store the advanced version info.
+    @property
+    def advanced(self) -> AdvancedVersionInfo:
+        return _advanced
+
+    @advanced.setter
+    def advanced(self, value: object) -> None:
+        global _advanced
+        _advanced = value
 
     @property
-    @deprecated("release_level", "2.3")
-    def releaselevel(self) -> Literal["alpha", "beta", "candidate", "final"]:
-        return self.release_level
+    @deprecated("release_level", "2.4")
+    def release_level(self) -> Literal["alpha", "beta", "candidate", "final"]:
+        return self.releaselevel
+
+    @property
+    @deprecated('.advanced["serial"]', "2.4")
+    def serial(self) -> int:
+        return self.advanced["serial"]
+
+    @property
+    @deprecated('.advanced["build"]', "2.4")
+    def build(self) -> int | None:
+        return self.advanced["build"]
+
+    @property
+    @deprecated('.advanced["commit"]', "2.4")
+    def commit(self) -> str | None:
+        return self.advanced["commit"]
+
+    @property
+    @deprecated('.advanced["date"]', "2.4")
+    def date(self) -> datetime.date | None:
+        return self.advanced["date"]
 
 
 version_regex = re.compile(
@@ -95,7 +131,7 @@ else:
     raise RuntimeError("Invalid release level")
 
 if (raw_date := raw_info["date"] or raw_info["date1"]) is not None:
-    date_info = date(
+    date_info = datetime.date(
         int(raw_date[:4]),
         int(raw_date[4:6]),
         int(raw_date[6:]),
@@ -107,7 +143,10 @@ version_info: VersionInfo = VersionInfo(
     major=int(raw_info["major"] or 0) or None,
     minor=int(raw_info["minor"] or 0) or None,
     micro=int(raw_info["patch"] or 0) or None,
-    release_level=level_info,
+    releaselevel=level_info,
+)
+
+_advanced = AdvancedVersionInfo(
     serial=raw_info["serial"],
     build=int(raw_info["build"] or 0) or None,
     commit=raw_info["commit"],


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
