### PR TITLE
docs: added get_ command return statement why they may return NoneType

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -881,7 +881,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_channel(id)
 
@@ -964,7 +964,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection._get_guild(id)
 
@@ -983,7 +983,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_user` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_user(id)
 
@@ -1019,7 +1019,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_sticker(id)
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -879,7 +879,7 @@ class Client:
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.client.fetch_channel` version of this command won't return ``None``, however it makes an API call.
         """
@@ -962,7 +962,7 @@ class Client:
         Optional[:class:`.Guild`]
             The guild or ``None`` if not found.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.client.fetch_guild` version of this command won't return ``None``, however it makes an API call.
         """
@@ -981,7 +981,7 @@ class Client:
         Optional[:class:`~discord.User`]
             The user or ``None`` if not found.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.client.fetch_user` version of this command won't return ``None``, however it makes an API call.
         """
@@ -1017,7 +1017,7 @@ class Client:
         Optional[:class:`.GuildSticker`]
             The sticker or ``None`` if not found.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.client.fetch_sticker` version of this command won't return ``None``, however it makes an API call.
         """

--- a/discord/client.py
+++ b/discord/client.py
@@ -980,8 +980,10 @@ class Client:
         -------
         Optional[:class:`~discord.User`]
             The user or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.client.fetch_user` version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.client.fetch_user` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_user(id)
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -984,7 +984,7 @@ class Client:
             The user or ``None`` if not found.
 
             .. note::
-            
+
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
         """

--- a/discord/client.py
+++ b/discord/client.py
@@ -882,6 +882,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the channel from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_channel(id)
@@ -966,6 +967,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the guild from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection._get_guild(id)
@@ -986,6 +988,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the user from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_user(id)
@@ -1023,6 +1026,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the sticker from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_sticker(id)

--- a/discord/client.py
+++ b/discord/client.py
@@ -1012,6 +1012,8 @@ class Client:
         -------
         Optional[:class:`.GuildSticker`]
             The sticker or ``None`` if not found.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_sticker(id)
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -879,9 +879,10 @@ class Client:
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_channel(id)
 
@@ -962,9 +963,10 @@ class Client:
         Optional[:class:`.Guild`]
             The guild or ``None`` if not found.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection._get_guild(id)
 
@@ -981,9 +983,10 @@ class Client:
         Optional[:class:`~discord.User`]
             The user or ``None`` if not found.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+            
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_user(id)
 
@@ -1017,9 +1020,10 @@ class Client:
         Optional[:class:`.GuildSticker`]
             The sticker or ``None`` if not found.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_sticker(id)
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -882,7 +882,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the channel from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_channel(id)

--- a/discord/client.py
+++ b/discord/client.py
@@ -878,6 +878,8 @@ class Client:
         -------
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_channel(id)
 
@@ -896,6 +898,8 @@ class Client:
         -------
         Optional[:class:`.Message`]
             The returned message or ``None`` if not found.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection._get_message(id)
 
@@ -957,6 +961,8 @@ class Client:
         -------
         Optional[:class:`.Guild`]
             The guild or ``None`` if not found.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection._get_guild(id)
 
@@ -972,6 +978,8 @@ class Client:
         -------
         Optional[:class:`~discord.User`]
             The user or ``None`` if not found.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_user(id)
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -967,7 +967,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the guild from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection._get_guild(id)
@@ -988,7 +988,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the user from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_user(id)
@@ -1026,7 +1026,7 @@ class Client:
             .. note::
 
                 It may return ``None`` because it tries to retrieve the sticker from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_sticker(id)

--- a/discord/client.py
+++ b/discord/client.py
@@ -881,7 +881,7 @@ class Client:
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve the channel from the cache.
                 The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_channel(id)
@@ -965,7 +965,7 @@ class Client:
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve the guild from the cache.
                 The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection._get_guild(id)
@@ -985,7 +985,7 @@ class Client:
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve the user from the cache.
                 The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_user(id)
@@ -1022,7 +1022,7 @@ class Client:
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve the sticker from the cache.
                 The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_sticker(id)

--- a/discord/client.py
+++ b/discord/client.py
@@ -879,9 +879,9 @@ class Client:
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_channel(id)
 
@@ -962,9 +962,9 @@ class Client:
         Optional[:class:`.Guild`]
             The guild or ``None`` if not found.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection._get_guild(id)
 
@@ -981,9 +981,9 @@ class Client:
         Optional[:class:`~discord.User`]
             The user or ``None`` if not found.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.Client.fetch_user` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_user(id)
 
@@ -1017,9 +1017,9 @@ class Client:
         Optional[:class:`.GuildSticker`]
             The sticker or ``None`` if not found.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._connection.get_sticker(id)
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -878,8 +878,10 @@ class Client:
         -------
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.client.fetch_channel` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_channel(id)
 
@@ -898,8 +900,6 @@ class Client:
         -------
         Optional[:class:`.Message`]
             The returned message or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection._get_message(id)
 
@@ -961,8 +961,10 @@ class Client:
         -------
         Optional[:class:`.Guild`]
             The guild or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.client.fetch_guild` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection._get_guild(id)
 
@@ -979,7 +981,7 @@ class Client:
         Optional[:class:`~discord.User`]
             The user or ``None`` if not found.
             It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+            The :meth:`.client.fetch_user` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_user(id)
 
@@ -1012,8 +1014,10 @@ class Client:
         -------
         Optional[:class:`.GuildSticker`]
             The sticker or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.client.fetch_sticker` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_sticker(id)
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -881,7 +881,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.client.fetch_channel` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_channel` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_channel(id)
 
@@ -964,7 +964,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.client.fetch_guild` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_guild` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection._get_guild(id)
 
@@ -983,7 +983,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.client.fetch_user` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_user` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_user(id)
 
@@ -1019,7 +1019,7 @@ class Client:
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.client.fetch_sticker` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.Client.fetch_sticker` version of this command won't return ``None``, however it makes an API call.
         """
         return self._connection.get_sticker(id)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -745,7 +745,9 @@ class Guild(Hashable):
         Returns
         -------
         Optional[:class:`.abc.GuildChannel`]
-            The returned channel or ``None`` if not found.
+            The returned channel or ``None`` if not found. 
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._channels.get(channel_id)
 
@@ -854,6 +856,8 @@ class Guild(Hashable):
         -------
         Optional[:class:`Member`]
             The member or ``None`` if not found.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._members.get(user_id)
 
@@ -883,6 +887,8 @@ class Guild(Hashable):
         -------
         Optional[:class:`Role`]
             The role or ``None`` if not found.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self._roles.get(role_id)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -747,9 +747,10 @@ class Guild(Hashable):
         Optional[:class:`.abc.GuildChannel`]
             The returned channel or ``None`` if not found.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._channels.get(channel_id)
 
@@ -859,9 +860,10 @@ class Guild(Hashable):
         Optional[:class:`Member`]
             The member or ``None`` if not found.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+            
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._members.get(user_id)
 
@@ -892,9 +894,10 @@ class Guild(Hashable):
         Optional[:class:`Role`]
             The role or ``None`` if not found.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._roles.get(role_id)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -745,7 +745,7 @@ class Guild(Hashable):
         Returns
         -------
         Optional[:class:`.abc.GuildChannel`]
-            The returned channel or ``None`` if not found. 
+            The returned channel or ``None`` if not found.
             It may return ``None`` because it retrieves from the cache.
             The fetch_ version of this command won't return ``None``, however it makes an API call.
         """

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -747,9 +747,9 @@ class Guild(Hashable):
         Optional[:class:`.abc.GuildChannel`]
             The returned channel or ``None`` if not found.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._channels.get(channel_id)
 
@@ -859,9 +859,9 @@ class Guild(Hashable):
         Optional[:class:`Member`]
             The member or ``None`` if not found.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._members.get(user_id)
 
@@ -892,9 +892,9 @@ class Guild(Hashable):
         Optional[:class:`Role`]
             The role or ``None`` if not found.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._roles.get(role_id)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -749,7 +749,7 @@ class Guild(Hashable):
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._channels.get(channel_id)
 
@@ -861,7 +861,7 @@ class Guild(Hashable):
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild.fetch_member` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._members.get(user_id)
 
@@ -894,7 +894,7 @@ class Guild(Hashable):
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._roles.get(role_id)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -746,8 +746,10 @@ class Guild(Hashable):
         -------
         Optional[:class:`.abc.GuildChannel`]
             The returned channel or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however it makes an API call.
         """
         return self._channels.get(channel_id)
 
@@ -856,8 +858,10 @@ class Guild(Hashable):
         -------
         Optional[:class:`Member`]
             The member or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild.fetch_member` version of this command won't return ``None``, however it makes an API call.
         """
         return self._members.get(user_id)
 
@@ -887,8 +891,10 @@ class Guild(Hashable):
         -------
         Optional[:class:`Role`]
             The role or ``None`` if not found.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however it makes an API call.
         """
         return self._roles.get(role_id)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -750,6 +750,7 @@ class Guild(Hashable):
             .. note::
 
                 It may return ``None`` because it tries to retrieve the channel from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._channels.get(channel_id)
@@ -863,6 +864,7 @@ class Guild(Hashable):
             .. note::
 
                 It may return ``None`` because it tries to retrieve member from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._members.get(user_id)
@@ -897,6 +899,7 @@ class Guild(Hashable):
             .. note::
 
                 It may return ``None`` because it tries to retrieve the role from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._roles.get(role_id)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -750,7 +750,7 @@ class Guild(Hashable):
             .. note::
 
                 It may return ``None`` because it tries to retrieve the channel from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._channels.get(channel_id)
@@ -864,7 +864,7 @@ class Guild(Hashable):
             .. note::
 
                 It may return ``None`` because it tries to retrieve member from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._members.get(user_id)
@@ -899,7 +899,7 @@ class Guild(Hashable):
             .. note::
 
                 It may return ``None`` because it tries to retrieve the role from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._roles.get(role_id)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -749,7 +749,7 @@ class Guild(Hashable):
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve the channel from the cache.
                 The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._channels.get(channel_id)
@@ -862,7 +862,7 @@ class Guild(Hashable):
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve member from the cache.
                 The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._members.get(user_id)
@@ -896,7 +896,7 @@ class Guild(Hashable):
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve the role from the cache.
                 The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however, it makes an API call.
         """
         return self._roles.get(role_id)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -861,7 +861,7 @@ class Guild(Hashable):
             The member or ``None`` if not found.
 
             .. note::
-            
+
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.guild.fetch_member` version of this command won't return ``None``, however, it makes an API call.
         """

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -747,7 +747,7 @@ class Guild(Hashable):
         Optional[:class:`.abc.GuildChannel`]
             The returned channel or ``None`` if not found.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.guild.fetch_channel` version of this command won't return ``None``, however it makes an API call.
         """
@@ -859,7 +859,7 @@ class Guild(Hashable):
         Optional[:class:`Member`]
             The member or ``None`` if not found.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.guild.fetch_member` version of this command won't return ``None``, however it makes an API call.
         """
@@ -892,7 +892,7 @@ class Guild(Hashable):
         Optional[:class:`Role`]
             The role or ``None`` if not found.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.guild.fetch_roles` version of this command won't return ``None``, however it makes an API call.
         """

--- a/discord/member.py
+++ b/discord/member.py
@@ -1092,6 +1092,6 @@ class Member(discord.abc.Messageable, _UserTag):
 
             ..note::
                 It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however it makes an API call.
+                The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1091,7 +1091,7 @@ class Member(discord.abc.Messageable, _UserTag):
             The role or ``None`` if not found in the member's roles.
 
             .. note::
-            
+
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
         """

--- a/discord/member.py
+++ b/discord/member.py
@@ -1089,7 +1089,9 @@ class Member(discord.abc.Messageable, _UserTag):
         -------
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
-            It may return ``None`` because it retrieves from the cache.
-            The fetch_ version of this command won't return ``None``, however it makes an API call.
+
+            ..note
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1093,6 +1093,7 @@ class Member(discord.abc.Messageable, _UserTag):
             .. note::
 
                 It may return ``None`` because it tries to retrieve the role from the cache.
+                It may not be in the cache because of intents or because of when the command was run.
                 The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1090,8 +1090,9 @@ class Member(discord.abc.Messageable, _UserTag):
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
 
-        ..note::
-            It may return ``None`` because it retrieves from the cache.
-            The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
+            .. note::
+            
+                It may return ``None`` because it retrieves from the cache.
+                The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1093,7 +1093,7 @@ class Member(discord.abc.Messageable, _UserTag):
             .. note::
 
                 It may return ``None`` because it tries to retrieve the role from the cache.
-                It may not be in the cache because of intents or because of when the command was run.
+                It may not be in the cache because of intents or because of when the method was run.
                 The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1090,8 +1090,8 @@ class Member(discord.abc.Messageable, _UserTag):
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
 
-            ..note::
-                It may return ``None`` because it retrieves from the cache.
-                The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
+        ..note::
+            It may return ``None`` because it retrieves from the cache.
+            The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1092,7 +1092,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
             .. note::
 
-                It may return ``None`` because it retrieves from the cache.
+                It may return ``None`` because it tries to retrieve the role from the cache.
                 The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however, it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1089,5 +1089,7 @@ class Member(discord.abc.Messageable, _UserTag):
         -------
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
+            It may return ``None`` because it retrieves from the cache.
+            The fetch_ version of this command won't return ``None``, however it makes an API call.
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None

--- a/discord/member.py
+++ b/discord/member.py
@@ -1090,7 +1090,7 @@ class Member(discord.abc.Messageable, _UserTag):
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
 
-            ..note
+            ..note::
                 It may return ``None`` because it retrieves from the cache.
                 The :meth:`.guild._fetch_role` (you'll still have to check for users with :attr:`.role.members`) version of this command won't return ``None``, however it makes an API call.
         """


### PR DESCRIPTION
## Summary

This pull request fixes the issue of the confusion on why get_ commands may return None. This message also points to fetch_ commands if get_ commands return None. It's not documented anywhere else that it retrieves from the cache, so it can be refered to in things like Stackoverflow posts and help channels.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
