### PR TITLE
docs: add missing changelog and fix stage_raise_hand grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual behavior
-([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
+- Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual
+  behavior ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 
 ## [2.4.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ These changes are available on the `master` branch, but have not yet been releas
 ### Fixed
 
 - Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual
-  behavior ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
+  behavior. ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 
 ## [2.4.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
-_No changes yet_
+### Fixed
+
+- Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual behavior
+([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 
 ## [2.4.0] - 2023-02-10
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -279,7 +279,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: stage_raise_hand
 
-        The system message denoting that a stage event has someone raising their hand.
+        The system message denoting that someone in a stage event is raising their hand.
 
         .. versionadded:: 2.4
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -279,7 +279,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: stage_raise_hand
 
-        The system message denoting that a stage event has someone has raised their hand.
+        The system message denoting that a stage event has someone raising their hand.
 
         .. versionadded:: 2.4
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Changelog entry for #1852 was missing.

Grammar was a bit wacky for `stage_raise_hand`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
