### PR TITLE
fix(ext.bridge): Bridge options & bool converter breaking sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
+- Fixed boolean converter breaking for bridge commands.
+  Fix bridge command Options not working.
+  ([#1999](https://github.com/Pycord-Development/pycord/pull/1999))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
-- Fixed boolean converter breaking for bridge commands.
-  Fix bridge command Options not working.
-  ([#1999](https://github.com/Pycord-Development/pycord/pull/1999))
+- Fixed boolean converter breaking for bridge commands. Fix bridge command Options not
+  working. ([#1999](https://github.com/Pycord-Development/pycord/pull/1999))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -529,6 +529,7 @@ class AttachmentConverter(Converter):
         else:
             return attach
 
+
 class BooleanConverter(Converter):
     async def convert(self, ctx, arg: bool):
         return _convert_to_bool(str(arg))

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -529,11 +529,15 @@ class AttachmentConverter(Converter):
         else:
             return attach
 
+class BooleanConverter(Converter):
+    async def convert(self, ctx, arg: bool):
+        return _convert_to_bool(str(arg))
+
 
 BRIDGE_CONVERTER_MAPPING = {
     SlashCommandOptionType.string: str,
     SlashCommandOptionType.integer: int,
-    SlashCommandOptionType.boolean: lambda val: _convert_to_bool(str(val)),
+    SlashCommandOptionType.boolean: BooleanConverter,
     SlashCommandOptionType.user: UserConverter,
     SlashCommandOptionType.channel: GuildChannelConverter,
     SlashCommandOptionType.role: RoleConverter,
@@ -577,3 +581,4 @@ class BridgeOption(Option, Converter):
 
 
 discord.commands.options.Option = BridgeOption
+discord.Option = BridgeOption


### PR DESCRIPTION
## Summary
1999!!!!!!

Fix #1988
Fix #1972 

1. When the user uses `discord.Option`, the `BridgeOption` class will not be used because of the import order.
2. CONVENIENTLY, the only non-class converter in the converter mapping (in ext.bridge) is the one for booleans, which is why `issubclass` throws everywhere. There *are* no errors when a direct typehint is used for the option (e.g. `opt1: bool`), but all the other ones still do.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.