### PR TITLE
feat: add current_page parameter to paginator.update()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1940](https://github.com/Pycord-Development/pycord/pull/1940))
 - Added support for text-related features in `StageChannel`.
   ([#1936](https://github.com/Pycord-Development/pycord/pull/1936))
+- Added `current_page` argument to Paginator.update()
+  ([#1983](https://github.com/Pycord-Development/pycord/pull/1983))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -465,6 +465,7 @@ class Paginator(discord.ui.View):
         custom_buttons: list[PaginatorButton] | None = None,
         trigger_on_display: bool | None = None,
         interaction: discord.Interaction | None = None,
+        current_page: int = 0,
     ):
         """Updates the existing :class:`Paginator` instance with the provided options.
 
@@ -505,6 +506,8 @@ class Paginator(discord.ui.View):
         interaction: Optional[:class:`discord.Interaction`]
             The interaction to use when updating the paginator. If not provided, the paginator will be updated
             by using its stored :attr:`message` attribute instead.
+        current_page: :class:`int`
+            The initial page number to display when updating the paginator.
         """
 
         # Update pages and reset current_page to 0 (default)
@@ -527,7 +530,9 @@ class Paginator(discord.ui.View):
                 self.page_groups[self.default_page_group]
             )
         self.page_count = max(len(self.pages) - 1, 0)
-        self.current_page = 0
+        self.current_page = (
+            current_page if current_page <= self.page_count else 0
+        )
         # Apply config changes, if specified
         self.show_disabled = (
             show_disabled if show_disabled is not None else self.show_disabled

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -530,9 +530,7 @@ class Paginator(discord.ui.View):
                 self.page_groups[self.default_page_group]
             )
         self.page_count = max(len(self.pages) - 1, 0)
-        self.current_page = (
-            current_page if current_page <= self.page_count else 0
-        )
+        self.current_page = current_page if current_page <= self.page_count else 0
         # Apply config changes, if specified
         self.show_disabled = (
             show_disabled if show_disabled is not None else self.show_disabled


### PR DESCRIPTION
## Summary

When updating the Paginator, the view always resets to page 0. This isn't always desirable, and enabling the optional argument simplifies logic without getting in the way of typical operation.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] I have searched the open pull requests for duplicates.
- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [X] I have updated the changelog to include these changes.
