### PR TITLE
docs: Document @option.parameter_name

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -395,6 +395,12 @@ def option(name, type=None, **kwargs):
     """A decorator that can be used instead of typehinting :class:`Option`.
 
     .. versionadded:: 2.0
+
+    Attributes
+    ----------
+    parameter_name: :class:`str`
+        The name of the target parameter this option is mapped to.
+        This allows you to have a separate UI ``name`` and parameter name.
     """
 
     def decorator(func):


### PR DESCRIPTION
## Summary

`@discord.option.parameter_name` is a kwarg that allows you to have separate parameter and UI names for an option.
E.g.
```py
@slash_command()
async def say(ctx, file: Option(Attachment, name="image"))
```
would look like
```py
@slash_command()
@option("image", parameter_name="file")
async def say(ctx, file: Attachment)
```
It seems to have existed since 2.1, but was never documented.
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
