### PR TITLE
fix: webhook message editing on forums missing thread_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
-- Editing a webhook message if the thread is a forum post or if the thread is a private thread
-  ([#1981](https://github.com/Pycord-Development/pycord/pull/1981))
+- Editing a webhook message if the thread is a forum post or if the thread is a private
+  thread ([#1981](https://github.com/Pycord-Development/pycord/pull/1981))
 - Fixed `View.message` not being set when view is sent using webhooks, including
   `Interaction.followup.send` or when a message is edited.
   ([#1997](https://github.com/Pycord-Development/pycord/pull/1997))
@@ -63,7 +63,6 @@ These changes are available on the `master` branch, but have not yet been releas
   working. ([#1999](https://github.com/Pycord-Development/pycord/pull/1999))
 - Fixed `TypeError` being raised when passing `name` argument to bridge groups.
   ([#2000](https://github.com/Pycord-Development/pycord/pull/2000))
-
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
+- Editing a webhook message if the thread is a forum post or if the thread is a private thread
+  ([#1981](https://github.com/Pycord-Development/pycord/pull/1981))
 - Fixed `None` being handled incorrectly for avatar in `ClientUser.edit`.
   ([#1994](https://github.com/Pycord-Development/pycord/pull/1994))
 - Fixed scheduled events breaking when changing the location from external to a channel.
@@ -54,6 +56,7 @@ These changes are available on the `master` branch, but have not yet been releas
   working. ([#1999](https://github.com/Pycord-Development/pycord/pull/1999))
 - Fixed `TypeError` being raised when passing `name` argument to bridge groups.
   ([#2000](https://github.com/Pycord-Development/pycord/pull/2000))
+
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -38,7 +38,7 @@ import aiohttp
 
 from .. import utils
 from ..asset import Asset
-from ..channel import PartialMessageable
+from ..channel import ForumChannel, PartialMessageable
 from ..enums import WebhookType, try_enum
 from ..errors import (
     DiscordServerError,
@@ -52,7 +52,6 @@ from ..message import Attachment, Message
 from ..mixins import Hashable
 from ..object import Object
 from ..threads import Thread
-from ..channel import ForumChannel
 from ..user import BaseUser, User
 
 __all__ = (

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -892,6 +892,8 @@ class WebhookMessage(Message):
             thread = Object(self._thread_id)
         elif isinstance(self.channel, Thread):
             thread = Object(self.channel.id)
+        elif isinstance(self.channel, ForumChannel):
+            thread = Object(self.id)
 
         if attachments is MISSING:
             attachments = self.attachments or MISSING

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -52,6 +52,7 @@ from ..message import Attachment, Message
 from ..mixins import Hashable
 from ..object import Object
 from ..threads import Thread
+from ..channel import ForumChannel
 from ..user import BaseUser, User
 
 __all__ = (


### PR DESCRIPTION
## Summary

Fix editing a webhook message if the thread is a forum post or if the thread is a private thread (no starter message)

Issue [here](https://github.com/Pycord-Development/pycord/issues/1979)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
