### PR TITLE
feat: Add slowmode_delay attribute to discord.VoiceChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2206](https://github.com/Pycord-Development/pycord/pull/2206))
 - Added function `Guild.delete_auto_moderation_rule`.
   ([#2153](https://github.com/Pycord-Development/pycord/pull/2153))
-- Added `slowmode_delay` support to `VoiceChannel`.
+- Added `VoiceChannel.slowmode_delay`.
   ([#2112](https://github.com/Pycord-Development/pycord/pull/2112))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2102](https://github.com/Pycord-Development/pycord/pull/2102))
 - Added `slowmode_delay` attribute to `discord.VoiceChannel`.
   ([#2112](https://github.com/Pycord-Development/pycord/pull/2112))
+
 ### Changed
 
 - Suppressed FFMPEG output when recording voice channels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2206](https://github.com/Pycord-Development/pycord/pull/2206))
 - Added function `Guild.delete_auto_moderation_rule`.
   ([#2153](https://github.com/Pycord-Development/pycord/pull/2153))
-- Added `slowmode_delay` attribute to `discord.VoiceChannel`.
+- Added `slowmode_delay` support to `VoiceChannel`.
   ([#2112](https://github.com/Pycord-Development/pycord/pull/2112))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,6 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2102](https://github.com/Pycord-Development/pycord/pull/2102))
 - Added `bridge.Context` as a shortcut to `Union` of subclasses.
   ([#2106](https://github.com/Pycord-Development/pycord/pull/2106))
-- Added `slowmode_delay` attribute to `discord.VoiceChannel`.
-  ([#2112](https://github.com/Pycord-Development/pycord/pull/2112))
 - Added Annotated forms support for type-hinting slash command options.
   ([#2124](https://github.com/Pycord-Development/pycord/pull/2124))
 - Added `suppress` and `allowed_mentions` parameters to `Webhook` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2086](https://github.com/Pycord-Development/pycord/pull/2086))
 - Added new embedded activities, Gartic Phone and Jamspace.
   ([#2102](https://github.com/Pycord-Development/pycord/pull/2102))
-
+- Added `slowmode_delay` attribute to `discord.VoiceChannel`.
+  ([#2112](https://github.com/Pycord-Development/pycord/pull/2112))
 ### Changed
 
 - Suppressed FFMPEG output when recording voice channels.

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1329,7 +1329,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
         "user_limit",
         "_state",
         "position",
-        'slowmode_delay',
+        "slowmode_delay",
         "_overwrites",
         "category_id",
         "rtc_region",
@@ -1377,7 +1377,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
                 data, "last_message_id"
             )
             self.position: int = data.get("position")
-            self.slowmode_delay = data.get('rate_limit_per_user', 0)
+            self.slowmode_delay = data.get("rate_limit_per_user", 0)
             self.bitrate: int = data.get("bitrate")
             self.user_limit: int = data.get("user_limit")
             self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
@@ -1483,7 +1483,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         .. versionadded:: 2.0
     last_message_id: Optional[:class:`int`]
         The ID of the last message sent to this channel. It may not always point to an existing or valid message.
-    
+
     slowmode_delay: :class:`int`
         The number of seconds a member must wait between sending messages
         in this channel. A value of `0` denotes that it is disabled.

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1484,12 +1484,13 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
     last_message_id: Optional[:class:`int`]
         The ID of the last message sent to this channel. It may not always point to an existing or valid message.
 
+        .. versionadded:: 2.0
     slowmode_delay: :class:`int`
         The number of seconds a member must wait between sending messages
         in this channel. A value of `0` denotes that it is disabled.
         Bots and users with :attr:`~Permissions.manage_channels` or
         :attr:`~Permissions.manage_messages` bypass slowmode.
-
+        
         .. versionadded:: 2.5
     flags: :class:`ChannelFlags`
         Extra features of the channel.

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1490,7 +1490,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         in this channel. A value of `0` denotes that it is disabled.
         Bots and users with :attr:`~Permissions.manage_channels` or
         :attr:`~Permissions.manage_messages` bypass slowmode.
-        
+
         .. versionadded:: 2.5
     flags: :class:`ChannelFlags`
         Extra features of the channel.

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1490,7 +1490,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         Bots and users with :attr:`~Permissions.manage_channels` or
         :attr:`~Permissions.manage_messages` bypass slowmode.
 
-        .. versionadded:: 2.0
+        .. versionadded:: 2.5
     flags: :class:`ChannelFlags`
         Extra features of the channel.
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1329,6 +1329,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
         "user_limit",
         "_state",
         "position",
+        'slowmode_delay',
         "_overwrites",
         "category_id",
         "rtc_region",
@@ -1376,6 +1377,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
                 data, "last_message_id"
             )
             self.position: int = data.get("position")
+            self.slowmode_delay = data.get('rate_limit_per_user', 0)
             self.bitrate: int = data.get("bitrate")
             self.user_limit: int = data.get("user_limit")
             self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
@@ -1481,6 +1483,12 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         .. versionadded:: 2.0
     last_message_id: Optional[:class:`int`]
         The ID of the last message sent to this channel. It may not always point to an existing or valid message.
+    
+    slowmode_delay: :class:`int`
+        The number of seconds a member must wait between sending messages
+        in this channel. A value of `0` denotes that it is disabled.
+        Bots and users with :attr:`~Permissions.manage_channels` or
+        :attr:`~Permissions.manage_messages` bypass slowmode.
 
         .. versionadded:: 2.0
     flags: :class:`ChannelFlags`
@@ -1791,6 +1799,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         overwrites: Mapping[Role | Member, PermissionOverwrite] = ...,
         rtc_region: VoiceRegion | None = ...,
         video_quality_mode: VideoQualityMode = ...,
+        slowmode_delay: int = ...,
         reason: str | None = ...,
     ) -> VoiceChannel | None:
         ...


### PR DESCRIPTION
## Summary

This PR added a new attribute for the `discord.VoiceChannel` which's `slowmode_delay` while it was missing, doc-strings has been updated.

## Information

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made, then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.