### PR TITLE
fix(misc): RawAuditLogEntryEvent fixes

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -616,8 +616,10 @@ class RawAuditLogEntryEvent(_RawReprMixin):
         The action that was done.
     id: :class:`int`
         The entry ID.
+    guild_id: :class:`int`
+        The ID of the guild this action came from.
     user_id: :class:`int`
-        The ID of the user who initiated this action
+        The ID of the user who initiated this action.
     target_id: :class:`int`
         The ID of the target that got changed.
     reason: Optional[:class:`str`]
@@ -636,6 +638,7 @@ class RawAuditLogEntryEvent(_RawReprMixin):
     __slots__ = (
         "id",
         "user_id",
+        "guild_id",
         "target_id",
         "action_type",
         "reason",

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -620,7 +620,7 @@ class RawAuditLogEntryEvent(_RawReprMixin):
         The ID of the guild this action came from.
     user_id: :class:`int`
         The ID of the user who initiated this action.
-    target_id: :class:`int`
+    target_id: Optional[:class:`int`]
         The ID of the target that got changed.
     reason: Optional[:class:`str`]
         The reason this action was done.
@@ -650,7 +650,9 @@ class RawAuditLogEntryEvent(_RawReprMixin):
         self.id = int(data["id"])
         self.user_id = int(data["user_id"])
         self.guild_id = int(data["guild_id"])
-        self.target_id = int(data["target_id"])
+        self.target_id = data.get("target_id")
+        if self.target_id:
+            self.target_id = int(self.target_id)
         self.action_type = try_enum(AuditLogAction, int(data["action_type"]))
         self.reason = data.get("reason")
         self.extra = data.get("options")

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -136,7 +136,7 @@ class AuditLogEntryEvent(TypedDict):
     id: Snowflake
     user_id: Snowflake
     guild_id: Snowflake
-    target_id: Snowflake
+    target_id: NotRequired[Snowflake]
     action_type: int
     changes: NotRequired[list[dict]]
     reason: NotRequired[str]


### PR DESCRIPTION
- Added `guild_id` to slots. It was already an attribute, but not useable.
- Made `target_id` optional

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
