### PR TITLE
Client.on_error() improvement with new parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These changes are available on the `master` branch, but have not yet been releas
   `on_bridge_command_error`.
   ([#1916](https://github.com/Pycord-Development/pycord/pull/1916))
 
+### Changed
+
+- `Client.on_error` now has an `exception` parameter for easier error handling. 
+
 ### Fixed
 
 - Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Changed
 
-- `Client.on_error` now has an `exception` parameter for easier error handling. 
+- `Client.on_error()` now has an `exception` parameter for easier error handling. 
+  ([#1943](https://github.com/Pycord-Development/pycord/pull/1943))
 
 ### Fixed
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -377,9 +377,9 @@ class Client:
             await coro(*args, **kwargs)
         except asyncio.CancelledError:
             pass
-        except Exception:
+        except Exception as exc:
             try:
-                await self.on_error(event_name, *args, **kwargs)
+                await self.on_error(event_name, exc, *args, **kwargs)
             except asyncio.CancelledError:
                 pass
 
@@ -439,7 +439,7 @@ class Client:
         for coro in self._event_handlers.get(method, []):
             self._schedule_event(coro, method, *args, **kwargs)
 
-    async def on_error(self, event_method: str, *args: Any, **kwargs: Any) -> None:
+    async def on_error(self, event_method: str, exception: Exception, *args: Any, **kwargs: Any) -> None:
         """|coro|
 
         The default error handler provided by the client.
@@ -449,7 +449,9 @@ class Client:
         Check :func:`~discord.on_error` for more details.
         """
         print(f"Ignoring exception in {event_method}", file=sys.stderr)
-        traceback.print_exc()
+        traceback.print_exception(
+            type(exception), exception, exception.__traceback__, file=sys.stderr
+        )
 
     # hooks
 

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -246,16 +246,13 @@ Channels
 
 Connection
 ----------
-.. function:: on_error(event, *args, **kwargs)
+.. function:: on_error(event, exception, *args, **kwargs)
 
     Usually when an event raises an uncaught exception, a traceback is
     printed to stderr and the exception is ignored. If you want to
     change this behaviour and handle the exception for whatever reason
     yourself, this event can be overridden. Which, when done, will
     suppress the default action of printing the traceback.
-
-    The information of the exception raised and the exception itself can
-    be retrieved with a standard call to :func:`sys.exc_info`.
 
     If you want exception to propagate out of the :class:`Client` class
     you can define an ``on_error`` handler consisting of a single empty
@@ -272,6 +269,9 @@ Connection
 
     :param event: The name of the event that raised the exception.
     :type event: :class:`str`
+    
+    :param exception: The exception raised by the event.
+    :type event: :class:`Exception`
 
     :param args: The positional arguments for the event that raised the
         exception.


### PR DESCRIPTION
Edited _run_event to pass the exception to on_error.

## Summary

in `client.py`, line 381 has included `as exc` in order to pass an exception into `Client.on_error`. This has also been changed in line 438 to 448, changing how the error is printed as well. This makes it easier to use `on_error` with this small change.

## Information

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.