### PR TITLE
fix: AttributeErrors from event handler move

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -735,7 +735,7 @@ class CogMixin:
                 self.remove_application_command(cmd)
 
         # remove all the listeners from the module
-        for event_list in self.extra_events.copy().values():
+        for event_list in self._event_handlers.copy().values():
             remove = [
                 index
                 for index, event in enumerate(event_list)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -159,7 +159,7 @@ class BotBase(GroupMixin, discord.cog.CogMixin):
 
         This only fires if you do not specify any listeners for command error.
         """
-        if self.extra_events.get("on_command_error", None):
+        if self._event_handlers.get("on_command_error", None):
             return
 
         command = context.command


### PR DESCRIPTION
## Summary

~~Someone didn't press ctrl+f~~ Renames `extra_events` to `_event_handlers` which caused issues during command errors and cog unloading.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
