### PR TITLE
feat(ext.pages): add more ways to send paginator by editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `suppress` and `allowed_mentions` parameters to `Webhook` and
   `InteractionResponse` edit methods.
   ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
-- Allowed more classes in `paginator.edit`.
+- Added more classes in `paginator.edit`.
   ([#2105](https://github.com/Pycord-Development/pycord/pull/2105))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,8 +96,6 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2087](https://github.com/Pycord-Development/pycord/pull/2087))
 - Typehinted `command_prefix` and `help_command` arguments properly.
   ([#2099](https://github.com/Pycord-Development/pycord/pull/2099))
-- Renamed `message` parameter to `target` in `paginator.edit`.
-  ([#2105](https://github.com/Pycord-Development/pycord/pull/2105))
 - Replace `orjson` support with `msgspec` support.
   ([#2170](https://github.com/Pycord-Development/pycord/pull/2170))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `suppress` and `allowed_mentions` parameters to `Webhook` and
   `InteractionResponse` edit methods.
   ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
+- Allowed more classes in `paginator.edit`.
+  ([#2105](https://github.com/Pycord-Development/pycord/pull/2105))
 
 ### Changed
 
@@ -93,6 +95,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2087](https://github.com/Pycord-Development/pycord/pull/2087))
 - Typehinted `command_prefix` and `help_command` arguments properly.
   ([#2099](https://github.com/Pycord-Development/pycord/pull/2099))
+- Renamed `message` parameter to `target in `paginator.edit`.
+  ([#2105](https://github.com/Pycord-Development/pycord/pull/2105))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2087](https://github.com/Pycord-Development/pycord/pull/2087))
 - Typehinted `command_prefix` and `help_command` arguments properly.
   ([#2099](https://github.com/Pycord-Development/pycord/pull/2099))
-- Renamed `message` parameter to `target in `paginator.edit`.
+- Renamed `message` parameter to `target` in `paginator.edit`.
   ([#2105](https://github.com/Pycord-Development/pycord/pull/2105))
 
 ### Removed

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1098,7 +1098,7 @@ class Paginator(discord.ui.View):
 
         Parameters
         ----------
-        target: Union[:class:`~discord.PartialMessage`, :class:`~discord.Message`, :class:`~discord.Interaction`, :class:`~discord.ApplicationContext`, :class:`~discord.ext.bridge.BridgeContext`]
+        target: Union[:class:`~discord.PartialMessage`, :class:`~discord.Message`, :class:`~discord.Interaction`, :class:`~discord.ApplicationContext`, :class:`~discord.ext.bridge.Context`]
             The target to edit.
         suppress: :class:`bool`
             Whether to suppress embeds for the message. This removes

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1099,6 +1099,12 @@ class Paginator(discord.ui.View):
                 allowed_mentions=allowed_mentions,
                 delete_after=delete_after,
             )
+            if self.message is None and isinstance(target, discord.Interaction):
+                # if the message is None, it means that interaction.response.edit_message was used.
+                # this can only be done if the interaction was from a component or a modal
+                # both of which have the message attribute set
+                self.message: discord.Message = target.message
+
         except (discord.NotFound, discord.Forbidden):
             pass
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1134,7 +1134,7 @@ class Paginator(discord.ui.View):
             self.update_custom_view(page_content.custom_view)
 
         if isinstance(message, discord.Interaction):
-            self.user = message.user  # type: ignore
+            self.user = message.user
         elif isinstance(message, (discord.Message, discord.PartialMessage)):
             if not isinstance(user, (discord.User, discord.Member)):
                 raise TypeError(

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from typing import List, overload
 
 import discord
-from discord.ext.bridge import BridgeApplicationContext, BridgeExtContext, BridgeContext
+from discord.ext.bridge import BridgeApplicationContext, BridgeContext, BridgeExtContext
 from discord.ext.commands import Context
 
 __all__ = (

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1042,7 +1042,7 @@ class Paginator(discord.ui.View):
 
         Parameters
         ----------
-        target: Union[:class:`~discord.Message`, :class:`~discord.Interaction`, :class:`~discord.ApplicationContext`, :class:`~discord.ext.bridge.BridgeContext`]
+        target: Union[:class:`~discord.PartialMessage`, :class:`~discord.Message`, :class:`~discord.Interaction`, :class:`~discord.ApplicationContext`, :class:`~discord.ext.bridge.BridgeContext`]
             The target to edit.
         suppress: :class:`bool`
             Whether to suppress embeds for the message. This removes

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1024,7 +1024,8 @@ class Paginator(discord.ui.View):
 
     async def edit(
         self,
-        target: discord.Message
+        target: discord.PartialMessage
+        | discord.Message
         | discord.Interaction
         | discord.ApplicationContext
         | BridgeContext,

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1145,6 +1145,7 @@ class Paginator(discord.ui.View):
             self.user = message.author
 
         try:
+            # pyright thinks the return type of this method can't be assigned to Message attribute for some reason
             self.message = await message.edit(  # type: ignore
                 content=page_content.content,
                 embeds=page_content.embeds,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Allows the Paginator to be sent using the edit methods offered by `Interaction`, `ApplicationContext`, and `BridgeContext`.

Also fixes #1877 by adding a new parameter `user`, when passing a `Message` object. 

`paginator.edit()` didn't work at all, because `paginator.user` was being set to `message.author`. But `message.author` will always be the bot itself, since it can edit that message. This caused the views to not respond, unless `author_check` was disabled. This means a user would need be to be explicitly accepted while calling `paginator.edit()`, thus the new parameter.


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
