### PR TITLE
chore(i18n): change localization attributes' defaults (#1866)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Added possibility to start bot via async context manager.
   ([#1801](https://github.com/Pycord-Development/pycord/pull/1801))
+- Change default for all `name_localizations` & `description_localizations` attributes
+  from being `None` to be `MISSING`.
+  ([#1866](https://github.com/Pycord-Development/pycord/pull/1866))
 - Added new parameters (`author`, `footer`, `image`, `thumbnail`) to `discord.Embed`.
   ([#1996](https://github.com/Pycord-Development/pycord/pull/1996))
 - Added new events `on_bridge_command`, `on_bridge_command_completion`, and

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -647,10 +647,10 @@ class SlashCommand(ApplicationCommand):
     cooldown: Optional[:class:`~discord.ext.commands.Cooldown`]
         The cooldown applied when the command is invoked. ``None`` if the command
         doesn't have a cooldown.
-    name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    name_localizations: Dict[:class:`str`, :class:`str`]
         The name localizations for this command. The values of this should be ``"locale": "name"``. See
         `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
-    description_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    description_localizations: Dict[:class:`str`, :class:`str`]
         The description localizations for this command. The values of this should be ``"locale": "description"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
     """
@@ -668,8 +668,8 @@ class SlashCommand(ApplicationCommand):
             raise TypeError("Callback must be a coroutine.")
         self.callback = func
 
-        self.name_localizations: dict[str, str] | None = kwargs.get(
-            "name_localizations", None
+        self.name_localizations: dict[str, str] = kwargs.get(
+            "name_localizations", MISSING
         )
         _validate_names(self)
 
@@ -680,8 +680,8 @@ class SlashCommand(ApplicationCommand):
         )
 
         self.description: str = description
-        self.description_localizations: dict[str, str] | None = kwargs.get(
-            "description_localizations", None
+        self.description_localizations: dict[str, str] = kwargs.get(
+            "description_localizations", MISSING
         )
         _validate_descriptions(self)
 
@@ -843,9 +843,9 @@ class SlashCommand(ApplicationCommand):
             "description": self.description,
             "options": [o.to_dict() for o in self.options],
         }
-        if self.name_localizations is not None:
+        if self.name_localizations is not MISSING:
             as_dict["name_localizations"] = self.name_localizations
-        if self.description_localizations is not None:
+        if self.description_localizations is not MISSING:
             as_dict["description_localizations"] = self.description_localizations
         if self.is_subcommand:
             as_dict["type"] = SlashCommandOptionType.sub_command.value
@@ -1081,10 +1081,10 @@ class SlashCommandGroup(ApplicationCommand):
         :exc:`.ApplicationCommandError` should be used. Note that if the checks fail then
         :exc:`.CheckFailure` exception is raised to the :func:`.on_application_command_error`
         event.
-    name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    name_localizations: Dict[:class:`str`, :class:`str`]
         The name localizations for this command. The values of this should be ``"locale": "name"``. See
         `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
-    description_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    description_localizations: Dict[:class:`str`, :class:`str`]
         The description localizations for this command. The values of this should be ``"locale": "description"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
     """
@@ -1146,11 +1146,11 @@ class SlashCommandGroup(ApplicationCommand):
         self.guild_only: bool | None = kwargs.get("guild_only", None)
         self.nsfw: bool | None = kwargs.get("nsfw", None)
 
-        self.name_localizations: dict[str, str] | None = kwargs.get(
-            "name_localizations", None
+        self.name_localizations: dict[str, str] = kwargs.get(
+            "name_localizations", MISSING
         )
-        self.description_localizations: dict[str, str] | None = kwargs.get(
-            "description_localizations", None
+        self.description_localizations: dict[str, str] = kwargs.get(
+            "description_localizations", MISSING
         )
 
     @property
@@ -1163,9 +1163,9 @@ class SlashCommandGroup(ApplicationCommand):
             "description": self.description,
             "options": [c.to_dict() for c in self.subcommands],
         }
-        if self.name_localizations is not None:
+        if self.name_localizations is not MISSING:
             as_dict["name_localizations"] = self.name_localizations
-        if self.description_localizations is not None:
+        if self.description_localizations is not MISSING:
             as_dict["description_localizations"] = self.description_localizations
 
         if self.parent is not None:
@@ -1236,10 +1236,10 @@ class SlashCommandGroup(ApplicationCommand):
             :exc:`.ApplicationCommandError` should be used. Note that if the checks fail then
             :exc:`.CheckFailure` exception is raised to the :func:`.on_application_command_error`
             event.
-        name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+        name_localizations: Dict[:class:`str`, :class:`str`]
             The name localizations for this command. The values of this should be ``"locale": "name"``. See
             `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
-        description_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+        description_localizations: Dict[:class:`str`, :class:`str`]
             The description localizations for this command. The values of this should be ``"locale": "description"``.
             See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
 
@@ -1413,7 +1413,7 @@ class ContextMenuCommand(ApplicationCommand):
     cooldown: Optional[:class:`~discord.ext.commands.Cooldown`]
         The cooldown applied when the command is invoked. ``None`` if the command
         doesn't have a cooldown.
-    name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    name_localizations: Dict[:class:`str`, :class:`str`]
         The name localizations for this command. The values of this should be ``"locale": "name"``. See
         `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
     """
@@ -1430,8 +1430,8 @@ class ContextMenuCommand(ApplicationCommand):
             raise TypeError("Callback must be a coroutine.")
         self.callback = func
 
-        self.name_localizations: dict[str, str] | None = kwargs.get(
-            "name_localizations", None
+        self.name_localizations: dict[str, str] = kwargs.get(
+            "name_localizations", MISSING
         )
 
         # Discord API doesn't support setting descriptions for context menu commands, so it must be empty
@@ -1506,7 +1506,7 @@ class ContextMenuCommand(ApplicationCommand):
                 "default_member_permissions"
             ] = self.default_member_permissions.value
 
-        if self.name_localizations is not None:
+        if self.name_localizations:
             as_dict["name_localizations"] = self.name_localizations
 
         return as_dict

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -41,6 +41,7 @@ from ..channel import (
 from ..enums import ChannelType
 from ..enums import Enum as DiscordEnum
 from ..enums import SlashCommandOptionType
+from ..utils import MISSING
 
 if TYPE_CHECKING:
     from ..ext.commands import Converter
@@ -152,10 +153,10 @@ class Option:
         A list of channel types that can be selected in this option.
         Only applies to Options with an :attr:`input_type` of :class:`discord.SlashCommandOptionType.channel`.
         If this argument is used, :attr:`input_type` will be ignored.
-    name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    name_localizations: Dict[:class:`str`, :class:`str`]
         The name localizations for this option. The values of this should be ``"locale": "name"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
-    description_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    description_localizations: Dict[:class:`str`, :class:`str`]
         The description localizations for this option. The values of this should be ``"locale": "description"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
 
@@ -323,8 +324,10 @@ class Option:
 
         self.autocomplete = kwargs.pop("autocomplete", None)
 
-        self.name_localizations = kwargs.pop("name_localizations", None)
-        self.description_localizations = kwargs.pop("description_localizations", None)
+        self.name_localizations = kwargs.pop("name_localizations", MISSING)
+        self.description_localizations = kwargs.pop(
+            "description_localizations", MISSING
+        )
 
     def to_dict(self) -> dict:
         as_dict = {
@@ -335,9 +338,9 @@ class Option:
             "choices": [c.to_dict() for c in self.choices],
             "autocomplete": bool(self.autocomplete),
         }
-        if self.name_localizations is not None:
+        if self.name_localizations is not MISSING:
             as_dict["name_localizations"] = self.name_localizations
-        if self.description_localizations is not None:
+        if self.description_localizations is not MISSING:
             as_dict["description_localizations"] = self.description_localizations
         if self.channel_types:
             as_dict["channel_types"] = [t.value for t in self.channel_types]
@@ -368,7 +371,7 @@ class OptionChoice:
         The name of the choice. Shown in the UI when selecting an option.
     value: Optional[Union[:class:`str`, :class:`int`, :class:`float`]]
         The value of the choice. If not provided, will use the value of ``name``.
-    name_localizations: Optional[Dict[:class:`str`, :class:`str`]]
+    name_localizations: Dict[:class:`str`, :class:`str`]
         The name localizations for this choice. The values of this should be ``"locale": "name"``.
         See `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
     """
@@ -377,7 +380,7 @@ class OptionChoice:
         self,
         name: str,
         value: str | int | float | None = None,
-        name_localizations: dict[str, str] | None = None,
+        name_localizations: dict[str, str] = MISSING,
     ):
         self.name = str(name)
         self.value = value if value is not None else name
@@ -385,7 +388,7 @@ class OptionChoice:
 
     def to_dict(self) -> dict[str, str | int | float]:
         as_dict = {"name": self.name, "value": self.value}
-        if self.name_localizations is not None:
+        if self.name_localizations is not MISSING:
             as_dict["name_localizations"] = self.name_localizations
 
         return as_dict


### PR DESCRIPTION
New PR to fix codeconv workflow

## Summary
EDIT: This PR makes it so that l10n attrs are by default `MISSING` to be more API consistent.
I'd call this a minor breaking change.

## Information

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.