### PR TITLE
fix: TypeError when raising ConnectionClosed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2029](https://github.com/Pycord-Development/pycord/pull/2029))
 - Reflecting the api for gettings bans correctly.
   ([#1922](https://github.com/Pycord-Development/pycord/pull/1922))
+- Fixed `TypeError` when raising ConnectionClosed.
+  ([#2049](https://github.com/Pycord-Development/pycord/pull/2049))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/errors.py
+++ b/discord/errors.py
@@ -223,7 +223,7 @@ class ConnectionClosed(ClientException):
         self,
         socket: ClientWebSocketResponse,
         *,
-        shard_id: int | None,
+        shard_id: int | None = None,
         code: int | None = None,
     ):
         # This exception is just the same exception except


### PR DESCRIPTION
## Summary

Fixes TypeError when raising ConnectionClosed. Since `shard_id` is optional, it should be `None` by default. It was missing an Default Value, and that was throwing an TypeError.
![Screenshot_20230505-204912](https://user-images.githubusercontent.com/103902727/236586428-cbd8a83c-e636-477d-a051-55940257f01a.png)


## Information

- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [X] I have searched the open pull requests for duplicates.
- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [X] I have updated the changelog to include these changes.
