### PR TITLE
fix: Make AuditLogEntry user/user_id optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2048](https://github.com/Pycord-Development/pycord/pull/2048))
 - Fixed the Slash command syncronization method `indiviual`.
   ([#1925](https://github.com/Pycord-Development/pycord/pull/1925))
+- Fixed major TypeError when an AuditLogEntry has no user.
+  ([#2079](https://github.com/Pycord-Development/pycord/pull/2079))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -483,7 +483,7 @@ class AuditLogEntry(Hashable):
     -----------
     action: :class:`AuditLogAction`
         The action that was done.
-    user: :class:`abc.User`
+    user: Optional[:class:`abc.User`]
         The user who initiated this action. Usually a :class:`Member`\, unless gone
         then it's a :class:`User`.
     id: :class:`int`

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -677,7 +677,7 @@ class RawAuditLogEntryEvent(_RawReprMixin):
         The entry ID.
     guild_id: :class:`int`
         The ID of the guild this action came from.
-    user_id: :class:`int`
+    user_id: Optional[:class:`int`]
         The ID of the user who initiated this action.
     target_id: Optional[:class:`int`]
         The ID of the target that got changed.
@@ -708,7 +708,9 @@ class RawAuditLogEntryEvent(_RawReprMixin):
 
     def __init__(self, data: AuditLogEntryEvent) -> None:
         self.id = int(data["id"])
-        self.user_id = int(data["user_id"])
+        self.user_id = data.get("user_id")
+        if self.user_id:
+            self.user_id = int(self.user_id)
         self.guild_id = int(data["guild_id"])
         self.target_id = data.get("target_id")
         if self.target_id:

--- a/discord/types/raw_models.py
+++ b/discord/types/raw_models.py
@@ -134,7 +134,7 @@ class ThreadMembersUpdateEvent(TypedDict):
 
 class AuditLogEntryEvent(TypedDict):
     id: Snowflake
-    user_id: Snowflake
+    user_id: NotRequired[Snowflake]
     guild_id: Snowflake
     target_id: NotRequired[Snowflake]
     action_type: int


### PR DESCRIPTION
## Summary

So *apparently* [it's possible to recieve a user_id of `None` for audit log entries](https://discord.com/channels/881207955029110855/998272089343668364/1109233676262309888)...
![image](https://github.com/Pycord-Development/pycord/assets/41271523/6369adef-428b-4b7f-81b7-a3eb2a5c9a1b)
![image](https://github.com/Pycord-Development/pycord/assets/41271523/af74f959-f26e-41c0-8261-45bec376e408)
Thus it's been made optional.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
