### PR TITLE
fix: command_prefix and help_command typehints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2014](https://github.com/Pycord-Development/pycord/pull/2014))
 - `Interaction.channel` is received from the gateway, so it can now be `DMChannel` and
   `GroupChannel`. ([#2025](https://github.com/Pycord-Development/pycord/pull/2025))
-- `DMChannel.recipients` can now be `None`
+- `DMChannel.recipients` can now be `None`.
   ([#2025](https://github.com/Pycord-Development/pycord/pull/2025))
 - Store `view.message` on receiving Interaction for a component.
   ([#2036](https://github.com/Pycord-Development/pycord/pull/2036))
@@ -78,10 +78,12 @@ These changes are available on the `master` branch, but have not yet been releas
 - Embed attribues like author, footer, etc now return `None` when not set, and return
   their respective classes when set.
   ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
-- `default_avatar` behavior changes depending on the user's username migration status
+- `default_avatar` behavior changes depending on the user's username migration status.
   ([#2087](https://github.com/Pycord-Development/pycord/pull/2087))
 - `Client.on_error()` now has an `exception` parameter for easier error handling.
   ([#1945](https://github.com/Pycord-Development/pycord/pull/1945))
+- Typehinted `command_prefix` and `help_command` arguments properly.
+  ([#2099](https://github.com/Pycord-Development/pycord/pull/2099))
 
 ### Removed
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -126,7 +126,9 @@ class BotBase(GroupMixin, discord.cog.CogMixin):
     ):
         super().__init__(**options)
         self.command_prefix = command_prefix
-        self.help_command = DefaultHelpCommand() if help_command is MISSING else help_command
+        self.help_command = (
+            DefaultHelpCommand() if help_command is MISSING else help_command
+        )
         self.strip_after_prefix = options.get("strip_after_prefix", False)
 
     @discord.utils.copy_doc(discord.Client.close)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -119,7 +119,9 @@ class BotBase(GroupMixin, discord.cog.CogMixin):
 
     def __init__(
         self,
-        command_prefix: str | Iterable[str] | Callable[
+        command_prefix: str
+        | Iterable[str]
+        | Callable[
             [Bot | AutoShardedBot, Message],
             str | Iterable[str] | Coroutine[Any, Any, str | Iterable[str]],
         ] = when_mentioned,

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -29,7 +29,7 @@ import collections
 import collections.abc
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Iterable, TypeVar
 
 import discord
 
@@ -114,19 +114,24 @@ class _DefaultRepr:
         return "<default-help-command>"
 
 
-_default = _DefaultRepr()
-
-
 class BotBase(GroupMixin, discord.cog.CogMixin):
     _supports_prefixed_commands = True
 
-    def __init__(self, command_prefix=when_mentioned, help_command=_default, **options):
+    def __init__(
+        self,
+        command_prefix: str | Iterable[str] | Callable[
+            [Bot | AutoShardedBot, Message],
+            str | Iterable[str] | Coroutine[Any, Any, str | Iterable[str]],
+        ] = when_mentioned,
+        help_command: HelpCommand | _DefaultRepr | None = _DefaultRepr(),
+        **options,
+    ):
         super().__init__(**options)
         self.command_prefix = command_prefix
         self._help_command = None
         self.strip_after_prefix = options.get("strip_after_prefix", False)
 
-        if help_command is _default:
+        if isinstance(help_command, _DefaultRepr):
             self.help_command = DefaultHelpCommand()
         else:
             self.help_command = help_command

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -109,12 +109,8 @@ def _is_submodule(parent: str, child: str) -> bool:
     return parent == child or child.startswith(f"{parent}.")
 
 
-class _DefaultRepr:
-    def __repr__(self):
-        return "<default-help-command>"
-
-
 class BotBase(GroupMixin, discord.cog.CogMixin):
+    _help_command = None
     _supports_prefixed_commands = True
 
     def __init__(
@@ -125,18 +121,13 @@ class BotBase(GroupMixin, discord.cog.CogMixin):
             [Bot | AutoShardedBot, Message],
             str | Iterable[str] | Coroutine[Any, Any, str | Iterable[str]],
         ] = when_mentioned,
-        help_command: HelpCommand | _DefaultRepr | None = _DefaultRepr(),
+        help_command: HelpCommand | None = MISSING,
         **options,
     ):
         super().__init__(**options)
         self.command_prefix = command_prefix
-        self._help_command = None
+        self.help_command = DefaultHelpCommand() if help_command is MISSING else help_command
         self.strip_after_prefix = options.get("strip_after_prefix", False)
-
-        if isinstance(help_command, _DefaultRepr):
-            self.help_command = DefaultHelpCommand()
-        else:
-            self.help_command = help_command
 
     @discord.utils.copy_doc(discord.Client.close)
     async def close(self) -> None:


### PR DESCRIPTION
## Summary
Gets rid of annoying & meaningless type errors when initalizing `commands.Bot` by typehinting the `command_prefix` and `help_command` arguments properly.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
