### PR TITLE
feat: Received Interactions come with a channel object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Changed file-upload size limit from 8 MB to 25 MB accordingly.
   ([#2014](https://github.com/Pycord-Development/pycord/pull/2014))
-- `Interaction.channel` is received from the gateway, so it can now be `DMChannel`
-  and `GroupChannel`.
-  ([#2025](https://github.com/Pycord-Development/pycord/pull/2025))
+- `Interaction.channel` is received from the gateway, so it can now be `DMChannel` and
+  `GroupChannel`. ([#2025](https://github.com/Pycord-Development/pycord/pull/2025))
 - `DMChannel.recipients` can now be `None`
   ([#2025](https://github.com/Pycord-Development/pycord/pull/2025))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Changed file-upload size limit from 8 MB to 25 MB accordingly.
   ([#2014](https://github.com/Pycord-Development/pycord/pull/2014))
+- `Interaction.channel` is received from the gateway, so it can now be `DMChannel`
+  and `GroupChannel`.
+  ([#2025](https://github.com/Pycord-Development/pycord/pull/2025))
+- `DMChannel.recipients` can now be `None`
+  ([#2025](https://github.com/Pycord-Development/pycord/pull/2025))
 
 ### Removed
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2838,7 +2838,9 @@ class DMChannel(discord.abc.Messageable, Hashable):
         self, *, me: ClientUser, state: ConnectionState, data: DMChannelPayload
     ):
         self._state: ConnectionState = state
-        self.recipient: User | None = state.store_user(data["recipients"][0])
+        self.recipient: User | None = None
+        if r := data.get("recipients"):
+            self.recipient: state.store_user(r[0])
         self.me: ClientUser = me
         self.id: int = int(data["id"])
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -29,7 +29,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Coroutine, Union
 
 from . import utils
-from .channel import ChannelType, PartialMessageable
+from .channel import ChannelType, PartialMessageable, _threaded_channel_factory
 from .enums import InteractionResponseType, InteractionType, try_enum
 from .errors import ClientException, InteractionResponded, InvalidArgument
 from .file import File
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
         StageChannel,
         TextChannel,
         VoiceChannel,
+        DMChannel,
+        GroupChannel
     )
     from .client import Client
     from .commands import OptionChoice
@@ -77,6 +79,8 @@ if TYPE_CHECKING:
         ForumChannel,
         CategoryChannel,
         Thread,
+        DMChannel,
+        GroupChannel,
         PartialMessageable,
     ]
 
@@ -99,8 +103,10 @@ class Interaction:
         The interaction type.
     guild_id: Optional[:class:`int`]
         The guild ID the interaction was sent from.
+    channel: Optional[Union[:class:`abc.GuildChannel`, :class:`abc.PrivateChannel`, :class:`Thread`]]
+        The channel the interaction was sent from.
     channel_id: Optional[:class:`int`]
-        The channel ID the interaction was sent from.
+        The ID of the channel the interaction was sent from.
     application_id: :class:`int`
         The application ID that the interaction was for.
     user: Optional[Union[:class:`User`, :class:`Member`]]
@@ -124,6 +130,7 @@ class Interaction:
         "id",
         "type",
         "guild_id",
+        "channel",
         "channel_id",
         "data",
         "application_id",
@@ -134,6 +141,7 @@ class Interaction:
         "token",
         "version",
         "custom_id",
+        "_channel_data",
         "_message_data",
         "_permissions",
         "_app_permissions",
@@ -169,13 +177,7 @@ class Interaction:
         self._app_permissions: int = int(data.get("app_permissions", 0))
 
         self.message: Message | None = None
-
-        if message_data := data.get("message"):
-            self.message = Message(
-                state=self._state, channel=self.channel, data=message_data
-            )
-
-        self._message_data = message_data
+        self.channel = None
 
         self.user: User | Member | None = None
         self._permissions: int = 0
@@ -206,6 +208,26 @@ class Interaction:
             except KeyError:
                 pass
 
+        if channel := data.get("channel"):
+            if (ch_type := channel.get('type')) is not None:
+                factory, ch_type = _threaded_channel_factory(ch_type)
+
+                if ch_type in (ChannelType.group, ChannelType.private):
+                    self.channel = factory(me=self.user, data=channel, state=self._state)
+                elif self.guild:
+                    self.channel = factory(guild=self.guild, state=self._state, data=channel)
+        else:
+            self.channel = self.cached_channel
+            
+        self._channel_data = channel
+
+        if message_data := data.get("message"):
+            self.message = Message(
+                state=self._state, channel=self.channel, data=message_data
+            )
+
+        self._message_data = message_data
+
     @property
     def client(self) -> Client:
         """Returns the client that sent the interaction."""
@@ -225,7 +247,7 @@ class Interaction:
         return self.type == InteractionType.component
 
     @utils.cached_slot_property("_cs_channel")
-    def channel(self) -> InteractionChannel | None:
+    def cached_channel(self) -> InteractionChannel | None:
         """The channel the
         interaction was sent from.
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -52,12 +52,12 @@ if TYPE_CHECKING:
 
     from .channel import (
         CategoryChannel,
+        DMChannel,
         ForumChannel,
+        GroupChannel,
         StageChannel,
         TextChannel,
         VoiceChannel,
-        DMChannel,
-        GroupChannel
     )
     from .client import Client
     from .commands import OptionChoice
@@ -209,16 +209,20 @@ class Interaction:
                 pass
 
         if channel := data.get("channel"):
-            if (ch_type := channel.get('type')) is not None:
+            if (ch_type := channel.get("type")) is not None:
                 factory, ch_type = _threaded_channel_factory(ch_type)
 
                 if ch_type in (ChannelType.group, ChannelType.private):
-                    self.channel = factory(me=self.user, data=channel, state=self._state)
+                    self.channel = factory(
+                        me=self.user, data=channel, state=self._state
+                    )
                 elif self.guild:
-                    self.channel = factory(guild=self.guild, state=self._state, data=channel)
+                    self.channel = factory(
+                        guild=self.guild, state=self._state, data=channel
+                    )
         else:
             self.channel = self.cached_channel
-            
+
         self._channel_data = channel
 
         if message_data := data.get("message"):

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -39,6 +39,7 @@ from .user import User
 
 if TYPE_CHECKING:
     from .message import AllowedMentions, Message
+    from ..interactions import InteractionChannel
 
 from .._typed_dict import NotRequired, TypedDict
 
@@ -196,6 +197,7 @@ class Interaction(TypedDict):
     data: NotRequired[InteractionData]
     guild_id: NotRequired[Snowflake]
     channel_id: NotRequired[Snowflake]
+    channel: NotRequired[InteractionChannel]
     member: NotRequired[Member]
     user: NotRequired[User]
     message: NotRequired[Message]


### PR DESCRIPTION
## Summary

All interactions now come with a partial `channel` object over the gateway as per discord/discord-api-docs#6051
- DMChannel and GroupChannel can successfully be received in this manner
```py
'channel': {'type': 1, 'last_pin_timestamp': '2022-02-06T14:08:54+00:00', 'last_message_id': '1095172313105846322', 'id': '456499933701341204', 'flags': 0}
```
- Changed `channel` to a regular attribute instead of a cached slot, though i've currently left the previous property in.
- `DMChannel.recipients` has been adjusted to support said attribute being missing from gateway events

This PR is functionally done, however I'm not entirely sure if this is a good implementation; I think there's merit in using the received channel object, but would it be better to continue using cache? Should we implement additional methods here?

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
