### PR TITLE
feat: Implement audit log events

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -717,7 +717,7 @@ class Intents(BaseFlags):
         """
         return 1 << 1
 
-    @flag_value
+    @alias_flag_value
     def bans(self):
         """:class:`bool`: Alias of :attr:`.moderation`.
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -721,7 +721,7 @@ class Intents(BaseFlags):
     def bans(self):
         """:class:`bool`: Alias of :attr:`.moderation`.
 
-        .. versionchanged:: 2.4
+        .. versionchanged:: 2.5
             Changed to an alias.
         """
         return 1 << 2

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -719,10 +719,20 @@ class Intents(BaseFlags):
 
     @flag_value
     def bans(self):
-        """:class:`bool`: Whether guild ban related events are enabled.
+        """:class:`bool`: Alias of :attr:`.moderation`.
+
+        .. versionchanged:: 2.4
+            Changed to an alias.
+        """
+        return 1 << 2
+
+    @flag_value
+    def moderation(self):
+        """:class:`bool`: Whether guild moderation related events are enabled.
 
         This corresponds to the following events:
 
+        - :func:`on_audit_log_entry`
         - :func:`on_member_ban`
         - :func:`on_member_unban`
 

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -608,7 +608,7 @@ class RawThreadMembersUpdateEvent(_RawReprMixin):
 class RawAuditLogEntryEvent(_RawReprMixin):
     """Represents the payload for an :func:`on_raw_audit_log_entry` event.
 
-    .. versionadded:: 2.4
+    .. versionadded:: 2.5
 
     Attributes
     ----------

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -29,7 +29,7 @@ import datetime
 from typing import TYPE_CHECKING
 
 from .automod import AutoModAction, AutoModTriggerType
-from .enums import ChannelType, try_enum
+from .enums import ChannelType, AuditLogAction, try_enum
 from .types.user import User
 
 if TYPE_CHECKING:
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from .threads import Thread
     from .types.raw_models import AutoModActionExecutionEvent as AutoModActionExecution
     from .types.raw_models import (
+        AuditLogEntryEvent,
         BulkMessageDeleteEvent,
         IntegrationDeleteEvent,
         MemberRemoveEvent,
@@ -73,6 +74,7 @@ __all__ = (
     "RawScheduledEventSubscription",
     "AutoModActionExecutionEvent",
     "RawThreadMembersUpdateEvent",
+    "RawAuditLogEntryEvent"
 )
 
 
@@ -600,4 +602,55 @@ class RawThreadMembersUpdateEvent(_RawReprMixin):
         self.thread_id = int(data["id"])
         self.guild_id = int(data["guild_id"])
         self.member_count = int(data["member_count"])
+        self.data = data
+
+
+class RawAuditLogEntryEvent(_RawReprMixin):
+    """Represents the payload for an :func:`on_raw_audit_log_entry` event.
+
+    .. versionadded:: 2.4
+
+    Attributes
+    ----------
+    action_type: :class:`AuditLogAction`
+        The action that was done.
+    id: :class:`int`
+        The entry ID.
+    user_id: :class:`int`
+        The ID of the user who initiated this action
+    target_id: :class:`int`
+        The ID of the target that got changed.
+    reason: Optional[:class:`str`]
+        The reason this action was done.
+    changes: Optional[:class:`list`]
+        The changes that were made to the target.
+    extra: Any
+        Extra information that this entry has that might be useful.
+        For most actions, this is ``None``. However, in some cases it
+        contains extra information. See :class:`AuditLogAction` for
+        which actions have this field filled out.
+    data: :class:`dict`
+        The raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create>`_.
+    """
+
+    __slots__ = (
+        "id",
+        "user_id",
+        "target_id",
+        "action_type",
+        "reason",
+        "extra",
+        "changes",
+    )
+    
+
+    def __init__(self, data: AuditLogEntryEvent) -> None:
+        self.id = int(data["id"])
+        self.user_id = int(data["user_id"])
+        self.guild_id = int(data["guild_id"])
+        self.target_id = int(data["target_id"])
+        self.action_type = try_enum(AuditLogAction, int(data["action_type"]))
+        self.reason = data.get("reason")
+        self.extra = data.get("options")
+        self.changes = data.get("changes")
         self.data = data

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -29,7 +29,7 @@ import datetime
 from typing import TYPE_CHECKING
 
 from .automod import AutoModAction, AutoModTriggerType
-from .enums import ChannelType, AuditLogAction, try_enum
+from .enums import AuditLogAction, ChannelType, try_enum
 from .types.user import User
 
 if TYPE_CHECKING:
@@ -40,9 +40,9 @@ if TYPE_CHECKING:
     from .partial_emoji import PartialEmoji
     from .state import ConnectionState
     from .threads import Thread
+    from .types.raw_models import AuditLogEntryEvent
     from .types.raw_models import AutoModActionExecutionEvent as AutoModActionExecution
     from .types.raw_models import (
-        AuditLogEntryEvent,
         BulkMessageDeleteEvent,
         IntegrationDeleteEvent,
         MemberRemoveEvent,
@@ -74,7 +74,7 @@ __all__ = (
     "RawScheduledEventSubscription",
     "AutoModActionExecutionEvent",
     "RawThreadMembersUpdateEvent",
-    "RawAuditLogEntryEvent"
+    "RawAuditLogEntryEvent",
 )
 
 
@@ -642,7 +642,6 @@ class RawAuditLogEntryEvent(_RawReprMixin):
         "extra",
         "changes",
     )
-    
 
     def __init__(self, data: AuditLogEntryEvent) -> None:
         self.id = int(data["id"])

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -131,6 +131,7 @@ class ThreadMembersUpdateEvent(TypedDict):
     added_members: NotRequired[list[ThreadMember]]
     removed_member_ids: NotRequired[list[Snowflake]]
 
+
 class AuditLogEntryEvent(TypedDict):
     id: Snowflake
     user_id: Snowflake

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -134,6 +134,7 @@ class ThreadMembersUpdateEvent(TypedDict):
 class AuditLogEntryEvent(TypedDict):
     id: Snowflake
     user_id: Snowflake
+    guild_id: Snowflake
     target_id: Snowflake
     action_type: int
     changes: NotRequired[list[dict]]

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -136,6 +136,6 @@ class AuditLogEntryEvent(TypedDict):
     user_id: Snowflake
     target_id: Snowflake
     action_type: int
-    changes: NotRequired[list[AuditLogChange]]
+    changes: NotRequired[list[dict]]
     reason: NotRequired[str]
     options: NotRequired[dict]

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -130,3 +130,12 @@ class ThreadMembersUpdateEvent(TypedDict):
     member_count: int
     added_members: NotRequired[list[ThreadMember]]
     removed_member_ids: NotRequired[list[Snowflake]]
+
+class AuditLogEntryEvent(TypedDict):
+    id: Snowflake
+    user_id: Snowflake
+    target_id: Snowflake
+    action_type: int
+    changes: NotRequired[list[AuditLogChange]]
+    reason: NotRequired[str]
+    options: NotRequired[dict]

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -85,7 +85,7 @@ Audit Logs
     .. versionadded:: 2.4
 
     :param entry: The audit log entry that was created.
-    :type rule: :class:`AuditLogEntry`
+    :type entry: :class:`AuditLogEntry`
 
 .. function:: on_raw_audit_log_entry(payload)
 
@@ -99,7 +99,7 @@ Audit Logs
     .. versionadded:: 2.4
 
     :param payload: The raw event payload data.
-    :type rule: :class:`RawAuditLogEntryEvent`
+    :type payload: :class:`RawAuditLogEntryEvent`
 
 AutoMod
 -------

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -72,6 +72,35 @@ Application Commands
     :param interaction: The interaction associated to the unknown command.
     :type interaction: :class:`Interaction`
 
+Audit Logs
+----------
+
+.. function:: on_audit_log_entry(entry)
+
+    Called when an audit log entry is created.
+
+    The bot must have :attr:`~Permissions.view_audit_log` to receive this, and
+    :attr:`Intents.moderation` must be enabled.
+
+    .. versionadded:: 2.4
+
+    :param entry: The audit log entry that was created.
+    :type rule: :class:`AuditLogEntry`
+
+.. function:: on_raw_audit_log_entry(payload)
+
+    Called when an audit log entry is created. Unlike
+    :func:`on_audit_log_entry`, this is called regardless of the state of the internal
+    member cache.
+
+    The bot must have :attr:`~Permissions.view_audit_log` to receive this, and
+    :attr:`Intents.moderation` must be enabled.
+
+    .. versionadded:: 2.4
+
+    :param payload: The raw event payload data.
+    :type rule: :class:`RawAuditLogEntryEvent`
+
 AutoMod
 -------
 .. function:: on_auto_moderation_rule_create(rule)
@@ -120,7 +149,7 @@ Bans
 
     Called when user gets banned from a :class:`Guild`.
 
-    This requires :attr:`Intents.bans` to be enabled.
+    This requires :attr:`Intents.moderation` to be enabled.
 
     :param guild: The guild the user got banned from.
     :type guild: :class:`Guild`
@@ -133,7 +162,7 @@ Bans
 
     Called when a :class:`User` gets unbanned from a :class:`Guild`.
 
-    This requires :attr:`Intents.bans` to be enabled.
+    This requires :attr:`Intents.moderation` to be enabled.
 
     :param guild: The guild the user got unbanned from.
     :type guild: :class:`Guild`

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -91,7 +91,7 @@ Audit Logs
 
     Called when an audit log entry is created. Unlike
     :func:`on_audit_log_entry`, this is called regardless of the state of the internal
-    member cache.
+    user cache.
 
     The bot must have :attr:`~Permissions.view_audit_log` to receive this, and
     :attr:`Intents.moderation` must be enabled.

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -82,7 +82,7 @@ Audit Logs
     The bot must have :attr:`~Permissions.view_audit_log` to receive this, and
     :attr:`Intents.moderation` must be enabled.
 
-    .. versionadded:: 2.4
+    .. versionadded:: 2.5
 
     :param entry: The audit log entry that was created.
     :type entry: :class:`AuditLogEntry`

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -96,7 +96,7 @@ Audit Logs
     The bot must have :attr:`~Permissions.view_audit_log` to receive this, and
     :attr:`Intents.moderation` must be enabled.
 
-    .. versionadded:: 2.4
+    .. versionadded:: 2.5
 
     :param payload: The raw event payload data.
     :type payload: :class:`RawAuditLogEntryEvent`

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -517,6 +517,11 @@ Events
 .. autoclass:: RawThreadMembersUpdateEvent()
     :members:
 
+.. attributetable:: RawAuditLogEntryEvent
+
+.. autoclass:: RawAuditLogEntryEvent()
+    :members:
+
 
 
 Webhooks

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -328,7 +328,7 @@ Quick example: ::
 Is there an event for audit log entries being created?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of version 2.4.x, it's now possible via the :func:`on_audit_log_entry` event.
+As of version 2.4.x, you can recieve audit log entries with the :func:`on_audit_log_entry` event.
 
 Commands Extension
 -------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -328,7 +328,7 @@ Quick example: ::
 Is there an event for audit log entries being created?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of version 2.4.x, you can recieve audit log entries with the :func:`on_audit_log_entry` event.
+As of version 2.5, you can receive audit log entries with the :func:`on_audit_log_entry` event.
 
 Commands Extension
 -------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -328,8 +328,7 @@ Quick example: ::
 Is there an event for audit log entries being created?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since Discord does not dispatch this information in the gateway, the library cannot provide this information.
-This is currently a Discord limitation.
+As of February 2023, it's now possible via the :func:`on_audit_log_entry` event.
 
 Commands Extension
 -------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -328,7 +328,7 @@ Quick example: ::
 Is there an event for audit log entries being created?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of February 2023, it's now possible via the :func:`on_audit_log_entry` event.
+As of version 2.4.x, it's now possible via the :func:`on_audit_log_entry` event.
 
 Commands Extension
 -------------------


### PR DESCRIPTION
## Summary

Continuation of #1873, implementing changes as per https://github.com/discord/discord-api-docs/pull/5849:
- `Intents.bans` is now an alias of `Intents.moderation`
- Implements `on_audit_log_entry`
- Implements `on_raw_audit_log_entry` and its respective payload.

Closes #1872.

This PR is functionally complete, however I'm not entirely sure on the raw payload structure; currently the only converted objects are:
- `guild`, as it'll only fire for cached guilds
- `action_type` as Enums are easy enough to deal with

Is it worth trying to convert anything else? It's kind of odd to work with the original data but both `extra` (`options`) and `changes` are fairly cache reliant and can't efficiently be done with the current methods, though `changes` could work if you force everything to be an `Object`. That being said, it's still a Raw event so working with raw data should be expected.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
