### PR TITLE
fix: Improve Automod compatibility with Audit Logs + minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,16 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added new `application_auto_moderation_rule_create_badge` to `ApplicationFlags`.
   ([#1992](https://github.com/Pycord-Development/pycord/pull/1992))
 - Added `custom_message` to AutoModActionMetadata.
-- ([#2029](https://github.com/Pycord-Development/pycord/pull/2029))
+  ([#2029](https://github.com/Pycord-Development/pycord/pull/2029))
+- Added and documented missing `AuditLogAction` enums.
+  ([#2030](https://github.com/Pycord-Development/pycord/pull/2030))
+- `AuditLogDiff` now supports AutoMod related models.
+  ([#2030](https://github.com/Pycord-Development/pycord/pull/2030))
 
 ### Changed
 
+- Suppressed FFMPEG output when recording voice channels.
+  ([#1993](https://github.com/Pycord-Development/pycord/pull/1993))
 - Changed file-upload size limit from 8 MB to 25 MB accordingly.
   ([#2014](https://github.com/Pycord-Development/pycord/pull/2014))
 
@@ -41,11 +47,6 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Removed `@client.once()` in favour of `@client.listen(once=True)`.
   ([#1957](https://github.com/Pycord-Development/pycord/pull/1957))
-
-### Changed
-
-- Suppressed FFMPEG output when recording voice channels.
-  ([#1993](https://github.com/Pycord-Development/pycord/pull/1993))
 
 ### Fixed
 
@@ -66,7 +67,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `TypeError` being raised when passing `name` argument to bridge groups.
   ([#2000](https://github.com/Pycord-Development/pycord/pull/2000))
 - Fixed `TypeError` in AutoModRule.
-- ([#2029](https://github.com/Pycord-Development/pycord/pull/2029))
+  ([#2029](https://github.com/Pycord-Development/pycord/pull/2029))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -34,6 +34,7 @@ from .invite import Invite
 from .mixins import Hashable
 from .object import Object
 from .permissions import PermissionOverwrite, Permissions
+from .automod import AutoModAction, AutoModTriggerMetadata
 
 __all__ = (
     "AuditLogDiff",
@@ -61,6 +62,8 @@ if TYPE_CHECKING:
     from .types.role import Role as RolePayload
     from .types.snowflake import Snowflake
     from .user import User
+    from .types.automod import AutoModAction as AutoModActionPayload
+    from .types.automod import AutoModTriggerMetadata as AutoModTriggerMetadataPayload
 
 
 def _transform_permissions(entry: AuditLogEntry, data: str) -> Permissions:
@@ -82,6 +85,19 @@ def _transform_channel(
         return None
     return entry.guild.get_channel(int(data)) or Object(id=data)
 
+def _transform_channels(
+    entry: AuditLogEntry, data: list[Snowflake] | None
+) -> list[abc.GuildChannel | Object] | None:
+    if data is None:
+        return None
+    return [_transform_channel(entry, channel) for channel in data]
+
+def _transform_roles(
+    entry: AuditLogEntry, data: list[Snowflake] | None
+) -> list[Role | Object] | None:
+    if data is None:
+        return None
+    return [entry.guild.get_role(int(r)) or Object(id=r) for r in data]
 
 def _transform_member_id(
     entry: AuditLogEntry, data: Snowflake | None
@@ -172,6 +188,24 @@ def _transform_type(
         return enums.try_enum(enums.ChannelType, data)
 
 
+def _transform_actions(
+    entry: AuditLogEntry, data: list[AutoModActionPayload] | None
+) -> AutoModAction | None:
+    if data is None:
+        return None
+    else:
+        return [AutoModAction.from_dict(d) for d in data]
+
+
+def _transform_trigger_metadata(
+    entry: AuditLogEntry, data: list[AutoModActionPayload] | None
+) -> AutoModAction | None:
+    if data is None:
+        return None
+    else:
+        return AutoModTriggerMetadata.from_dict(data)
+
+
 class AuditLogDiff:
     def __len__(self) -> int:
         return len(self.__dict__)
@@ -240,6 +274,12 @@ class AuditLogChanges:
         ),
         "command_id": ("command_id", _transform_snowflake),
         "image_hash": ("cover", _transform_scheduled_event_cover),
+        "trigger_type": (None, _enum_transformer(enums.AutoModTriggerType)),
+        "event_type": (None, _enum_transformer(enums.AutoModEventType)),
+        "actions": (None, _transform_actions),
+        "trigger_metadata": (None, _transform_trigger_metadata),
+        "exempt_roles": (None, _transform_roles),
+        "exempt_channels": (None, _transform_channels)
     }
 
     def __init__(
@@ -255,12 +295,18 @@ class AuditLogChanges:
         for elem in sorted(data, key=lambda i: i["key"]):
             attr = elem["key"]
 
-            # special cases for role add/remove
+            # special cases for role/trigger_metadata add/remove
             if attr == "$add":
                 self._handle_role(self.before, self.after, entry, elem["new_value"])  # type: ignore
                 continue
             elif attr == "$remove":
                 self._handle_role(self.after, self.before, entry, elem["new_value"])  # type: ignore
+                continue
+            elif attr in ["$add_keyword_filter", "$add_regex_patterns", "$add_allow_list"]:
+                self._handle_trigger_metadata(self.before, self.after, entry, elem["new_value"], attr)
+                continue
+            elif attr in ["$remove_keyword_filter", "$remove_regex_patterns", "$remove_allow_list"]:
+                self._handle_trigger_metadata(self.after, self.before, entry, elem["new_value"], attr)
                 continue
 
             try:
@@ -354,6 +400,23 @@ class AuditLogChanges:
             data.append(role)
 
         setattr(second, "roles", data)
+
+    def _handle_trigger_metadata(
+        self,
+        first: AuditLogDiff,
+        second: AuditLogDiff,
+        entry: AuditLogEntry,
+        elem: list[AutoModTriggerMetadataPayload],
+        attr: str,
+    ) -> None:
+        if not hasattr(first, "trigger_metadata"):
+            setattr(first, "trigger_metadata", None)
+
+        key = attr.split("_", 1)[-1]
+        data = {key: elem}
+        tm = AutoModTriggerMetadata.from_dict(data)
+
+        setattr(second, "trigger_metadata", tm)
 
 
 class _AuditLogProxyMemberPrune:

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -301,7 +301,7 @@ class AutoModTriggerMetadata:
                 inner.append(f"{attr}={value}")
         inner = " ".join(inner)
 
-        return f"<AutoModActionMetadata {inner}>"
+        return f"<AutoModTriggerMetadata {inner}>"
 
 
 class AutoModRule(Hashable):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -499,7 +499,7 @@ class AuditLogAction(Enum):
             AuditLogAction.auto_moderation_rule_delete: AuditLogActionCategory.delete,
             AuditLogAction.auto_moderation_block_message: None,
             AuditLogAction.auto_moderation_flag_to_channel: None,
-            AuditLogAction.auto_moderation_user_communication_disabled: None
+            AuditLogAction.auto_moderation_user_communication_disabled: None,
         }
         return lookup[self]
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -438,6 +438,8 @@ class AuditLogAction(Enum):
     auto_moderation_rule_update = 141
     auto_moderation_rule_delete = 142
     auto_moderation_block_message = 143
+    auto_moderation_flag_to_channel = 144
+    auto_moderation_user_communication_disabled = 145
 
     @property
     def category(self) -> AuditLogActionCategory | None:
@@ -496,6 +498,8 @@ class AuditLogAction(Enum):
             AuditLogAction.auto_moderation_rule_update: AuditLogActionCategory.update,
             AuditLogAction.auto_moderation_rule_delete: AuditLogActionCategory.delete,
             AuditLogAction.auto_moderation_block_message: None,
+            AuditLogAction.auto_moderation_flag_to_channel: None,
+            AuditLogAction.auto_moderation_user_communication_disabled: None
         }
         return lookup[self]
 
@@ -534,7 +538,7 @@ class AuditLogAction(Enum):
             return "thread"
         elif v < 122:
             return "application_command_permission"
-        elif v < 144:
+        elif v < 146:
             return "auto_moderation_rule"
 
 

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -267,6 +267,9 @@ class AuditEntryInfo(TypedDict):
     id: Snowflake
     type: Literal["0", "1"]
     role_name: str
+    application_id: Snowflake
+    auto_moderation_rule_name: str
+    auto_moderation_rule_trigger_type: str
 
 
 class AuditLogEntry(TypedDict):

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1512,6 +1512,74 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.0
 
+    .. attribute:: auto_moderation_rule_create
+
+        A guild auto moderation rule was created.
+
+        Possible attributes for :class:`AuditLogDiff`:
+
+        - :attr:`~AuditLogDiff.name`
+        - :attr:`~AuditLogDiff.enabled`
+        - :attr:`~AuditLogDiff.trigger_type`
+        - :attr:`~AuditLogDiff.event_type`
+        - :attr:`~AuditLogDiff.trigger_metadata`
+        - :attr:`~AuditLogDiff.actions`
+        - :attr:`~AuditLogDiff.exempt_roles`
+        - :attr:`~AuditLogDiff.exempt_channels`
+
+        .. versionadded:: 2.5
+
+    .. attribute:: auto_moderation_rule_update
+
+        A guild auto moderation rule was updated.
+
+        Possible attributes for :class:`AuditLogDiff`:
+
+        - :attr:`~AuditLogDiff.name`
+        - :attr:`~AuditLogDiff.enabled`
+        - :attr:`~AuditLogDiff.trigger_type`
+        - :attr:`~AuditLogDiff.trigger_metadata`
+        - :attr:`~AuditLogDiff.actions`
+        - :attr:`~AuditLogDiff.exempt_roles`
+        - :attr:`~AuditLogDiff.exempt_channels`
+
+        .. versionadded:: 2.5
+
+    .. attribute:: auto_moderation_rule_delete
+
+        A guild auto moderation rule was deleted.
+
+        Possible attributes for :class:`AuditLogDiff`:
+
+        - :attr:`~AuditLogDiff.name`
+        - :attr:`~AuditLogDiff.enabled`
+        - :attr:`~AuditLogDiff.trigger_type`
+        - :attr:`~AuditLogDiff.event_type`
+        - :attr:`~AuditLogDiff.trigger_metadata`
+        - :attr:`~AuditLogDiff.actions`
+        - :attr:`~AuditLogDiff.exempt_roles`
+        - :attr:`~AuditLogDiff.exempt_channels`
+
+        .. versionadded:: 2.5
+
+    .. attribute:: auto_moderation_block_message
+
+        A message was blocked by auto moderation.
+
+        .. versionadded:: 2.5
+
+    .. attribute:: auto_moderation_flag_to_channel
+
+        A message was flagged by auto moderation.
+
+        .. versionadded:: 2.5
+
+    .. attribute:: auto_moderation_user_communication_disabled
+
+        A member was timed out by auto moderation.
+
+        .. versionadded:: 2.5
+
 
 .. class:: AuditLogActionCategory
 


### PR DESCRIPTION
## Summary

- Adds missing audit log event enums related to automod, alongside their relevant docs
- Adds transformer support for several AutoModRule attributes
- Adds missing audit log attributes related to automod
- Fix repr typo for AutoModTriggerMetadata

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
