### PR TITLE
Handle typing annotated

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -35,6 +35,7 @@ from collections import OrderedDict
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Callable,
     Coroutine,
@@ -42,6 +43,8 @@ from typing import (
     Generic,
     TypeVar,
     Union,
+    get_origin,
+    get_args
 )
 
 from ..channel import _threaded_guild_channel_factory
@@ -731,6 +734,20 @@ class SlashCommand(ApplicationCommand):
             option = p_obj.annotation
             if option == inspect.Parameter.empty:
                 option = str
+            
+            if self._is_typing_annotated(option):
+                type_hint = get_args(option)[0]
+                metadata = option.__metadata__
+                # If multiple Options in metadata, the first will be used.
+                option_gen = (elem for elem in metadata if isinstance(elem, Option))
+                option = next(option_gen, Option())
+                # Handle Optional
+                if self._is_typing_optional(type_hint):
+                    option.input_type = get_args(type_hint)[0]
+                    option.default = None
+                else:
+                    option.input_type = type_hint
+
 
             if self._is_typing_union(option):
                 if self._is_typing_optional(option):
@@ -819,6 +836,9 @@ class SlashCommand(ApplicationCommand):
 
     def _is_typing_optional(self, annotation):
         return self._is_typing_union(annotation) and type(None) in annotation.__args__  # type: ignore
+    
+    def _is_typing_annotated(self, annotation):
+        return get_origin(annotation) is Annotated
 
     @property
     def cog(self):

--- a/tests/test_typing_annotated.py
+++ b/tests/test_typing_annotated.py
@@ -1,0 +1,69 @@
+from typing import Annotated, Optional
+
+import pytest
+
+import discord
+from discord import ApplicationContext
+from discord.commands.core import SlashCommand, slash_command
+
+def test_typing_annotated():
+    async def echo(ctx, txt: Annotated[str, discord.Option()]):
+        await ctx.respond(txt)
+    cmd = SlashCommand(echo)
+    bot = discord.Bot()
+    bot.add_application_command(cmd)
+
+def test_typing_annotated_decorator():
+    bot = discord.Bot()
+    @bot.slash_command()
+    async def echo(ctx, txt: Annotated[str, discord.Option(description='Some text')]):
+        await ctx.respond(txt)
+
+        
+def test_typing_annotated_cog():
+    class echoCog(discord.Cog):
+        def __init__(self, bot_) -> None:
+            self.bot = bot_
+            super().__init__()
+
+        @slash_command()
+        async def echo(self, ctx, txt: Annotated[str, discord.Option(description='Some text')]):
+            await ctx.respond(txt)
+
+    bot = discord.Bot()
+    bot.add_cog(echoCog(bot))
+
+def test_typing_annotated_cog_slashgroup():
+    class echoCog(discord.Cog):
+        grp = discord.commands.SlashCommandGroup('echo')
+        def __init__(self, bot_) -> None:
+            self.bot = bot_
+            super().__init__()
+
+        @grp.command()
+        async def echo(self, ctx, txt: Annotated[str, discord.Option(description='Some text')]):
+            await ctx.respond(txt)
+
+    bot = discord.Bot()
+    bot.add_cog(echoCog(bot))
+
+def test_typing_annotated_optional():
+    async def echo(ctx, txt: Annotated[Optional[str], discord.Option()]):
+        await ctx.respond(txt)
+    cmd = SlashCommand(echo)
+    bot = discord.Bot()
+    bot.add_application_command(cmd)
+
+def test_no_annotation():
+    async def echo(ctx, txt: str):
+        await ctx.respond(txt)
+    cmd = SlashCommand(echo)
+    bot = discord.Bot()
+    bot.add_application_command(cmd)
+
+def test_annotated_no_option():
+    async def echo(ctx, txt: Annotated[str, "..."]):
+        await ctx.respond(txt)
+    cmd = SlashCommand(echo)
+    bot = discord.Bot()
+    bot.add_application_command(cmd)


### PR DESCRIPTION
## Summary

Resolves #2120. These changes allow options definitions of the form:
```python
some_int: Annotated[int, Option(description="Tell me an integer")]
``` 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x ] I have searched the open pull requests for duplicates.
- [x ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
