### PR TITLE
fix: pass `reason` to the correct method in AutoModRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed the voice ip discovery due to the recent
   [announced change](https://discord.com/channels/613425648685547541/697138785317814292/1080623873629884486).
   ([#1955](https://github.com/Pycord-Development/pycord/pull/1955))
+- Fixed `reason` being passed to wrong method in `guild.create_auto_moderation_rule`
+  ([#1960](https://github.com/Pycord-Development/pycord/pull/1960))
 
 ## [2.4.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed the voice ip discovery due to the recent
   [announced change](https://discord.com/channels/613425648685547541/697138785317814292/1080623873629884486).
   ([#1955](https://github.com/Pycord-Development/pycord/pull/1955))
-- Fixed `reason` being passed to wrong method in `guild.create_auto_moderation_rule`
+- Fixed `reason` being passed to wrong method in `guild.create_auto_moderation_rule`.
   ([#1960](https://github.com/Pycord-Development/pycord/pull/1960))
 
 ## [2.4.0] - 2023-02-10

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3835,5 +3835,7 @@ class Guild(Hashable):
         if exempt_channels:
             payload["exempt_channels"] = [c.id for c in exempt_channels]
 
-        data = await self._state.http.create_auto_moderation_rule(self.id, payload, reason=reason)
+        data = await self._state.http.create_auto_moderation_rule(
+            self.id, payload, reason=reason
+        )
         return AutoModRule(state=self._state, data=data)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3836,4 +3836,4 @@ class Guild(Hashable):
             payload["exempt_channels"] = [c.id for c in exempt_channels]
 
         data = await self._state.http.create_auto_moderation_rule(self.id, payload)
-        return AutoModRule(state=self._state, data=data, reason=reason)
+        return AutoModRule(state=self._state, data=data)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3835,5 +3835,5 @@ class Guild(Hashable):
         if exempt_channels:
             payload["exempt_channels"] = [c.id for c in exempt_channels]
 
-        data = await self._state.http.create_auto_moderation_rule(self.id, payload)
+        data = await self._state.http.create_auto_moderation_rule(self.id, payload, reason=reason)
         return AutoModRule(state=self._state, data=data)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`AutoModRule` does not accept a `reason` parameter. This raises an unexpected keyword argument error.
This PR fixes it.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
