### PR TITLE
fix: Restore overriding on_application_command_error via listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2029](https://github.com/Pycord-Development/pycord/pull/2029))
 - Reflecting the api for gettings bans correctly.
   ([#1922](https://github.com/Pycord-Development/pycord/pull/1922))
+- Restored functionality for overriding default `on_application_command_error` via listeners.
+  ([#2044](https://github.com/Pycord-Development/pycord/pull/2044))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2029](https://github.com/Pycord-Development/pycord/pull/2029))
 - Reflecting the api for gettings bans correctly.
   ([#1922](https://github.com/Pycord-Development/pycord/pull/1922))
-- Restored functionality for overriding default `on_application_command_error` via listeners.
-  ([#2044](https://github.com/Pycord-Development/pycord/pull/2044))
+- Restored functionality for overriding default `on_application_command_error` via
+  listeners. ([#2044](https://github.com/Pycord-Development/pycord/pull/2044))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1177,6 +1177,8 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
 
         This only fires if you do not specify any listeners for command error.
         """
+        if self._event_handlers.get("on_application_command_error", None):
+            return
         command = context.command
         if command and command.has_error_handler():
             return


### PR DESCRIPTION
## Summary

Reverts an out of scope change made in #1907 so the default `on_application_command_error` won't fire if listeners for it exist.
Side note: should changelog be updated for this?
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
