### PR TITLE
fix: Flags again...

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -33,6 +33,11 @@ from typing import TYPE_CHECKING, Any, Iterator, Literal, Pattern, TypeVar, Unio
 
 from discord.utils import MISSING, MissingField, maybe_coroutine, resolve_annotation
 
+if sys.version_info >= (3, 11):
+    _MISSING = MissingField
+else:
+    _MISSING = MISSING
+
 from .converter import run_converters
 from .errors import (
     BadFlagArgument,
@@ -81,13 +86,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = MISSING
+    name: str = _MISSING
     aliases: list[str] = field(default_factory=list)
-    attribute: str = MISSING
-    annotation: Any = MISSING
-    default: Any = MISSING
-    max_args: int = MISSING
-    override: bool = MISSING
+    attribute: str = _MISSING
+    annotation: Any = _MISSING
+    default: Any = _MISSING
+    max_args: int = _MISSING
+    override: bool = _MISSING
     cast_to_dict: bool = False
 
     @property


### PR DESCRIPTION
## Summary

Gives up trying to unify MISSING types by doing a version check instead
**Not tested yet**, just putting this out there because master is broken again for py3.11 due to #1806 
Hopefully closes #2110 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
