### PR TITLE
docs: Fix typo in `abc.Messageable.pins()`

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1716,7 +1716,7 @@ class Messageable:
         .. note::
 
             Due to a limitation with the Discord API, the :class:`.Message`
-            objects returned by this method do not contain complete
+            objects returned by this method does not contain complete
             :attr:`.Message.reactions` data.
 
         Returns


### PR DESCRIPTION
## Summary
Fixes a typo in the doc

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
