### PR TITLE
feat: add `once` decorator to `discord.Client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added new events `on_bridge_command`, `on_bridge_command_completion`, and
   `on_bridge_command_error`.
   ([#1916](https://github.com/Pycord-Development/pycord/pull/1916))
+- Added a `@client.once()` decorator that works like a one-time event listener.
+  ([#1940](https://github.com/Pycord-Development/pycord/pull/1940))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added new events `on_bridge_command`, `on_bridge_command_completion`, and
   `on_bridge_command_error`.
   ([#1916](https://github.com/Pycord-Development/pycord/pull/1916))
-- Added a `@client.once()` decorator that works like a one-time event listener.
+- Added the `@client.once()` decorator, which serves as a one-time event listener.
   ([#1940](https://github.com/Pycord-Development/pycord/pull/1940))
 
 ### Fixed

--- a/discord/client.py
+++ b/discord/client.py
@@ -1286,6 +1286,64 @@ class Client:
         _log.debug("%s has successfully been registered as an event", coro.__name__)
         return coro
 
+    def once(
+        self, name: str = MISSING, check: Callable[..., bool] | None = None
+    ) -> Coro:
+        """A decorator that registers an event to listen to only once.
+
+        You can find more info about the events on the :ref:`documentation below <discord-api-events>`.
+
+        The events must be a :ref:`coroutine <coroutine>`, if not, :exc:`TypeError` is raised.
+
+        Parameters
+        ----------
+        name: :class:`str`
+            The name of the event we want to listen to. This is passed to
+            :py:meth:`~discord.Client.wait_for`. Defaults to ``func.__name__``.
+        check: Optional[Callable[..., :class:`bool`]]
+            A predicate to check what to wait for. The arguments must meet the
+            parameters of the event being waited for.
+
+        Raises
+        ------
+        TypeError
+            The coroutine passed is not actually a coroutine.
+
+        Example
+        -------
+
+        .. code-block:: python3
+
+            @client.once()
+            async def ready():
+                print('Ready!')
+        """
+
+        def decorator(func: Coro) -> Coro:
+            if not asyncio.iscoroutinefunction(func):
+                raise TypeError("event registered must be a coroutine function")
+
+            async def wrapped() -> None:
+                nonlocal name
+                nonlocal check
+
+                name = func.__name__ if name is MISSING else name
+
+                args = await self.wait_for(name, check=check)
+
+                arg_len = func.__code__.co_argcount
+                if arg_len == 0 and args is None:
+                    await func()
+                elif arg_len == 1:
+                    await func(args)
+                else:
+                    await func(*args)
+
+            self.loop.create_task(wrapped())
+            return func
+
+        return decorator
+
     async def change_presence(
         self,
         *,

--- a/docs/api/clients.rst
+++ b/docs/api/clients.rst
@@ -10,7 +10,7 @@ Bots
 .. autoclass:: Bot
     :members:
     :inherited-members:
-    :exclude-members: command, event, message_command, slash_command, user_command, listen
+    :exclude-members: command, event, message_command, slash_command, user_command, listen, once
 
     .. automethod:: Bot.command(**kwargs)
         :decorator:
@@ -29,6 +29,9 @@ Bots
 
     .. automethod:: Bot.listen(name=None)
         :decorator:
+    
+    .. automethod:: Bot.once(name=None, check=None)
+        :decorator:
 
 .. attributetable:: AutoShardedBot
 .. autoclass:: AutoShardedBot
@@ -41,13 +44,16 @@ Clients
 .. attributetable:: Client
 .. autoclass:: Client
     :members:
-    :exclude-members: fetch_guilds, event
+    :exclude-members: fetch_guilds, event, once
 
     .. automethod:: Client.event()
         :decorator:
 
     .. automethod:: Client.fetch_guilds
         :async-for:
+
+    .. automethod:: Client.once(name=None, check=None)
+        :decorator:
 
 .. attributetable:: AutoShardedClient
 .. autoclass:: AutoShardedClient

--- a/docs/api/clients.rst
+++ b/docs/api/clients.rst
@@ -29,7 +29,7 @@ Bots
 
     .. automethod:: Bot.listen(name=None)
         :decorator:
-    
+
     .. automethod:: Bot.once(name=None, check=None)
         :decorator:
 

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -7,10 +7,11 @@ Event Reference
 
 This section outlines the different types of events listened by :class:`Client`.
 
-There are 3 ways to register an event, the first way is through the use of
+There are 4 ways to register an event, the first way is through the use of
 :meth:`Client.event`. The second way is through subclassing :class:`Client` and
-overriding the specific events. The third way is through the use of :meth:`Client.listen`, which can be used to assign multiple
-event handlers instead of only one like in :meth:`Client.event`. For example:
+overriding the specific events. The third way is through the use of :meth:`Client.listen`, 
+which can be used to assign multiple event handlers instead of only one like in :meth:`Client.event`. 
+The fourth way is through the use of :meth:`Client.once`, which serves as a one-time event listener. For example:
 
 .. code-block:: python
     :emphasize-lines: 17, 22
@@ -38,6 +39,11 @@ event handlers instead of only one like in :meth:`Client.event`. For example:
     # Assigns an ADDITIONAL handler
     @client.listen()
     async def on_message(message: discord.Message):
+        print(f"Received {message.content}")
+    
+    # Runs only for the 1st 'on_message' event. Can be useful for listening to 'on_ready'
+    @client.once()
+    async def message(message: discord.Message):
         print(f"Received {message.content}")
 
 

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -9,8 +9,8 @@ This section outlines the different types of events listened by :class:`Client`.
 
 There are 4 ways to register an event, the first way is through the use of
 :meth:`Client.event`. The second way is through subclassing :class:`Client` and
-overriding the specific events. The third way is through the use of :meth:`Client.listen`, 
-which can be used to assign multiple event handlers instead of only one like in :meth:`Client.event`. 
+overriding the specific events. The third way is through the use of :meth:`Client.listen`,
+which can be used to assign multiple event handlers instead of only one like in :meth:`Client.event`.
 The fourth way is through the use of :meth:`Client.once`, which serves as a one-time event listener. For example:
 
 .. code-block:: python
@@ -40,7 +40,7 @@ The fourth way is through the use of :meth:`Client.once`, which serves as a one-
     @client.listen()
     async def on_message(message: discord.Message):
         print(f"Received {message.content}")
-    
+
     # Runs only for the 1st 'on_message' event. Can be useful for listening to 'on_ready'
     @client.once()
     async def message(message: discord.Message):

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -48,7 +48,7 @@ Bot
 
     .. automethod:: Bot.listen(name=None)
         :decorator:
-    
+
     .. automethod:: Bot.once(name=None, check=None)
         :decorator:
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -23,7 +23,7 @@ Bot
 .. autoclass:: discord.ext.commands.Bot
     :members:
     :inherited-members:
-    :exclude-members: after_invoke, before_invoke, check, check_once, command, event, group, listen
+    :exclude-members: after_invoke, before_invoke, check, check_once, command, event, group, listen, once
 
     .. automethod:: Bot.after_invoke()
         :decorator:
@@ -47,6 +47,9 @@ Bot
         :decorator:
 
     .. automethod:: Bot.listen(name=None)
+        :decorator:
+    
+    .. automethod:: Bot.once(name=None, check=None)
         :decorator:
 
 AutoShardedBot


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds a `@client.once()` decorator. Unlike `@client.event` or `@client.listen()`, functions decorated will run only once.
It wraps `await client.wait_for()`. Similar functionality is found in discord.js, as it extends Node's Event Emitter. 

This is useful for having stuff run when the bot is ready for the first time, like database connections once ready and stuff.
(Side note - This can potentially be a race condition, as other events can start dispatching before db connects. Since there is no built in functionality to delay dispatching of `ready` until a function has returned, using the `once` decorator is the closest and simplest you can get)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
