### PR TITLE
docs: mark Client.get_or_fetch_user() as a coro

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1049,7 +1049,9 @@ class Client:
             yield from guild.members
 
     async def get_or_fetch_user(self, id: int, /) -> User | None:
-        """Looks up a user in the user cache or fetches if not found.
+        """|coro|
+      
+        Looks up a user in the user cache or fetches if not found.
 
         Parameters
         ----------

--- a/discord/client.py
+++ b/discord/client.py
@@ -1050,7 +1050,7 @@ class Client:
 
     async def get_or_fetch_user(self, id: int, /) -> User | None:
         """|coro|
-      
+
         Looks up a user in the user cache or fetches if not found.
 
         Parameters


### PR DESCRIPTION
## Summary
`Client.get_or_fetch_user()` was not marked as a coro meaning it did not show the `This function is a coroutine` in the docs.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
