### PR TITLE
docs: get_ commands cache docs message

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -879,7 +879,7 @@ class Client:
         Returns
         -------
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
-            The returned channel or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The returned channel or ``None`` if not found. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection.get_channel(id)
@@ -898,7 +898,7 @@ class Client:
         Returns
         -------
         Optional[:class:`.Message`]
-            The returned message or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The returned message or ``None`` if not found. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection._get_message(id)
@@ -960,7 +960,7 @@ class Client:
         Returns
         -------
         Optional[:class:`.Guild`]
-            The guild or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The guild or ``None`` if not found. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection._get_guild(id)
@@ -976,7 +976,7 @@ class Client:
         Returns
         -------
         Optional[:class:`~discord.User`]
-            The user or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The user or ``None`` if not found. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection.get_user(id)

--- a/discord/client.py
+++ b/discord/client.py
@@ -879,7 +879,8 @@ class Client:
         Returns
         -------
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
-            The returned channel or ``None`` if not found.
+            The returned channel or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection.get_channel(id)
 
@@ -897,7 +898,8 @@ class Client:
         Returns
         -------
         Optional[:class:`.Message`]
-            The returned message or ``None`` if not found.
+            The returned message or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection._get_message(id)
 
@@ -958,7 +960,8 @@ class Client:
         Returns
         -------
         Optional[:class:`.Guild`]
-            The guild or ``None`` if not found.
+            The guild or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection._get_guild(id)
 
@@ -973,7 +976,8 @@ class Client:
         Returns
         -------
         Optional[:class:`~discord.User`]
-            The user or ``None`` if not found.
+            The user or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._connection.get_user(id)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -736,9 +736,9 @@ class Guild(Hashable):
         .. note::
 
             This does *not* search for threads.
-        
+
         .. warning::
-            
+
             `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Parameters
@@ -855,7 +855,7 @@ class Guild(Hashable):
             The ID to search for.
 
         .. warning::
-            
+
             `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns
@@ -888,7 +888,7 @@ class Guild(Hashable):
             The ID to search for.
 
         .. warning::
-            
+
             `get_role` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -739,7 +739,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the channel is not found.
+            Consider using the `fetch_x` version of this method if this returns `None`.
 
         Parameters
         ----------
@@ -850,7 +850,7 @@ class Guild(Hashable):
         """Returns a member with the given ID.
         .. warning::
 
-            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+            Consider using the `fetch_x` version of this method if this returns `None`.
 
         Parameters
         ----------
@@ -888,7 +888,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            `get_role` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+            Consider using the `fetch_x` version of this method if this returns `None`.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -737,7 +737,6 @@ class Guild(Hashable):
 
             This does *not* search for threads.
 
-
         Parameters
         ----------
         channel_id: :class:`int`
@@ -746,7 +745,7 @@ class Guild(Hashable):
         Returns
         -------
         Optional[:class:`.abc.GuildChannel`]
-            The returned channel or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The returned channel or ``None`` if not found. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._channels.get(channel_id)
@@ -855,7 +854,7 @@ class Guild(Hashable):
         Returns
         -------
         Optional[:class:`Member`]
-            The member or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The member or ``None`` if not found. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._members.get(user_id)
@@ -882,11 +881,10 @@ class Guild(Hashable):
         role_id: :class:`int`
             The ID to search for.
 
-
         Returns
         -------
         Optional[:class:`Role`]
-            The role or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The role or ``None`` if not found. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._roles.get(role_id)
@@ -2024,7 +2022,7 @@ class Guild(Hashable):
         Returns
         -------
         :class:`Member`
-            The member from the member ID. It can return ``None`` because it retrieves from the cache. 
+            The member from the member ID. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
 
         Raises

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -848,7 +848,7 @@ class Guild(Hashable):
 
     def get_member(self, user_id: int, /) -> Member | None:
         """Returns a member with the given ID.
-        
+
         .. warning::
 
             Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -739,7 +739,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the channel is not found.
 
         Parameters
         ----------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -848,6 +848,7 @@ class Guild(Hashable):
 
     def get_member(self, user_id: int, /) -> Member | None:
         """Returns a member with the given ID.
+        
         .. warning::
 
             Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -847,16 +847,15 @@ class Guild(Hashable):
         return list(self._members.values())
 
     def get_member(self, user_id: int, /) -> Member | None:
-        """Returns a member with the given ID.
+        """Returns a member with the given ID.       
+        .. warning::
 
+            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+        
         Parameters
         ----------
         user_id: :class:`int`
             The ID to search for.
-
-        .. warning::
-
-            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -739,7 +739,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            Consider using the `fetch_x` version of this method if this returns `None`.
+            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Parameters
         ----------
@@ -850,7 +850,7 @@ class Guild(Hashable):
         """Returns a member with the given ID.
         .. warning::
 
-            Consider using the `fetch_x` version of this method if this returns `None`.
+            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Parameters
         ----------
@@ -888,7 +888,7 @@ class Guild(Hashable):
 
         .. warning::
 
-            Consider using the `fetch_x` version of this method if this returns `None`.
+            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -736,6 +736,10 @@ class Guild(Hashable):
         .. note::
 
             This does *not* search for threads.
+        
+        .. warning::
+            
+            `get_channel` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Parameters
         ----------
@@ -850,6 +854,10 @@ class Guild(Hashable):
         user_id: :class:`int`
             The ID to search for.
 
+        .. warning::
+            
+            `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
+
         Returns
         -------
         Optional[:class:`Member`]
@@ -878,6 +886,10 @@ class Guild(Hashable):
         ----------
         role_id: :class:`int`
             The ID to search for.
+
+        .. warning::
+            
+            `get_role` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
 
         Returns
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -737,9 +737,6 @@ class Guild(Hashable):
 
             This does *not* search for threads.
 
-        .. warning::
-
-            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Parameters
         ----------
@@ -749,7 +746,8 @@ class Guild(Hashable):
         Returns
         -------
         Optional[:class:`.abc.GuildChannel`]
-            The returned channel or ``None`` if not found.
+            The returned channel or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._channels.get(channel_id)
 
@@ -849,10 +847,6 @@ class Guild(Hashable):
     def get_member(self, user_id: int, /) -> Member | None:
         """Returns a member with the given ID.
 
-        .. warning::
-
-            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
-
         Parameters
         ----------
         user_id: :class:`int`
@@ -861,7 +855,8 @@ class Guild(Hashable):
         Returns
         -------
         Optional[:class:`Member`]
-            The member or ``None`` if not found.
+            The member or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._members.get(user_id)
 
@@ -887,14 +882,12 @@ class Guild(Hashable):
         role_id: :class:`int`
             The ID to search for.
 
-        .. warning::
-
-            Consider using the `fetch_x` version of this method if this returns `None`. This method retrieves from the cache.
 
         Returns
         -------
         Optional[:class:`Role`]
-            The role or ``None`` if not found.
+            The role or ``None`` if not found. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self._roles.get(role_id)
 
@@ -2031,7 +2024,8 @@ class Guild(Hashable):
         Returns
         -------
         :class:`Member`
-            The member from the member ID.
+            The member from the member ID. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
 
         Raises
         ------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -847,11 +847,11 @@ class Guild(Hashable):
         return list(self._members.values())
 
     def get_member(self, user_id: int, /) -> Member | None:
-        """Returns a member with the given ID.       
+        """Returns a member with the given ID.
         .. warning::
 
             `get_member` and other `get_x` commands come from the cache. It may return None even if it exists. Use the `fetch_x` version of this command if the role is not found.
-        
+
         Parameters
         ----------
         user_id: :class:`int`

--- a/discord/member.py
+++ b/discord/member.py
@@ -1088,6 +1088,7 @@ class Member(discord.abc.Messageable, _UserTag):
         Returns
         -------
         Optional[:class:`Role`]
-            The role or ``None`` if not found in the member's roles.
+            The role or ``None`` if not found in the member's roles. It can return ``None`` because it retrieves from the cache. 
+            The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1088,7 +1088,7 @@ class Member(discord.abc.Messageable, _UserTag):
         Returns
         -------
         Optional[:class:`Role`]
-            The role or ``None`` if not found in the member's roles. It can return ``None`` because it retrieves from the cache. 
+            The role or ``None`` if not found in the member's roles. It can return ``None`` because it retrieves from the cache.
             The fetch_ version of this command makes an API call and won't return ``None``.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None


### PR DESCRIPTION
## Summary

This is a docs change for clarity on get_ commands. It's to show that get_ commands retrieve from the cache which is why they may return None. 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
