### PR TITLE
feat: Return message on `InteractionResponse.send_message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1983](https://github.com/Pycord-Development/pycord/pull/1983)
 - Added new `application_auto_moderation_rule_create_badge` to `ApplicationFlags`.
   ([#1992](https://github.com/Pycord-Development/pycord/pull/1992))
-- Added `return_message` parameter to `InteractionResponse.send_message`, 
-  which returns the message object of the response, instead of the 
-  parent interaction object.
+- Added `return_message` parameter to `InteractionResponse.send_message`, which returns
+  the message object of the response, instead of the parent interaction object.
   ([#2006](https://github.com/Pycord-Development/pycord/pull/2006))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1983](https://github.com/Pycord-Development/pycord/pull/1983)
 - Added new `application_auto_moderation_rule_create_badge` to `ApplicationFlags`.
   ([#1992](https://github.com/Pycord-Development/pycord/pull/1992))
+- Added `return_message` parameter to `InteractionResponse.send_message`, 
+  which returns the message object of the response, instead of the 
+  parent interaction object.
+  ([#2006](https://github.com/Pycord-Development/pycord/pull/2006))
 
 ### Removed
 

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -266,7 +266,9 @@ class ApplicationContext(discord.abc.Messageable):
     def send_modal(self) -> Callable[..., Awaitable[Interaction]]:
         return self.interaction.response.send_modal
 
-    async def respond(self, *args, **kwargs) -> Interaction | WebhookMessage:
+    async def respond(
+        self, *args, **kwargs
+    ) -> Interaction | WebhookMessage | InteractionMessage:
         """|coro|
 
         Sends either a response or a message using the followup webhook determined by whether the interaction

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -749,7 +749,7 @@ class InteractionResponse:
         files: list[File] = ...,
         delete_after: float = ...,
         return_message: bool = ...,
-    ) -> Union[Interaction, InteractionMessage]:
+    ) -> Interaction | InteractionMessage:
         ...
 
     async def send_message(
@@ -766,7 +766,7 @@ class InteractionResponse:
         files: list[File] = None,
         delete_after: float = None,
         return_message: bool = False,
-    ) -> Union[Interaction, InteractionMessage]:
+    ) -> Interaction | InteractionMessage:
         """|coro|
 
         Responds to this interaction by sending a message.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Added a `return_message` argument to fetch and return `original_response` if set True. The library was already fetching the original response if a view was passed. This uses the same call for both

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
