### PR TITLE
Warning get x commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
-_No changes yet_
+### Fixed
+
+- Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual
+  behavior. ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 
 ## [2.4.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ possible (see our [Version Guarantees] for more info).
 These changes are available on the `master` branch, but have not yet been released.
 
 ### Added
+
 - Added new events `on_bridge_command`, `on_bridge_command_completion`, and
   `on_bridge_command_error`.
   ([#1916](https://github.com/Pycord-Development/pycord/pull/1916))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+### Added
+- Added new events `on_bridge_command`, `on_bridge_command_completion`, and
+  `on_bridge_command_error`.
+  ([#1916](https://github.com/Pycord-Development/pycord/pull/1916))
+
 ### Fixed
 
 - Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added new events `on_bridge_command`, `on_bridge_command_completion`, and
   `on_bridge_command_error`.
   ([#1916](https://github.com/Pycord-Development/pycord/pull/1916))
+- Added the `@client.once()` decorator, which serves as a one-time event listener.
+  ([#1940](https://github.com/Pycord-Development/pycord/pull/1940))
+- Added support for text-related features in `StageChannel`.
+  ([#1936](https://github.com/Pycord-Development/pycord/pull/1936))
+
+## [2.4.1] - 2023-03-20
+
+### Changed
+
+- Updated the values of the `Color.embed_background()` classmethod to correspond with
+  new theme colors in the app.
+  ([#1931](https://github.com/Pycord-Development/pycord/pull/1931))
 
 ### Fixed
 
@@ -535,7 +547,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fix py3.10 UnionType checks issue.
   ([#1240](https://github.com/Pycord-Development/pycord/pull/1240))
 
-[unreleased]: https://github.com/Pycord-Development/pycord/compare/v2.4.0...HEAD
+[unreleased]: https://github.com/Pycord-Development/pycord/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/Pycord-Development/pycord/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Pycord-Development/pycord/compare/v2.3.3...v2.4.0
 [2.3.3]: https://github.com/Pycord-Development/pycord/compare/v2.3.2...v2.3.3
 [2.3.2]: https://github.com/Pycord-Development/pycord/compare/v2.3.1...v2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed the voice ip discovery due to the recent
   [announced change](https://discord.com/channels/613425648685547541/697138785317814292/1080623873629884486).
   ([#1955](https://github.com/Pycord-Development/pycord/pull/1955))
+- Fixed `reason` being passed to wrong method in `guild.create_auto_moderation_rule`.
+  ([#1960](https://github.com/Pycord-Development/pycord/pull/1960))
 
 ## [2.4.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual
   behavior. ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
+- Fixed the voice ip discovery due to the recent
+  [announced change](https://discord.com/channels/613425648685547541/697138785317814292/1080623873629884486).
+  ([#1955](https://github.com/Pycord-Development/pycord/pull/1955))
 
 ## [2.4.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+_No changes yet_
+
+## [2.4.0] - 2023-02-10
+
 ### Added
 
 - Added new AutoMod trigger metadata properties `regex_patterns`, `allow_list`, and
@@ -21,8 +25,8 @@ These changes are available on the `master` branch, but have not yet been releas
   metadata, along with the `fetch_role_connection_metadata_records` and
   `update_role_connection_metadata_records` methods in `Client`.
   ([#1791](https://github.com/Pycord-Development/pycord/pull/1791))
-- Added new message types, `interaction_premium_upsell`, `stage_start`, `stage_end`,
-  `stage_speaker`, `stage_raise_hand`, `stage_topic`, and
+- Added new message types, `role_subscription_purchase`, `interaction_premium_upsell`,
+  `stage_start`, `stage_end`, `stage_speaker`, `stage_raise_hand`, `stage_topic`, and
   `guild_application_premium_subscription`.
   ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
 - Added new `EmbeddedActivity` values.
@@ -34,11 +38,18 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added new raw events: `raw_member_remove`, `raw_thread_update`, and
   `raw_thread_member_remove`.
   ([#1880](https://github.com/Pycord-Development/pycord/pull/1880))
+- Improved support for setting channel types & added new channel types for
+  `discord.Option`. ([#1883](https://github.com/Pycord-Development/pycord/pull/1883))
 
 ### Changed
 
 - Changed `EmbeddedActivity` values to update accordingly with the new activities.
   ([#1859](https://github.com/Pycord-Development/pycord/pull/1859))
+- Advanced version info is now stored as a dict in `version_info.advanced` instead of
+  attributes on the `version_info` object.
+  ([#1920](https://github.com/Pycord-Development/pycord/pull/1920))
+- The `version_info.release_level` attribute has been reverted to its previous name,
+  `releaselevel`. ([#1920](https://github.com/Pycord-Development/pycord/pull/1920))
 
 ### Fixed
 
@@ -46,15 +57,15 @@ These changes are available on the `master` branch, but have not yet been releas
   `AttributeError`, and `io.BytesIO` files didn't send properly more than once.
   ([#1869](https://github.com/Pycord-Development/pycord/pull/1869) &
   [#1881](https://github.com/Pycord-Development/pycord/pull/1881))
-- Fixed an unhandled `KeyError` exception when receiving GIF stickers.
-  ([#1915](https://github.com/Pycord-Development/pycord/pull/1915))
-
-## [2.3.2] - 2022-12-03
-
-### Fixed
-
 - Fixed bridge groups missing the `parent` attribute.
   ([#1823](https://github.com/Pycord-Development/pycord/pull/1823))
+- Fixed issues with creating auto moderation rules.
+  ([#1822](https://github.com/Pycord-Development/pycord/pull/1822))
+
+## [2.3.3] - 2023-02-10
+
+- Fixed an unhandled `KeyError` exception when receiving GIF stickers, causing crashes.
+  ([#1915](https://github.com/Pycord-Development/pycord/pull/1915))
 
 ## [2.3.2] - 2022-12-03
 
@@ -114,6 +125,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1678](https://github.com/Pycord-Development/pycord/pull/1678))
 - `get_application_command()` now supports retrieving subcommands and subcommand groups.
   ([#1678](https://github.com/Pycord-Development/pycord/pull/1678))
+-
 
 ### Removed
 
@@ -509,7 +521,9 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fix py3.10 UnionType checks issue.
   ([#1240](https://github.com/Pycord-Development/pycord/pull/1240))
 
-[unreleased]: https://github.com/Pycord-Development/pycord/compare/v2.3.2...HEAD
+[unreleased]: https://github.com/Pycord-Development/pycord/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/Pycord-Development/pycord/compare/v2.3.3...v2.4.0
+[2.3.3]: https://github.com/Pycord-Development/pycord/compare/v2.3.2...v2.3.3
 [2.3.2]: https://github.com/Pycord-Development/pycord/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/Pycord-Development/pycord/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/Pycord-Development/pycord/compare/v2.2.2...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ These changes are available on the `master` branch, but have not yet been releas
 ### Fixed
 
 - Fixed the type-hinting of `SlashCommandGroup.walk_commands()` to reflect actual
-  behavior. ([#1852](https://github.com/Pycord-Development/pycord/pull/1852))
+  behavior. ([#1838](https://github.com/Pycord-Development/pycord/pull/1838))
 - Fixed the voice ip discovery due to the recent
   [announced change](https://discord.com/channels/613425648685547541/697138785317814292/1080623873629884486).
   ([#1955](https://github.com/Pycord-Development/pycord/pull/1955))

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -338,8 +338,8 @@ class Colour:
         """A factory method that returns a :class:`Color` corresponding to the
         embed colors on discord clients, with a value of:
 
-        - ``0x2F3136`` (dark)
-        - ``0xf2f3f5`` (light)
+        - ``0x2B2D31`` (dark)
+        - ``0xEEEFF1`` (light)
         - ``0x000000`` (amoled).
 
         .. versionadded:: 2.0
@@ -350,8 +350,8 @@ class Colour:
             The theme color to apply, must be one of "dark", "light", or "amoled".
         """
         themes_cls = {
-            "dark": 0x2F3136,
-            "light": 0xF2F3F5,
+            "dark": 0x2B2D31,
+            "light": 0xEEEFF1,
             "amoled": 0x000000,
         }
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1317,13 +1317,13 @@ class SlashCommandGroup(ApplicationCommand):
         ctx.interaction.data = option
         await command.invoke_autocomplete_callback(ctx)
 
-    def walk_commands(self) -> Generator[SlashCommand, None, None]:
-        """An iterator that recursively walks through all slash commands in this group.
+    def walk_commands(self) -> Generator[SlashCommand | SlashCommandGroup, None, None]:
+        """An iterator that recursively walks through all slash commands and groups in this group.
 
         Yields
         ------
-        :class:`.SlashCommand`
-            A slash command from the group.
+        :class:`.SlashCommand` | :class:`.SlashCommandGroup`
+            A nested slash command or slash command group from the group.
         """
         for command in self.subcommands:
             if isinstance(command, SlashCommandGroup):

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1067,7 +1067,7 @@ class Intents(BaseFlags):
 
         .. note::
 
-            As of September 2022 requires opting in explicitly via the Developer Portal to receive the actual content
+            As of September 2022 using this intent requires opting in explicitly via the Developer Portal to receive the actual content
             of the guild messages. This intent is privileged, meaning that bots in over 100 guilds that require this
             intent would need to request this intent on the Developer Portal.
             See https://support-dev.discord.com/hc/en-us/articles/4404772028055 for more information.

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -892,16 +892,16 @@ class DiscordVoiceWebSocket:
         state.voice_port = data["port"]
         state.endpoint_ip = data["ip"]
 
-        packet = bytearray(70)
+        packet = bytearray(74)
         struct.pack_into(">H", packet, 0, 1)  # 1 = Send
         struct.pack_into(">H", packet, 2, 70)  # 70 = Length
         struct.pack_into(">I", packet, 4, state.ssrc)
         state.socket.sendto(packet, (state.endpoint_ip, state.voice_port))
-        recv = await self.loop.sock_recv(state.socket, 70)
+        recv = await self.loop.sock_recv(state.socket, 74)
         _log.debug("received packet in initial_connection: %s", recv)
 
-        # the ip is ascii starting at the 4th byte and ending at the first null
-        ip_start = 4
+        # the ip is ascii starting at the 8th byte and ending at the first null
+        ip_start = 8
         ip_end = recv.index(0, ip_start)
         state.ip = recv[ip_start:ip_end].decode("ascii")
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -778,7 +778,11 @@ class Guild(Hashable):
         .. note::
 
             This does *not* search for threads.
-
+        
+        .. warning::
+            
+            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command which raises if the role is not found.
+    
         Parameters
         ----------
         channel_id: :class:`int`
@@ -887,6 +891,11 @@ class Guild(Hashable):
     def get_member(self, user_id: int, /) -> Member | None:
         """Returns a member with the given ID.
 
+        .. warning::
+            
+            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command which raises if the role is not found.
+
+
         Parameters
         ----------
         user_id: :class:`int`
@@ -915,6 +924,10 @@ class Guild(Hashable):
 
     def get_role(self, role_id: int, /) -> Role | None:
         """Returns a role with the given ID.
+
+        .. warning::
+            
+            `get_role` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command which raises if the role is not found.
 
         Parameters
         ----------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3835,5 +3835,7 @@ class Guild(Hashable):
         if exempt_channels:
             payload["exempt_channels"] = [c.id for c in exempt_channels]
 
-        data = await self._state.http.create_auto_moderation_rule(self.id, payload)
-        return AutoModRule(state=self._state, data=data, reason=reason)
+        data = await self._state.http.create_auto_moderation_rule(
+            self.id, payload, reason=reason
+        )
+        return AutoModRule(state=self._state, data=data)

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -279,7 +279,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: stage_raise_hand
 
-        The system message denoting that a stage event has someone has raised their hand.
+        The system message denoting that someone in a stage event is raising their hand.
 
         .. versionadded:: 2.4
 

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -899,6 +899,7 @@ If you want a more robust error system, you can derive from the exception and ra
             return True
         return commands.check(predicate)
 
+    @bot.command()
     @guild_only()
     async def test(ctx):
         await ctx.send('Hey this is not a DM! Nice.')

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r _.txt
-pylint~=2.16.1
+pylint~=2.16.2
 pytest~=7.2.1
 pytest-asyncio~=0.20.3
 # pytest-order~=1.0.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ pylint~=2.16.2
 pytest~=7.2.1
 pytest-asyncio~=0.20.3
 # pytest-order~=1.0.1
-mypy~=1.0.0
+mypy~=1.0.1
 coverage~=7.1
 pre-commit==3.0.4
 codespell==2.2.2


### PR DESCRIPTION
## Summary

Adds warning messages to the documentation in get_channel, get_role, and get_member as they retrieve from the cache and may return None.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
