### PR TITLE
docs: remove `@client.once()`

### DIFF
--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -7,11 +7,11 @@ Event Reference
 
 This section outlines the different types of events listened by :class:`Client`.
 
-There are 4 ways to register an event, the first way is through the use of
+There are 3 ways to register an event, the first way is through the use of
 :meth:`Client.event`. The second way is through subclassing :class:`Client` and
 overriding the specific events. The third way is through the use of :meth:`Client.listen`,
 which can be used to assign multiple event handlers instead of only one like in :meth:`Client.event`.
-The fourth way is through the use of :meth:`Client.once`, which serves as a one-time event listener. For example:
+For example:
 
 .. code-block:: python
     :emphasize-lines: 17, 22
@@ -41,10 +41,10 @@ The fourth way is through the use of :meth:`Client.once`, which serves as a one-
     async def on_message(message: discord.Message):
         print(f"Received {message.content}")
 
-    # Runs only for the 1st 'on_message' event. Can be useful for listening to 'on_ready'
-    @client.once()
-    async def message(message: discord.Message):
-        print(f"Received {message.content}")
+    # Runs only for the 1st event dispatch. Can be useful for listening to 'on_ready'
+    @client.listen(once=True)
+    async def on_ready():
+        print("Client is ready!")
 
 
 If an event handler raises an exception, :func:`on_error` will be called


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Updates docs to use [`@client.listen(once=True)`](https://github.com/Pycord-Development/pycord/pull/1957) instead of [`@client.once()`](https://github.com/Pycord-Development/pycord/pull/1940)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
