### PR TITLE
fix(scheduled_events): location editing breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
+- Fixed scheduled events breaking when changing the location from external to a channel.
+  ([#1998](https://github.com/Pycord-Development/pycord/pull/1998))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -359,6 +359,8 @@ class ScheduledEvent(Hashable):
                 payload["channel_id"] = location.value.id
                 payload["entity_metadata"] = None
 
+            payload["entity_type"] = location.type.value
+
         location = location if location is not MISSING else self.location
         if end_time is MISSING and location.type is ScheduledEventLocationType.external:
             end_time = self.end_time


### PR DESCRIPTION
## Summary
Fix #1847
Changing an event's location from string (external) to a channel breaks.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.