### PR TITLE
feat: Add custom_message to AutoModActionMetadata and fix TypeError on AutoModRule

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -76,6 +76,10 @@ class AutoModActionMetadata:
     timeout_duration: :class:`datetime.timedelta`
         How long the member that triggered the action should be timed out for.
         Only for actions of type :attr:`AutoModActionType.timeout`.
+    custom_message: :class:`str`
+        An additional message shown to members when their message is blocked.
+        Maximum 150 characters.
+        Only for actions of type :attr:`AutoModActionType.block_message`.
     """
 
     # maybe add a table of action types and attributes?
@@ -83,13 +87,15 @@ class AutoModActionMetadata:
     __slots__ = (
         "channel_id",
         "timeout_duration",
+        "custom_message",
     )
 
     def __init__(
-        self, channel_id: int = MISSING, timeout_duration: timedelta = MISSING
+        self, channel_id: int = MISSING, timeout_duration: timedelta = MISSING, custom_message: str = MISSING
     ):
         self.channel_id: int = channel_id
         self.timeout_duration: timedelta = timeout_duration
+        self.custom_message: str = custom_message
 
     def to_dict(self) -> dict:
         data = {}
@@ -99,6 +105,9 @@ class AutoModActionMetadata:
 
         if self.timeout_duration is not MISSING:
             data["duration_seconds"] = self.timeout_duration.total_seconds()
+
+        if self.custom_message is not MISSING:
+            data["custom_message"] = self.custom_message
 
         return data
 
@@ -113,12 +122,16 @@ class AutoModActionMetadata:
             # might need an explicit int cast
             kwargs["timeout_duration"] = timedelta(seconds=duration_seconds)
 
+        if (custom_message := data.get("custom_message")) is not None:
+            kwargs["custom_message"] = custom_message
+
         return cls(**kwargs)
 
     def __repr__(self) -> str:
         repr_attrs = (
             "channel_id",
             "timeout_duration",
+            "custom_message",
         )
         inner = []
 
@@ -352,6 +365,7 @@ class AutoModRule(Hashable):
     """
 
     __slots__ = (
+        "__dict__",
         "_state",
         "id",
         "guild_id",

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -91,7 +91,10 @@ class AutoModActionMetadata:
     )
 
     def __init__(
-        self, channel_id: int = MISSING, timeout_duration: timedelta = MISSING, custom_message: str = MISSING
+        self,
+        channel_id: int = MISSING,
+        timeout_duration: timedelta = MISSING,
+        custom_message: str = MISSING,
     ):
         self.channel_id: int = channel_id
         self.timeout_duration: timedelta = timeout_duration

--- a/discord/types/automod.py
+++ b/discord/types/automod.py
@@ -47,6 +47,7 @@ class AutoModTriggerMetadata(TypedDict, total=False):
 class AutoModActionMetadata(TypedDict, total=False):
     channel_id: Snowflake
     duration_seconds: int
+    custom_message: str
 
 
 class AutoModAction(TypedDict):


### PR DESCRIPTION
## Summary
- Adds `AutoModActionMetadata.custom_message` as per discord/discord-api-docs#5955
- Adds `__dict__` to `AutoModRule.__slots__` to close #1976 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
