### PR TITLE
feat: Add icon and unicode_emoji to Guild.create_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1867](https://github.com/Pycord-Development/pycord/pull/1867))
 - Added support for usernames and modified multiple methods accordingly.
   ([#2042](https://github.com/Pycord-Development/pycord/pull/2042))
+- Added `icon` and `unicode_emoji` to `Guild.create_role`.
+  ([#2086](https://github.com/Pycord-Development/pycord/pull/2086))
 
 ### Changed
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2869,7 +2869,6 @@ class Guild(Hashable):
             A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG/WebP is supported.
             If this argument is passed, ``unicode_emoji`` is set to None.
             Only available to guilds that contain ``ROLE_ICONS`` in :attr:`Guild.features`.
-            Could be ``None`` to denote removal of the icon.
         unicode_emoji: Optional[:class:`str`]
             The role's unicode emoji. If this argument is passed, ``icon`` is set to None.
             Only available to guilds that contain ``ROLE_ICONS`` in :attr:`Guild.features`.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2803,6 +2803,8 @@ class Guild(Hashable):
         colour: Colour | int = ...,
         hoist: bool = ...,
         mentionable: bool = ...,
+        icon: bytes | None = MISSING,
+        unicode_emoji: str | None = MISSING,
     ) -> Role:
         ...
 
@@ -2816,6 +2818,8 @@ class Guild(Hashable):
         color: Colour | int = ...,
         hoist: bool = ...,
         mentionable: bool = ...,
+        icon: bytes | None = ...,
+        unicode_emoji: str | None = ...,
     ) -> Role:
         ...
 
@@ -2829,6 +2833,8 @@ class Guild(Hashable):
         hoist: bool = MISSING,
         mentionable: bool = MISSING,
         reason: str | None = None,
+        icon: bytes | None = MISSING,
+        unicode_emoji: str | None = MISSING,
     ) -> Role:
         """|coro|
 
@@ -2859,6 +2865,14 @@ class Guild(Hashable):
             Defaults to ``False``.
         reason: Optional[:class:`str`]
             The reason for creating this role. Shows up on the audit log.
+        icon: Optional[:class:`bytes`]
+            A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG/WebP is supported.
+            If this argument is passed, ``unicode_emoji`` is set to None.
+            Only available to guilds that contain ``ROLE_ICONS`` in :attr:`Guild.features`.
+            Could be ``None`` to denote removal of the icon.
+        unicode_emoji: Optional[:class:`str`]
+            The role's unicode emoji. If this argument is passed, ``icon`` is set to None.
+            Only available to guilds that contain ``ROLE_ICONS`` in :attr:`Guild.features`.
 
         Returns
         -------
@@ -2894,6 +2908,17 @@ class Guild(Hashable):
 
         if name is not MISSING:
             fields["name"] = name
+
+        if icon is not MISSING:
+            if icon is None:
+                fields["icon"] = None
+            else:
+                fields["icon"] = _bytes_to_base64_data(icon)
+                fields["unicode_emoji"] = None
+
+        if unicode_emoji is not MISSING:
+            fields["unicode_emoji"] = unicode_emoji
+            fields["icon"] = None
 
         data = await self._state.http.create_role(self.id, reason=reason, **fields)
         role = Role(guild=self, data=data, state=self._state)


### PR DESCRIPTION
## Summary

The `icon` and `unicode_emoji` args have been available in `Role.edit` from the start, but were never added to `Guild.create_role`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
