### PR TITLE
fix: Adjust default_avatar behavior depending on username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Embed attribues like author, footer, etc now return `None` when not set, and return
   their respective classes when set.
   ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
+- `default_avatar` behavior changes depending on the user's username migration status
+  ([#2087](https://github.com/Pycord-Development/pycord/pull/2087))
 
 ### Removed
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -195,9 +195,10 @@ class BaseUser(_UserTag):
     @property
     def default_avatar(self) -> Asset:
         """Returns the default avatar for a given user.
-        This is calculated by the user's ID.
+        This is calculated by the user's ID if they're on the new username system, otherwise their discriminator.
         """
-        return Asset._from_default_avatar(self._state, (self.id >> 22) % 5)
+        eq = (self.id >> 22) if self.is_migrated else int(self.discriminator) 
+        return Asset._from_default_avatar(self._state, eq % 5)
 
     @property
     def display_avatar(self) -> Asset:

--- a/discord/user.py
+++ b/discord/user.py
@@ -197,7 +197,7 @@ class BaseUser(_UserTag):
         """Returns the default avatar for a given user.
         This is calculated by the user's ID if they're on the new username system, otherwise their discriminator.
         """
-        eq = (self.id >> 22) if self.is_migrated else int(self.discriminator) 
+        eq = (self.id >> 22) if self.is_migrated else int(self.discriminator)
         return Asset._from_default_avatar(self._state, eq % 5)
 
     @property


### PR DESCRIPTION
## Summary

As per https://github.com/discord/discord-api-docs/pull/6130#issuecomment-1556391316, `default_avatar` should still use discrim if the user hasn't migrated yet.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
