### PR TITLE
fix: values access before interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2079](https://github.com/Pycord-Development/pycord/pull/2079))
 - Fixed `HTTPException` when trying to create a forum thread with files.
   ([#2075](https://github.com/Pycord-Development/pycord/pull/2075))
+- Fixed `AttributeError` when accessing a `Select`'s values when it hasn't been interacted with.
+  ([#2104](https://github.com/Pycord-Development/pycord/pull/2104))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,8 +129,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2079](https://github.com/Pycord-Development/pycord/pull/2079))
 - Fixed `HTTPException` when trying to create a forum thread with files.
   ([#2075](https://github.com/Pycord-Development/pycord/pull/2075))
-- Fixed `AttributeError` when accessing a `Select`'s values when it hasn't been interacted with.
-  ([#2104](https://github.com/Pycord-Development/pycord/pull/2104))
+- Fixed `AttributeError` when accessing a `Select`'s values when it hasn't been
+  interacted with. ([#2104](https://github.com/Pycord-Development/pycord/pull/2104))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -334,13 +334,16 @@ class Select(Item[V]):
         | list[Member | User | Role]
         | list[GuildChannel | Thread]
     ):
-        """Union[List[:class:`str`], List[Union[:class:`discord.Member`, :class:`discord.User`]], List[:class:`discord.Role`]],
-        List[Union[:class:`discord.Member`, :class:`discord.User`, :class:`discord.Role`]], List[:class:`discord.abc.GuildChannel`]]:
-        A list of values that have been selected by the user.
+        """List[:class:`str`] | List[:class:`discord.Member` | :class:`discord.User`]] | List[:class:`discord.Role`]] | 
+        List[:class:`discord.Member` | :class:`discord.User` | :class:`discord.Role`]] | List[:class:`discord.abc.GuildChannel`]:
+        A list of values that have been selected by the user. This will be an empty list if the select has not been interacted with yet.
         """
         select_type = self._underlying.type
         if select_type is ComponentType.string_select:
             return self._selected_values
+        if self._interaction is None:
+            # The select has not been interacted with yet
+            return []
         resolved = []
         selected_values = list(self._selected_values)
         state = self._interaction._state

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -334,7 +334,7 @@ class Select(Item[V]):
         | list[Member | User | Role]
         | list[GuildChannel | Thread]
     ):
-        """List[:class:`str`] | List[:class:`discord.Member` | :class:`discord.User`]] | List[:class:`discord.Role`]] | 
+        """List[:class:`str`] | List[:class:`discord.Member` | :class:`discord.User`]] | List[:class:`discord.Role`]] |
         List[:class:`discord.Member` | :class:`discord.User` | :class:`discord.Role`]] | List[:class:`discord.abc.GuildChannel`]:
         A list of values that have been selected by the user. This will be an empty list if the select has not been interacted with yet.
         """

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -335,15 +335,15 @@ class Select(Item[V]):
         | list[GuildChannel | Thread]
     ):
         """List[:class:`str`] | List[:class:`discord.Member` | :class:`discord.User`]] | List[:class:`discord.Role`]] |
-        List[:class:`discord.Member` | :class:`discord.User` | :class:`discord.Role`]] | List[:class:`discord.abc.GuildChannel`]:
-        A list of values that have been selected by the user. This will be an empty list if the select has not been interacted with yet.
+        List[:class:`discord.Member` | :class:`discord.User` | :class:`discord.Role`]] | List[:class:`discord.abc.GuildChannel`] | None:
+        A list of values that have been selected by the user. This will be ``None`` if the select has not been interacted with yet.
         """
+        if self._interaction is None:
+            # The select has not been interacted with yet
+            return None
         select_type = self._underlying.type
         if select_type is ComponentType.string_select:
             return self._selected_values
-        if self._interaction is None:
-            # The select has not been interacted with yet
-            return []
         resolved = []
         selected_values = list(self._selected_values)
         state = self._interaction._state


### PR DESCRIPTION
## Summary

Fixes a bug that caused an AttributeError to be raised from `Select.values` if the select had not been interacted with yet, specifically non-string selects.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
