### PR TITLE
revert: #1945

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,6 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
 - `default_avatar` behavior changes depending on the user's username migration status.
   ([#2087](https://github.com/Pycord-Development/pycord/pull/2087))
-- `Client.on_error()` now has an `exception` parameter for easier error handling.
-  ([#1945](https://github.com/Pycord-Development/pycord/pull/1945))
 - Typehinted `command_prefix` and `help_command` arguments properly.
   ([#2099](https://github.com/Pycord-Development/pycord/pull/2099))
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -399,9 +399,9 @@ class Client:
             await coro(*args, **kwargs)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except Exception:
             try:
-                await self.on_error(event_name, exc, *args, **kwargs)
+                await self.on_error(event_name, *args, **kwargs)
             except asyncio.CancelledError:
                 pass
 
@@ -481,9 +481,7 @@ class Client:
         for coro in once_listeners:
             self._event_handlers[method].remove(coro)
 
-    async def on_error(
-        self, event_method: str, exception: Exception, *args: Any, **kwargs: Any
-    ) -> None:
+    async def on_error(self, event_method: str, *args: Any, **kwargs: Any) -> None:
         """|coro|
 
         The default error handler provided by the client.

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -252,13 +252,16 @@ Channels
 
 Connection
 ----------
-.. function:: on_error(event, exception, *args, **kwargs)
+.. function:: on_error(event, *args, **kwargs)
 
     Usually when an event raises an uncaught exception, a traceback is
     printed to stderr and the exception is ignored. If you want to
     change this behaviour and handle the exception for whatever reason
     yourself, this event can be overridden. Which, when done, will
     suppress the default action of printing the traceback.
+
+    The information of the exception raised and the exception itself can
+    be retrieved with a standard call to :func:`sys.exc_info`.
 
     If you want exception to propagate out of the :class:`Client` class
     you can define an ``on_error`` handler consisting of a single empty
@@ -275,9 +278,6 @@ Connection
 
     :param event: The name of the event that raised the exception.
     :type event: :class:`str`
-
-    :param exception: The exception raised by the event.
-    :type event: :class:`Exception`
 
     :param args: The positional arguments for the event that raised the
         exception.


### PR DESCRIPTION
## Summary

Reverts #1945 due to a breaking change that should not have been made at this time.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
