### PR TITLE
fix: Correct regression from pull #2124

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -30,6 +30,7 @@ import datetime
 import functools
 import inspect
 import re
+import sys
 import types
 from collections import OrderedDict
 from enum import Enum
@@ -43,8 +44,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
-from typing_extensions import Annotated, get_args, get_origin
 
 from ..channel import _threaded_guild_channel_factory
 from ..enums import Enum as DiscordEnum
@@ -65,6 +64,11 @@ from ..user import User
 from ..utils import MISSING, async_all, find, maybe_coroutine, utcnow
 from .context import ApplicationContext, AutocompleteContext
 from .options import Option, OptionChoice
+
+if sys.version_info >= (3, 11):
+    from typing import Annotated, get_args, get_origin
+else:
+    from typing_extensions import Annotated, get_args, get_origin
 
 __all__ = (
     "_BaseCommand",


### PR DESCRIPTION
## Summary
Pycord requires typing_extensions as a dependency for python < 3.11, however not on version >= 3.11. Because the changes in the referenced pull always tries to load from typing_extensions, they make it so an exception will be raised if the end user is using python >= 3.11 and does not otherwise have that library installed when _parse_options is run (ie, whenever a command is registered).

This change checks the version of python running Pycord, then imports stdlib typing if >= 3.11.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (N/A?)
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes. (N/A?)
