### PR TITLE
fix: store message in view when sent using webhook or when message is edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ These changes are available on the `master` branch, but have not yet been releas
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
 - Fixed `view.message` not being set when view is sent using webhooks, including
-  `interaction.followup`.
+  `interaction.followup` or when message is edited.
   ([#1997](https://github.com/Pycord-Development/pycord/pull/1997))
 
 ## [2.4.1] - 2023-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
+- Fixed `view.message` not being set when view is sent using webhooks, including `interaction.followup`.
+  ([#1997](https://github.com/Pycord-Development/pycord/pull/1997))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
-- Fixed `view.message` not being set when view is sent using webhooks, including `interaction.followup`.
+- Fixed `view.message` not being set when view is sent using webhooks, including
+  `interaction.followup`.
   ([#1997](https://github.com/Pycord-Development/pycord/pull/1997))
 
 ## [2.4.1] - 2023-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
-- Fixed `view.message` not being set when view is sent using webhooks, including
-  `interaction.followup` or when message is edited.
+- Fixed `View.message` not being set when view is sent using webhooks, including
+  `Interaction.followup.send` or when a message is edited.
   ([#1997](https://github.com/Pycord-Development/pycord/pull/1997))
 
 ## [2.4.1] - 2023-03-20

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -440,6 +440,7 @@ class Interaction:
         state = _InteractionMessageState(self, self._state)
         message = InteractionMessage(state=state, channel=self.channel, data=data)  # type: ignore
         if view and not view.is_finished():
+            view.message = message
             self._state.store_view(view, message.id)
 
         if delete_after is not None:
@@ -976,6 +977,7 @@ class InteractionResponse:
                     file.close()
 
         if view and not view.is_finished():
+            view.message = msg
             state.store_view(view, message_id)
 
         self._responded = True

--- a/discord/message.py
+++ b/discord/message.py
@@ -1468,6 +1468,7 @@ class Message(Hashable):
         message = Message(state=self._state, channel=self.channel, data=data)
 
         if view and not view.is_finished():
+            view.message = message
             self._state.store_view(view, self.id)
 
         if delete_after is not None:
@@ -2021,5 +2022,6 @@ class PartialMessage(Hashable):
             # data isn't unbound
             msg = self._state.create_message(channel=self.channel, data=data)  # type: ignore
             if view and not view.is_finished():
+                view.message = msg
                 self._state.store_view(view, self.id)
             return msg

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1762,6 +1762,7 @@ class Webhook(BaseWebhook):
 
         if view is not MISSING and not view.is_finished():
             message_id = None if msg is None else msg.id
+            view.message = None if msg is None else msg
             self._state.store_view(view, message_id)
 
         if delete_after is not None:

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1958,6 +1958,7 @@ class Webhook(BaseWebhook):
 
         message = self._create_message(data)
         if view and not view.is_finished():
+            view.message = message
             self._state.store_view(view, message_id)
         return message
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Stores the message object on the view sent using webhook if the message has a view.
Fixes #1600. Also fixes #1572 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
