### PR TITLE
docs: add warning to get_x methods in guild.py

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -736,9 +736,9 @@ class Guild(Hashable):
         .. note::
 
             This does *not* search for threads.
-        
+
         .. warning::
-            
+
             `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Parameters
@@ -855,7 +855,7 @@ class Guild(Hashable):
             The ID to search for.
 
         .. warning::
-            
+
             `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns
@@ -888,7 +888,7 @@ class Guild(Hashable):
             The ID to search for.
 
         .. warning::
-            
+
             `get_role` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -739,7 +739,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the channel is not found.
+            Consider using the `fetch_x` version of this method if this returns `None`.
 
         Parameters
         ----------
@@ -850,7 +850,7 @@ class Guild(Hashable):
         """Returns a member with the given ID.
         .. warning::
 
-            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+            Consider using the `fetch_x` version of this method if this returns `None`.
 
         Parameters
         ----------
@@ -888,7 +888,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            `get_role` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+            Consider using the `fetch_x` version of this method if this returns `None`.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -848,7 +848,7 @@ class Guild(Hashable):
 
     def get_member(self, user_id: int, /) -> Member | None:
         """Returns a member with the given ID.
-        
+
         .. warning::
 
             Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -739,7 +739,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the channel is not found.
 
         Parameters
         ----------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -848,6 +848,7 @@ class Guild(Hashable):
 
     def get_member(self, user_id: int, /) -> Member | None:
         """Returns a member with the given ID.
+        
         .. warning::
 
             Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -847,16 +847,15 @@ class Guild(Hashable):
         return list(self._members.values())
 
     def get_member(self, user_id: int, /) -> Member | None:
-        """Returns a member with the given ID.
+        """Returns a member with the given ID.       
+        .. warning::
 
+            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+        
         Parameters
         ----------
         user_id: :class:`int`
             The ID to search for.
-
-        .. warning::
-
-            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -739,7 +739,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            Consider using the `fetch_x` version of this method if this returns `None`.
+            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Parameters
         ----------
@@ -850,7 +850,7 @@ class Guild(Hashable):
         """Returns a member with the given ID.
         .. warning::
 
-            Consider using the `fetch_x` version of this method if this returns `None`.
+            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Parameters
         ----------
@@ -888,7 +888,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            Consider using the `fetch_x` version of this method if this returns `None`.
+            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -736,6 +736,10 @@ class Guild(Hashable):
         .. note::
 
             This does *not* search for threads.
+        
+        .. warning::
+            
+            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Parameters
         ----------
@@ -850,6 +854,10 @@ class Guild(Hashable):
         user_id: :class:`int`
             The ID to search for.
 
+        .. warning::
+            
+            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+
         Returns
         -------
         Optional[:class:`Member`]
@@ -878,6 +886,10 @@ class Guild(Hashable):
         ----------
         role_id: :class:`int`
             The ID to search for.
+
+        .. warning::
+            
+            `get_role` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -847,11 +847,11 @@ class Guild(Hashable):
         return list(self._members.values())
 
     def get_member(self, user_id: int, /) -> Member | None:
-        """Returns a member with the given ID.       
+        """Returns a member with the given ID.
         .. warning::
 
             `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
-        
+
         Parameters
         ----------
         user_id: :class:`int`


### PR DESCRIPTION
## Summary

This adds that get_x commands retrieve from the cache and gives a warning message in the docs.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
