### PR TITLE
fix: creating forum threads with files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1925](https://github.com/Pycord-Development/pycord/pull/1925))
 - Fixed major TypeError when an AuditLogEntry has no user.
   ([#2079](https://github.com/Pycord-Development/pycord/pull/2079))
+- Fixed `HTTPException` when trying to create a forum thread with files.
+  ([#2075](https://github.com/Pycord-Development/pycord/pull/2075))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1274,26 +1274,7 @@ class ForumChannel(_TextChannel):
         if file is not None and files is not None:
             raise InvalidArgument("cannot pass both file and files parameter to send()")
 
-        if file is not None:
-            if not isinstance(file, File):
-                raise InvalidArgument("file parameter must be File")
-
-            try:
-                data = await state.http.send_files(
-                    self.id,
-                    files=[file],
-                    allowed_mentions=allowed_mentions,
-                    content=message_content,
-                    embed=embed,
-                    embeds=embeds,
-                    nonce=nonce,
-                    stickers=stickers,
-                    components=components,
-                )
-            finally:
-                file.close()
-
-        elif files is not None:
+        if files is not None:
             if len(files) > 10:
                 raise InvalidArgument(
                     "files parameter must be a list of up to 10 elements"
@@ -1301,26 +1282,17 @@ class ForumChannel(_TextChannel):
             elif not all(isinstance(file, File) for file in files):
                 raise InvalidArgument("files parameter must be a list of File")
 
-            try:
-                data = await state.http.send_files(
-                    self.id,
-                    files=files,
-                    content=message_content,
-                    embed=embed,
-                    embeds=embeds,
-                    nonce=nonce,
-                    allowed_mentions=allowed_mentions,
-                    stickers=stickers,
-                    components=components,
-                )
-            finally:
-                for f in files:
-                    f.close()
-        else:
+        if file is not None:
+            if not isinstance(file, File):
+                raise InvalidArgument("file parameter must be File")
+            files = [file]
+
+        try:
             data = await state.http.start_forum_thread(
                 self.id,
                 content=message_content,
                 name=name,
+                files=files,
                 embed=embed,
                 embeds=embeds,
                 nonce=nonce,
@@ -1333,6 +1305,11 @@ class ForumChannel(_TextChannel):
                 applied_tags=applied_tags,
                 reason=reason,
             )
+        finally:
+            if files is not None:
+                for f in files:
+                    f.close()
+
         ret = Thread(guild=self.guild, state=self._state, data=data)
         msg = ret.get_partial_message(data["last_message_id"])
         if view:

--- a/discord/http.py
+++ b/discord/http.py
@@ -1241,8 +1241,7 @@ class HTTPClient:
             payload["attachments"] = attachments
             form[0]["value"] = utils._to_json(payload)
             return self.request(route, form=form, reason=reason)
-        else:
-            return self.request(route, json=payload, reason=reason)
+        return self.request(route, json=payload, reason=reason)
 
     def join_thread(self, channel_id: Snowflake) -> Response[None]:
         return self.request(


### PR DESCRIPTION
## Summary

Allows creating a new forum thread with files. As mentioned in the issue, the [thread creation endpoint](https://discord.com/developers/docs/resources/channel#start-thread-in-forum-channel) supports uploading files directly, so there is no need to use a separate endpoint when this argument is provided to `create_thread`.

Fixes #1949

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
