### PR TITLE
fix: add defaults to __init__s on embed classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,8 +106,9 @@ These changes are available on the `master` branch, but have not yet been releas
   listeners. ([#2044](https://github.com/Pycord-Development/pycord/pull/2044))
 - Fixed unloading of cogs having bridge commands.
   ([#2048](https://github.com/Pycord-Development/pycord/pull/2048))
-- Added a default value of `EmptyEmbed` to `EmbedAuthor` and `EmbedFooter` to fix an 
-  AttributeError when accessing the classes from `Embed` ([#2061](https://github.com/Pycord-Development/pycord/pull/2061))
+- Added a default value of `EmptyEmbed` to `EmbedAuthor` and `EmbedFooter` to fix an
+  AttributeError when accessing the classes from `Embed`
+  ([#2061](https://github.com/Pycord-Development/pycord/pull/2061))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ These changes are available on the `master` branch, but have not yet been releas
   listeners. ([#2044](https://github.com/Pycord-Development/pycord/pull/2044))
 - Fixed unloading of cogs having bridge commands.
   ([#2048](https://github.com/Pycord-Development/pycord/pull/2048))
+- Added a default value of `EmptyEmbed` to `EmbedAuthor` and `EmbedFooter` to fix an 
+  AttributeError when accessing the classes from `Embed` ([#2061](https://github.com/Pycord-Development/pycord/pull/2061))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -122,7 +122,7 @@ class EmbedAuthor(EmbedProxy):
 
     def __init__(
         self,
-        name: str,
+        name: MaybeEmpty[str] = EmptyEmbed,
         url: MaybeEmpty[str] = EmptyEmbed,
         icon_url: MaybeEmpty[str] = EmptyEmbed,
         proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
@@ -151,7 +151,7 @@ class EmbedFooter(EmbedProxy):
 
     def __init__(
         self,
-        text: str,
+        text: MaybeEmpty[str] = EmptyEmbed,
         icon_url: MaybeEmpty[str] = EmptyEmbed,
         proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes #2052

Alternatively, add a different method that converts it from a dict to the class, to emphasise the defaulted parameters actually being required when sent to Discord

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
