### PR TITLE
feat: Move ctx.respond to Interaction and implement Interaction.edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1983](https://github.com/Pycord-Development/pycord/pull/1983))
 - Added new `application_auto_moderation_rule_create_badge` to `ApplicationFlags`.
   ([#1992](https://github.com/Pycord-Development/pycord/pull/1992))
+- Added `Interaction.respond` and `Interaction.edit` as shortcut responses.
+  ([#2026](https://github.com/Pycord-Development/pycord/pull/2026))
 
 ### Changed
 

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -268,7 +268,9 @@ class ApplicationContext(discord.abc.Messageable):
 
     @property
     @discord.utils.copy_doc(Interaction.respond)
-    def respond(self, *args, **kwargs) ->  Callable[..., Awaitable[Interaction | WebhookMessage]]:
+    def respond(
+        self, *args, **kwargs
+    ) -> Callable[..., Awaitable[Interaction | WebhookMessage]]:
         return self.interaction.respond
 
     @property

--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -266,26 +266,10 @@ class ApplicationContext(discord.abc.Messageable):
     def send_modal(self) -> Callable[..., Awaitable[Interaction]]:
         return self.interaction.response.send_modal
 
-    async def respond(self, *args, **kwargs) -> Interaction | WebhookMessage:
-        """|coro|
-
-        Sends either a response or a message using the followup webhook determined by whether the interaction
-        has been responded to or not.
-
-        Returns
-        -------
-        Union[:class:`discord.Interaction`, :class:`discord.WebhookMessage`]:
-            The response, its type depending on whether it's an interaction response or a followup.
-        """
-        try:
-            if not self.interaction.response.is_done():
-                return await self.interaction.response.send_message(
-                    *args, **kwargs
-                )  # self.response
-            else:
-                return await self.followup.send(*args, **kwargs)  # self.send_followup
-        except discord.errors.InteractionResponded:
-            return await self.followup.send(*args, **kwargs)
+    @property
+    @discord.utils.copy_doc(Interaction.respond)
+    def respond(self, *args, **kwargs) ->  Callable[..., Awaitable[Interaction | WebhookMessage]]:
+        return self.interaction.respond
 
     @property
     @discord.utils.copy_doc(InteractionResponse.send_message)

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -38,7 +38,7 @@ from .message import Attachment, Message
 from .object import Object
 from .permissions import Permissions
 from .user import User
-from .webhook.async_ import Webhook, async_context, handle_message_parameters
+from .webhook.async_ import Webhook, WebhookMessage, async_context, handle_message_parameters
 
 __all__ = (
     "Interaction",
@@ -518,6 +518,48 @@ class Interaction:
             Deleted a message that is not yours.
         """
         return await self.delete_original_response(**kwargs)
+
+    async def respond(self, *args, **kwargs) -> Interaction | WebhookMessage:
+        """|coro|
+
+        Sends either a response or a message using the followup webhook determined by whether the interaction
+        has been responded to or not.
+
+        Returns
+        -------
+        Union[:class:`discord.Interaction`, :class:`discord.WebhookMessage`]:
+            The response, its type depending on whether it's an interaction response or a followup.
+        """
+        try:
+            if not self.response.is_done():
+                return await self.response.send_message(
+                    *args, **kwargs
+                )
+            else:
+                return await self.followup.send(*args, **kwargs)
+        except discord.errors.InteractionResponded:
+            return await self.followup.send(*args, **kwargs)
+
+    async def edit(self, *args, **kwargs) -> InteractionMessage | None:
+        """|coro|
+
+        Either respond to the interaction with an edit_message or edits the existing response, determined by
+        whether the interaction has been responded to or not.
+
+        Returns
+        -------
+        Union[:class:`discord.InteractionMessage`, :class:`discord.WebhookMessage`]:
+            The response, its type depending on whether it's an interaction response or a followup.
+        """
+        try:
+            if not self.response.is_done():
+                return await self.response.edit_message(
+                    *args, **kwargs
+                )
+            else:
+                return await self.edit_original_response(*args, **kwargs)
+        except discord.errors.InteractionResponded:
+            return await self.edit_original_response(*args, **kwargs)
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -540,7 +540,7 @@ class Interaction:
                 return await self.response.send_message(*args, **kwargs)
             else:
                 return await self.followup.send(*args, **kwargs)
-        except discord.errors.InteractionResponded:
+        except InteractionResponded:
             return await self.followup.send(*args, **kwargs)
 
     async def edit(self, *args, **kwargs) -> InteractionMessage | None:
@@ -559,7 +559,7 @@ class Interaction:
                 return await self.response.edit_message(*args, **kwargs)
             else:
                 return await self.edit_original_response(*args, **kwargs)
-        except discord.errors.InteractionResponded:
+        except InteractionResponded:
             return await self.edit_original_response(*args, **kwargs)
 
     def to_dict(self) -> dict[str, Any]:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -38,7 +38,12 @@ from .message import Attachment, Message
 from .object import Object
 from .permissions import Permissions
 from .user import User
-from .webhook.async_ import Webhook, WebhookMessage, async_context, handle_message_parameters
+from .webhook.async_ import (
+    Webhook,
+    WebhookMessage,
+    async_context,
+    handle_message_parameters,
+)
 
 __all__ = (
     "Interaction",
@@ -532,9 +537,7 @@ class Interaction:
         """
         try:
             if not self.response.is_done():
-                return await self.response.send_message(
-                    *args, **kwargs
-                )
+                return await self.response.send_message(*args, **kwargs)
             else:
                 return await self.followup.send(*args, **kwargs)
         except discord.errors.InteractionResponded:
@@ -553,9 +556,7 @@ class Interaction:
         """
         try:
             if not self.response.is_done():
-                return await self.response.edit_message(
-                    *args, **kwargs
-                )
+                return await self.response.edit_message(*args, **kwargs)
             else:
                 return await self.edit_original_response(*args, **kwargs)
         except discord.errors.InteractionResponded:


### PR DESCRIPTION
## Summary

`ctx.respond` and `ctx.edit` have existed for a while now for convenient command responses, but the same can't be said for `Interaction`. This PR does the following:
- `ctx.respond` is moved to `Interaction`; the `ctx` version now simply references `self.interaction.respond`
- `Interaction.edit` is added as a shortcut for `InteractionResponse.edit_message` and `Interaction.edit_original_response`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
