### PR TITLE
fix(docs): Fix readthedocs build failures

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,9 @@ version: 2
 formats: []
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 
 sphinx:
   configuration: docs/conf.py
@@ -10,7 +12,6 @@ sphinx:
   builder: html
 
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Summary
This PR fixes build failures with readthedocs due to a new urllib3 release.

References:
- urllib3/urllib3#2168
- readthedocs/readthedocs.org#10290
- [Readthedocs config file documentation](https://docs.readthedocs.io/en/stable/config-file/v2.html#legacy-build-specification)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
