### PR TITLE
fix: bridge command group name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ These changes are available on the `master` branch, but have not yet been releas
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
 - Fixed scheduled events breaking when changing the location from external to a channel.
   ([#1998](https://github.com/Pycord-Development/pycord/pull/1998))
+- Fixed `TypeError` being raised when passing `name` argument to bridge groups.
+  ([#2000](https://github.com/Pycord-Development/pycord/pull/2000))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -325,10 +325,12 @@ class BridgeCommandGroup(BridgeCommand):
     slash_variant: BridgeSlashGroup
 
     def __init__(self, callback, *args, **kwargs):
+        ext_var = BridgeExtGroup(callback, *args, **kwargs)
+        kwargs.update({"name": ext_var.name})
         super().__init__(
             callback,
-            ext_variant=(ext_var := BridgeExtGroup(callback, *args, **kwargs)),
-            slash_variant=BridgeSlashGroup(callback, ext_var.name, *args, **kwargs),
+            ext_variant=ext_var,
+            slash_variant=BridgeSlashGroup(callback, *args, **kwargs),
             parent=kwargs.pop("parent", None),
         )
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix the error caused by `name` parameter being passed twice when using `@bridge_group(name="...")`.

Fixes #1987 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
