### PR TITLE
docs: update thread edit docs

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -611,7 +611,7 @@ class Thread(Messageable, Hashable):
         Editing the thread requires :attr:`.Permissions.manage_threads`. The thread
         creator can also edit ``name``, ``archived`` or ``auto_archive_duration``.
         Note that if the thread is locked then only those with :attr:`.Permissions.manage_threads`
-        can send messages in in or unarchive a thread.
+        can send messages in it or unarchive a thread.
 
         The thread must be unarchived to be edited.
 

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -611,7 +611,7 @@ class Thread(Messageable, Hashable):
         Editing the thread requires :attr:`.Permissions.manage_threads`. The thread
         creator can also edit ``name``, ``archived`` or ``auto_archive_duration``.
         Note that if the thread is locked then only those with :attr:`.Permissions.manage_threads`
-        can unarchive a thread.
+        can send messages in in or unarchive a thread.
 
         The thread must be unarchived to be edited.
 


### PR DESCRIPTION
Now mentions that only members with manage_threads can **send messages in or**  unarchive a thread.

Closes #1919

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
