### PR TITLE
refactor!: embed classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ These changes are available on the `master` branch, but have not yet been releas
   listeners. ([#2044](https://github.com/Pycord-Development/pycord/pull/2044))
 - Fixed unloading of cogs having bridge commands.
   ([#2048](https://github.com/Pycord-Development/pycord/pull/2048))
+- Added a default value of `EmptyEmbed` to `EmbedAuthor` and `EmbedFooter` to fix an
+  AttributeError when accessing the classes from `Embed`
+  ([#2061](https://github.com/Pycord-Development/pycord/pull/2061))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,9 +106,6 @@ These changes are available on the `master` branch, but have not yet been releas
   listeners. ([#2044](https://github.com/Pycord-Development/pycord/pull/2044))
 - Fixed unloading of cogs having bridge commands.
   ([#2048](https://github.com/Pycord-Development/pycord/pull/2048))
-- Added a default value of `EmptyEmbed` to `EmbedAuthor` and `EmbedFooter` to fix an
-  AttributeError when accessing the classes from `Embed`
-  ([#2061](https://github.com/Pycord-Development/pycord/pull/2061))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Removed `view.message` being set when the view was sent by
   `interaction.response.send_message`.
   ([#2036](https://github.com/Pycord-Development/pycord/pull/2036))
-- Removed `Embed.Empty` in favour of `None`, and `EmbedProxy` in favour of individual classes.
-  ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
+- Removed `Embed.Empty` in favour of `None`, and `EmbedProxy` in favour of individual
+  classes. ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2036](https://github.com/Pycord-Development/pycord/pull/2036))
 - Attributes shared between ext and slash commands are now dynamically fetched on bridge
   commands. ([#1867](https://github.com/Pycord-Development/pycord/pull/1867))
+- Embed attribues like author, footer, etc now return `None` when not set, and return
+  their respective classes when set.
+  ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
 
 ### Removed
 
@@ -79,6 +82,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Removed `view.message` being set when the view was sent by
   `interaction.response.send_message`.
   ([#2036](https://github.com/Pycord-Development/pycord/pull/2036))
+- Removed `Embed.Empty` in favour of `None`, and `EmbedProxy` in favour of individual classes.
+  ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
 
 ### Fixed
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -122,7 +122,7 @@ class EmbedAuthor(EmbedProxy):
 
     def __init__(
         self,
-        name: str,
+        name: MaybeEmpty[str] = EmptyEmbed,
         url: MaybeEmpty[str] = EmptyEmbed,
         icon_url: MaybeEmpty[str] = EmptyEmbed,
         proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
@@ -151,7 +151,7 @@ class EmbedFooter(EmbedProxy):
 
     def __init__(
         self,
-        text: str,
+        text: MaybeEmpty[str] = EmptyEmbed,
         icon_url: MaybeEmpty[str] = EmptyEmbed,
         proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
     ) -> None:

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -26,7 +26,16 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Final, Mapping, Protocol, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Mapping,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+)
 
 from . import utils
 from .colour import Colour
@@ -39,18 +48,18 @@ __all__ = (
 )
 
 
-class _EmptyEmbed:
-    def __bool__(self) -> bool:
-        return False
+# class None:
+#     def __bool__(self) -> bool:
+#         return False
 
-    def __repr__(self) -> str:
-        return "Embed.Empty"
+#     def __repr__(self) -> str:
+#         return "Embed.Empty"
 
-    def __len__(self) -> int:
-        return 0
+#     def __len__(self) -> int:
+#         return 0
 
 
-EmptyEmbed: Final = _EmptyEmbed()
+# None: Final = None()
 
 
 class EmbedProxy:
@@ -66,8 +75,8 @@ class EmbedProxy:
         )
         return f"{type(self).__name__}({inner})"
 
-    def __getattr__(self, attr: str) -> _EmptyEmbed:
-        return EmptyEmbed
+    def __getattr__(self, attr: str) -> None:
+        return None
 
 
 E = TypeVar("E", bound="Embed")
@@ -77,32 +86,31 @@ if TYPE_CHECKING:
     from discord.types.embed import EmbedType
 
     T = TypeVar("T")
-    MaybeEmpty = Union[T, _EmptyEmbed]
 
     class _EmbedFooterProxy(Protocol):
-        text: MaybeEmpty[str]
-        icon_url: MaybeEmpty[str]
+        text: Optional[str]
+        icon_url: Optional[str]
 
     class _EmbedMediaProxy(Protocol):
-        url: MaybeEmpty[str]
-        proxy_url: MaybeEmpty[str]
-        height: MaybeEmpty[int]
-        width: MaybeEmpty[int]
+        url: Optional[str]
+        proxy_url: Optional[str]
+        height: Optional[int]
+        width: Optional[int]
 
     class _EmbedVideoProxy(Protocol):
-        url: MaybeEmpty[str]
-        height: MaybeEmpty[int]
-        width: MaybeEmpty[int]
+        url: Optional[str]
+        height: Optional[int]
+        width: Optional[int]
 
     class _EmbedProviderProxy(Protocol):
-        name: MaybeEmpty[str]
-        url: MaybeEmpty[str]
+        name: Optional[str]
+        url: Optional[str]
 
     class _EmbedAuthorProxy(Protocol):
-        name: MaybeEmpty[str]
-        url: MaybeEmpty[str]
-        icon_url: MaybeEmpty[str]
-        proxy_icon_url: MaybeEmpty[str]
+        name: Optional[str]
+        url: Optional[str]
+        icon_url: Optional[str]
+        proxy_icon_url: Optional[str]
 
 
 class EmbedAuthor(EmbedProxy):
@@ -123,16 +131,23 @@ class EmbedAuthor(EmbedProxy):
     def __init__(
         self,
         name: str,
-        url: MaybeEmpty[str] = EmptyEmbed,
-        icon_url: MaybeEmpty[str] = EmptyEmbed,
-        proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
+        url: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        proxy_icon_url: Optional[str] = None,
     ) -> None:
+        # layer = {
+        #     k: v
+        #     for k, v in locals().items()
+        #     if k in {"name", "url", "icon_url", "proxy_icon_url"} and v
+        # }
         layer = {
-            k: v
-            for k, v in locals().items()
-            if k in {"name", "url", "icon_url", "proxy_icon_url"}
-            and v is not EmptyEmbed
+            "name": name,
+            "url": url,
+            "icon_url": icon_url,
+            "proxy_icon_url": proxy_icon_url,
         }
+        # remove None values
+        layer = {k: v for k, v in layer.items() if v}
         super().__init__(layer)
 
 
@@ -152,14 +167,17 @@ class EmbedFooter(EmbedProxy):
     def __init__(
         self,
         text: str,
-        icon_url: MaybeEmpty[str] = EmptyEmbed,
-        proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
+        icon_url: Optional[str] = None,
+        proxy_icon_url: Optional[str] = None,
     ) -> None:
-        layer = {
-            k: v
-            for k, v in locals().items()
-            if k in {"text", "icon_url", "proxy_icon_url"} and v is not EmptyEmbed
-        }
+        # layer = {
+        #     k: v
+        #     for k, v in locals().items()
+        #     if k in {"text", "icon_url", "proxy_icon_url"} and v
+        # }
+        layer = {"text": text, "icon_url": icon_url, "proxy_icon_url": proxy_icon_url}
+        # remove None values
+        layer = {k: v for k, v in layer.items() if v}
         super().__init__(layer)
 
 
@@ -293,53 +311,54 @@ class Embed:
         "description",
     )
 
-    Empty: Final = EmptyEmbed
+    Empty: Final = None
 
     def __init__(
         self,
         *,
-        colour: int | Colour | _EmptyEmbed = EmptyEmbed,
-        color: int | Colour | _EmptyEmbed = EmptyEmbed,
-        title: MaybeEmpty[Any] = EmptyEmbed,
+        colour: int | Colour | None = None,
+        color: int | Colour | None = None,
+        title: Optional[Any] = None,
         type: EmbedType = "rich",
-        url: MaybeEmpty[Any] = EmptyEmbed,
-        description: MaybeEmpty[Any] = EmptyEmbed,
+        url: Optional[Any] = None,
+        description: Optional[Any] = None,
         timestamp: datetime.datetime = None,
-        fields: list[EmbedField] | None = None,
-        author: MaybeEmpty[EmbedAuthor] = EmptyEmbed,
-        footer: MaybeEmpty[EmbedFooter] = EmptyEmbed,
-        image: MaybeEmpty[str] = EmptyEmbed,
-        thumbnail: MaybeEmpty[str] = EmptyEmbed,
+        fields: list[EmbedField] = [],
+        author: Optional[EmbedAuthor] = None,
+        footer: Optional[EmbedFooter] = None,
+        image: Optional[str] = None,
+        thumbnail: Optional[str] = None,
     ):
-        self.colour = colour if colour is not EmptyEmbed else color
+        self.colour = colour if colour else color
         self.title = title
         self.type = type
         self.url = url
         self.description = description
 
-        if self.title is not EmptyEmbed and self.title is not None:
+        if self.title:
             self.title = str(self.title)
 
-        if self.description is not EmptyEmbed and self.description is not None:
+        if self.description:
             self.description = str(self.description)
 
-        if self.url is not EmptyEmbed and self.url is not None:
+        if self.url:
             self.url = str(self.url)
 
         if timestamp:
             self.timestamp = timestamp
-        self._fields: list[EmbedField] = fields or []
 
-        if author is not EmptyEmbed:
+        self._fields: list[EmbedField] = fields
+
+        if author:
             self.set_author(**author.__dict__)
 
-        if footer is not EmptyEmbed:
+        if footer:
             self.set_footer(**footer.__dict__)
 
-        if image is not EmptyEmbed:
+        if image:
             self.set_image(url=image)
 
-        if thumbnail is not EmptyEmbed:
+        if thumbnail:
             self.set_thumbnail(url=thumbnail)
 
     @classmethod
@@ -368,18 +387,18 @@ class Embed:
 
         # fill in the basic fields
 
-        self.title = data.get("title", EmptyEmbed)
-        self.type = data.get("type", EmptyEmbed)
-        self.description = data.get("description", EmptyEmbed)
-        self.url = data.get("url", EmptyEmbed)
+        self.title = data.get("title", None)
+        self.type = data.get("type", None)
+        self.description = data.get("description", None)
+        self.url = data.get("url", None)
 
-        if self.title is not EmptyEmbed:
+        if self.title:
             self.title = str(self.title)
 
-        if self.description is not EmptyEmbed:
+        if self.description:
             self.description = str(self.description)
 
-        if self.url is not EmptyEmbed:
+        if self.url:
             self.url = str(self.url)
 
         # try to fill in the more rich fields
@@ -466,12 +485,12 @@ class Embed:
         )
 
     @property
-    def colour(self) -> MaybeEmpty[Colour]:
-        return getattr(self, "_colour", EmptyEmbed)
+    def colour(self) -> Optional[Colour]:
+        return getattr(self, "_colour", None)
 
     @colour.setter
-    def colour(self, value: int | Colour | _EmptyEmbed):  # type: ignore
-        if isinstance(value, (Colour, _EmptyEmbed)):
+    def colour(self, value: int | Colour | None):  # type: ignore
+        if isinstance(value, (Colour, None)):
             self._colour = value
         elif isinstance(value, int):
             self._colour = Colour(value=value)
@@ -484,16 +503,16 @@ class Embed:
     color = colour
 
     @property
-    def timestamp(self) -> MaybeEmpty[datetime.datetime]:
-        return getattr(self, "_timestamp", EmptyEmbed)
+    def timestamp(self) -> Optional[datetime.datetime]:
+        return getattr(self, "_timestamp", None)
 
     @timestamp.setter
-    def timestamp(self, value: MaybeEmpty[datetime.datetime]):
+    def timestamp(self, value: Optional[datetime.datetime]):
         if isinstance(value, datetime.datetime):
             if value.tzinfo is None:
                 value = value.astimezone()
             self._timestamp = value
-        elif isinstance(value, _EmptyEmbed):
+        elif isinstance(value, None):
             self._timestamp = value
         else:
             raise TypeError(
@@ -502,20 +521,23 @@ class Embed:
             )
 
     @property
-    def footer(self) -> EmbedFooter:
+    def footer(self) -> EmbedFooter | _EmbedFooterProxy:
         """Returns an ``EmbedProxy`` denoting the footer contents.
 
         See :meth:`set_footer` for possible values you can access.
 
         If the attribute has no value then :attr:`Empty` is returned.
         """
-        return EmbedFooter(**getattr(self, "_footer", {}))
+        f = getattr(self, "_footer", None)
+        if f is None:
+            return EmbedProxy({})
+        return EmbedFooter(**f)
 
     def set_footer(
         self: E,
         *,
-        text: MaybeEmpty[Any] = EmptyEmbed,
-        icon_url: MaybeEmpty[Any] = EmptyEmbed,
+        text: Optional[Any] = None,
+        icon_url: Optional[Any] = None,
     ) -> E:
         """Sets the footer for the embed content.
 
@@ -532,10 +554,10 @@ class Embed:
         """
 
         self._footer = {}
-        if text is not EmptyEmbed:
+        if text:
             self._footer["text"] = str(text)
 
-        if icon_url is not EmptyEmbed:
+        if icon_url:
             self._footer["icon_url"] = str(icon_url)
 
         return self
@@ -570,7 +592,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_image", {}))  # type: ignore
 
-    def set_image(self: E, *, url: MaybeEmpty[Any]) -> E:
+    def set_image(self: E, *, url: Optional[Any]) -> E:
         """Sets the image for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -585,7 +607,7 @@ class Embed:
             The source URL for the image. Only HTTP(S) is supported.
         """
 
-        if url is EmptyEmbed:
+        if url is None:
             try:
                 del self._image
             except AttributeError:
@@ -627,7 +649,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_thumbnail", {}))  # type: ignore
 
-    def set_thumbnail(self: E, *, url: MaybeEmpty[Any]) -> E:
+    def set_thumbnail(self: E, *, url: Optional[Any]) -> E:
         """Sets the thumbnail for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -642,7 +664,7 @@ class Embed:
             The source URL for the thumbnail. Only HTTP(S) is supported.
         """
 
-        if url is EmptyEmbed:
+        if url is None:
             try:
                 del self._thumbnail
             except AttributeError:
@@ -694,21 +716,24 @@ class Embed:
         return EmbedProxy(getattr(self, "_provider", {}))  # type: ignore
 
     @property
-    def author(self) -> EmbedAuthor:
+    def author(self) -> EmbedAuthor | _EmbedAuthorProxy:
         """Returns an ``EmbedProxy`` denoting the author contents.
 
         See :meth:`set_author` for possible values you can access.
 
         If the attribute has no value then :attr:`Empty` is returned.
         """
-        return EmbedAuthor(**getattr(self, "_author", {}))  # type: ignore
+        a = getattr(self, "_author", None)
+        if a is None:
+            return EmbedProxy({})
+        return EmbedAuthor(**a)  # type: ignore
 
     def set_author(
         self: E,
         *,
         name: Any,
-        url: MaybeEmpty[Any] = EmptyEmbed,
-        icon_url: MaybeEmpty[Any] = EmptyEmbed,
+        url: Optional[Any] = None,
+        icon_url: Optional[Any] = None,
     ) -> E:
         """Sets the author for the embed content.
 
@@ -730,10 +755,10 @@ class Embed:
             "name": str(name),
         }
 
-        if url is not EmptyEmbed:
+        if url:
             self._author["url"] = str(url)
 
-        if icon_url is not EmptyEmbed:
+        if icon_url:
             self._author["icon_url"] = str(icon_url)
 
         return self

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -122,7 +122,7 @@ class EmbedAuthor(EmbedProxy):
 
     def __init__(
         self,
-        name: MaybeEmpty[str] = EmptyEmbed,
+        name: str,
         url: MaybeEmpty[str] = EmptyEmbed,
         icon_url: MaybeEmpty[str] = EmptyEmbed,
         proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
@@ -151,7 +151,7 @@ class EmbedFooter(EmbedProxy):
 
     def __init__(
         self,
-        text: MaybeEmpty[str] = EmptyEmbed,
+        text: str,
         icon_url: MaybeEmpty[str] = EmptyEmbed,
         proxy_icon_url: MaybeEmpty[str] = EmptyEmbed,
     ) -> None:

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -26,7 +26,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Final, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar
 
 from . import utils
 from .colour import Colour
@@ -37,6 +37,7 @@ __all__ = (
     "EmbedAuthor",
     "EmbedFooter",
     "EmbedMedia",
+    "EmbedProvider",
 )
 
 
@@ -92,6 +93,13 @@ class EmbedAuthor:
             d["icon_url"] = str(self.icon_url)
         return d
 
+    def __len__(self) -> int:
+        """Returns the total number of characters in the author name."""
+        return len(self.name)
+
+    def __repr__(self) -> str:
+        return f"<EmbedAuthor name={self.name!r} url={self.url!r} icon_url={self.icon_url!r}>"
+
 
 class EmbedFooter:
     """Represents the footer on the :class:`Embed` object.
@@ -131,6 +139,13 @@ class EmbedFooter:
             d["icon_url"] = str(self.icon_url)
         return d
 
+    def __len__(self) -> int:
+        """Returns the total number of characters in the footer text."""
+        return len(self.text)
+
+    def __repr__(self) -> str:
+        return f"<EmbedFooter text={self.text!r} icon_url={self.icon_url!r}>"
+
 
 class EmbedMedia:  # Thumbnail, Image, Video
     """Represents a media on the :class:`Embed` object.
@@ -164,6 +179,9 @@ class EmbedMedia:  # Thumbnail, Image, Video
         self.width = data.get("width")
         return self
 
+    def __repr__(self) -> str:
+        return f"<EmbedMedia url={self.url!r} proxy_url={self.proxy_url!r}> height={self.height!r} width={self.width!r}>"
+
 
 class EmbedProvider:
     """Represents a provider on the :class:`Embed` object.
@@ -187,6 +205,9 @@ class EmbedProvider:
         self.name = data.get("name")
         self.url = data.get("url")
         return self
+
+    def __repr__(self) -> str:
+        return f"<EmbedProvider name={self.name!r} url={self.url!r}>"
 
 
 class EmbedField:
@@ -246,6 +267,9 @@ class EmbedField:
             "value": self.value,
             "inline": self.inline,
         }
+
+    def __repr__(self) -> str:
+        return f"<EmbedField name={self.name!r} value={self.value!r} inline={self.inline!r}>"
 
 
 class Embed:

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -26,7 +26,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Final, Mapping, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Final, Mapping, TypeVar
 
 from . import utils
 from .colour import Colour

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -48,7 +48,7 @@ __all__ = (
 )
 
 
-# class None:
+# class _EmbedEmpty:
 #     def __bool__(self) -> bool:
 #         return False
 
@@ -59,7 +59,7 @@ __all__ = (
 #         return 0
 
 
-# None: Final = None()
+# EmbedEmpty: Final = _EmptyEmbed()
 
 
 class EmbedProxy:

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -79,13 +79,16 @@ class EmbedAuthor:
     @classmethod
     def from_dict(cls, data: dict[str, str | None]) -> EmbedAuthor:
         self = cls.__new__(cls)
-        self.name = data.get("name")
+        name = data.get("name")
+        if not name:
+            raise ValueError("name field is required")
+        self.name = name
         self.url = data.get("url")
         self.icon_url = data.get("icon_url")
         self.proxy_icon_url = data.get("proxy_icon_url")
         return self
 
-    def to_dict(self) -> dict[str, str | None]:
+    def to_dict(self) -> dict[str, str]:
         d = {"name": str(self.name)}
         if self.url:
             d["url"] = str(self.url)
@@ -128,7 +131,10 @@ class EmbedFooter:
     @classmethod
     def from_dict(cls, data: dict[str, str | None]) -> EmbedFooter:
         self = cls.__new__(cls)
-        self.text = data.get("text")
+        text = data.get("text")
+        if not text:
+            raise ValueError("text field is required")
+        self.text = text
         self.icon_url = data.get("icon_url")
         self.proxy_icon_url = data.get("proxy_icon_url")
         return self
@@ -171,12 +177,12 @@ class EmbedMedia:  # Thumbnail, Image, Video
     width: int
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | int | None]) -> EmbedMedia:
+    def from_dict(cls, data: dict[str, str | int]) -> EmbedMedia:
         self = cls.__new__(cls)
-        self.url = data.get("url")
-        self.proxy_url = data.get("proxy_url")
-        self.height = data.get("height")
-        self.width = data.get("width")
+        self.url = str(data.get("url"))
+        self.proxy_url = str(data.get("proxy_url"))
+        self.height = int(data["height"])
+        self.width = int(data["width"])
         return self
 
     def __repr__(self) -> str:
@@ -231,7 +237,7 @@ class EmbedField:
         self.inline = inline
 
     @classmethod
-    def from_dict(cls, data: dict[str,]) -> EmbedField:
+    def from_dict(cls, data: dict[str, str | bool]) -> EmbedField:
         """Converts a :class:`dict` to a :class:`EmbedField` provided it is in the
         format that Discord expects it to be in.
 
@@ -246,7 +252,7 @@ class EmbedField:
         data: :class:`dict`
             The dictionary to convert into an EmbedField object.
         """
-        self: E = cls.__new__(cls)
+        self = cls.__new__(cls)
 
         self.name = data["name"]
         self.value = data["value"]
@@ -254,7 +260,7 @@ class EmbedField:
 
         return self
 
-    def to_dict(self) -> dict[str, str | bool]:
+    def to_dict(self) -> dict[str, str | bool | None]:
         """Converts this EmbedField object into a dict.
 
         Returns
@@ -343,7 +349,7 @@ class Embed:
         type: EmbedType = "rich",
         url: Any | None = None,
         description: Any | None = None,
-        timestamp: datetime.datetime = None,
+        timestamp: datetime.datetime | None = None,
         fields: list[EmbedField] = [],
         author: EmbedAuthor | None = None,
         footer: EmbedFooter | None = None,
@@ -467,7 +473,11 @@ class Embed:
         return self.__class__.from_dict(self.to_dict())
 
     def __len__(self) -> int:
-        total = len(self.title) + len(self.description)
+        total = 0
+        if self.title:
+            total += len(self.title)
+        if self.description:
+            total += len(self.description)
         for field in getattr(self, "_fields", []):
             total += len(field.name) + len(field.value)
 
@@ -614,7 +624,7 @@ class Embed:
         img = getattr(self, "_image", None)
         if not img:
             return None
-        return EmbedMedia.from_dict(img)  # type: ignore
+        return EmbedMedia.from_dict(img)
 
     def set_image(self: E, *, url: Any | None) -> E:
         """Sets the image for the embed content.
@@ -674,7 +684,7 @@ class Embed:
         thumb = getattr(self, "_thumbnail", None)
         if not thumb:
             return None
-        return EmbedMedia.from_dict(thumb)  # type: ignore
+        return EmbedMedia.from_dict(thumb)
 
     def set_thumbnail(self: E, *, url: Any | None) -> E:
         """Sets the thumbnail for the embed content.
@@ -733,7 +743,7 @@ class Embed:
         vid = getattr(self, "_video", None)
         if not vid:
             return None
-        return EmbedMedia.from_dict(vid)  # type: ignore
+        return EmbedMedia.from_dict(vid)
 
     @property
     def provider(self) -> EmbedProvider | None:
@@ -746,7 +756,7 @@ class Embed:
         prov = getattr(self, "_provider", None)
         if not prov:
             return None
-        return EmbedProvider.from_dict(prov)  # type: ignore
+        return EmbedProvider.from_dict(prov)
 
     @property
     def author(self) -> EmbedAuthor | None:
@@ -759,7 +769,7 @@ class Embed:
         auth = getattr(self, "_author", None)
         if not auth:
             return None
-        return EmbedAuthor.from_dict(auth)  # type: ignore
+        return EmbedAuthor.from_dict(auth)
 
     def set_author(
         self: E,

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -26,16 +26,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Final,
-    Mapping,
-    Optional,
-    Protocol,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Final, Mapping, Optional, Protocol, TypeVar
 
 from . import utils
 from .colour import Colour
@@ -88,29 +79,29 @@ if TYPE_CHECKING:
     T = TypeVar("T")
 
     class _EmbedFooterProxy(Protocol):
-        text: Optional[str]
-        icon_url: Optional[str]
+        text: str | None
+        icon_url: str | None
 
     class _EmbedMediaProxy(Protocol):
-        url: Optional[str]
-        proxy_url: Optional[str]
-        height: Optional[int]
-        width: Optional[int]
+        url: str | None
+        proxy_url: str | None
+        height: int | None
+        width: int | None
 
     class _EmbedVideoProxy(Protocol):
-        url: Optional[str]
-        height: Optional[int]
-        width: Optional[int]
+        url: str | None
+        height: int | None
+        width: int | None
 
     class _EmbedProviderProxy(Protocol):
-        name: Optional[str]
-        url: Optional[str]
+        name: str | None
+        url: str | None
 
     class _EmbedAuthorProxy(Protocol):
-        name: Optional[str]
-        url: Optional[str]
-        icon_url: Optional[str]
-        proxy_icon_url: Optional[str]
+        name: str | None
+        url: str | None
+        icon_url: str | None
+        proxy_icon_url: str | None
 
 
 class EmbedAuthor(EmbedProxy):
@@ -131,9 +122,9 @@ class EmbedAuthor(EmbedProxy):
     def __init__(
         self,
         name: str,
-        url: Optional[str] = None,
-        icon_url: Optional[str] = None,
-        proxy_icon_url: Optional[str] = None,
+        url: str | None = None,
+        icon_url: str | None = None,
+        proxy_icon_url: str | None = None,
     ) -> None:
         # layer = {
         #     k: v
@@ -167,8 +158,8 @@ class EmbedFooter(EmbedProxy):
     def __init__(
         self,
         text: str,
-        icon_url: Optional[str] = None,
-        proxy_icon_url: Optional[str] = None,
+        icon_url: str | None = None,
+        proxy_icon_url: str | None = None,
     ) -> None:
         # layer = {
         #     k: v
@@ -318,16 +309,16 @@ class Embed:
         *,
         colour: int | Colour | None = None,
         color: int | Colour | None = None,
-        title: Optional[Any] = None,
+        title: Any | None = None,
         type: EmbedType = "rich",
-        url: Optional[Any] = None,
-        description: Optional[Any] = None,
+        url: Any | None = None,
+        description: Any | None = None,
         timestamp: datetime.datetime = None,
         fields: list[EmbedField] = [],
-        author: Optional[EmbedAuthor] = None,
-        footer: Optional[EmbedFooter] = None,
-        image: Optional[str] = None,
-        thumbnail: Optional[str] = None,
+        author: EmbedAuthor | None = None,
+        footer: EmbedFooter | None = None,
+        image: str | None = None,
+        thumbnail: str | None = None,
     ):
         self.colour = colour if colour else color
         self.title = title
@@ -485,7 +476,7 @@ class Embed:
         )
 
     @property
-    def colour(self) -> Optional[Colour]:
+    def colour(self) -> Colour | None:
         return getattr(self, "_colour", None)
 
     @colour.setter
@@ -503,11 +494,11 @@ class Embed:
     color = colour
 
     @property
-    def timestamp(self) -> Optional[datetime.datetime]:
+    def timestamp(self) -> datetime.datetime | None:
         return getattr(self, "_timestamp", None)
 
     @timestamp.setter
-    def timestamp(self, value: Optional[datetime.datetime]):
+    def timestamp(self, value: datetime.datetime | None):
         if isinstance(value, datetime.datetime):
             if value.tzinfo is None:
                 value = value.astimezone()
@@ -536,8 +527,8 @@ class Embed:
     def set_footer(
         self: E,
         *,
-        text: Optional[Any] = None,
-        icon_url: Optional[Any] = None,
+        text: Any | None = None,
+        icon_url: Any | None = None,
     ) -> E:
         """Sets the footer for the embed content.
 
@@ -592,7 +583,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_image", {}))  # type: ignore
 
-    def set_image(self: E, *, url: Optional[Any]) -> E:
+    def set_image(self: E, *, url: Any | None) -> E:
         """Sets the image for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -649,7 +640,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_thumbnail", {}))  # type: ignore
 
-    def set_thumbnail(self: E, *, url: Optional[Any]) -> E:
+    def set_thumbnail(self: E, *, url: Any | None) -> E:
         """Sets the thumbnail for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -732,8 +723,8 @@ class Embed:
         self: E,
         *,
         name: Any,
-        url: Optional[Any] = None,
-        icon_url: Optional[Any] = None,
+        url: Any | None = None,
+        icon_url: Any | None = None,
     ) -> E:
         """Sets the author for the embed content.
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -553,7 +553,7 @@ class Embed:
 
     @property
     def footer(self) -> EmbedFooter | None:
-        """Returns an ``EmbedFooter`` denoting the footer contents.
+        """Returns an :class:`EmbedFooter` denoting the footer contents.
 
         See :meth:`set_footer` for possible values you can access.
 
@@ -610,7 +610,7 @@ class Embed:
 
     @property
     def image(self) -> EmbedMedia | None:
-        """Returns an ``EmbedMedia`` denoting the image contents.
+        """Returns an :class:`EmbedMedia` denoting the image contents.
 
         Attributes you can access are:
 
@@ -670,7 +670,7 @@ class Embed:
 
     @property
     def thumbnail(self) -> EmbedMedia | None:
-        """Returns an ``EmbedMedia`` denoting the thumbnail contents.
+        """Returns an :class:`EmbedMedia` denoting the thumbnail contents.
 
         Attributes you can access are:
 
@@ -730,7 +730,7 @@ class Embed:
 
     @property
     def video(self) -> EmbedMedia | None:
-        """Returns an ``EmbedMedia`` denoting the video contents.
+        """Returns an :class:`EmbedMedia` denoting the video contents.
 
         Attributes include:
 
@@ -747,7 +747,7 @@ class Embed:
 
     @property
     def provider(self) -> EmbedProvider | None:
-        """Returns an ``EmbedProvider`` denoting the provider contents.
+        """Returns an :class:`EmbedProvider` denoting the provider contents.
 
         The only attributes that might be accessed are ``name`` and ``url``.
 
@@ -760,7 +760,7 @@ class Embed:
 
     @property
     def author(self) -> EmbedAuthor | None:
-        """Returns an ``EmbedAuthor`` denoting the author contents.
+        """Returns an :class:`EmbedAuthor` denoting the author contents.
 
         See :meth:`set_author` for possible values you can access.
 

--- a/docs/api/data_classes.rst
+++ b/docs/api/data_classes.rst
@@ -83,6 +83,16 @@ Embed
 .. autoclass:: EmbedFooter
     :members:
 
+.. attributetable:: EmbedMedia
+
+.. autoclass:: EmbedMedia
+    :members:
+
+.. attributetable:: EmbedProvider
+
+.. autoclass:: EmbedProvider
+    :members:
+
 
 
 Flags


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Attributes for Author, Footer, Image, Thumbnail, Video, and Provider on the embed will now return `None` instead of `EmbedProxy`, when they are not set. This change is done for correct API reflection.

This allowed the complete removal of `EmbedProxy` in favour of separate classes for the above attributes. This allows for concrete typing support. The new classes are `EmbedAuthor`, `EmbedFooter`, `EmbedMedia` and `EmbedProxy`

`Embed.Empty` and `EmptyEmbed` have now been removed in favour of `None`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
