### PR TITLE
feat: Implement Onboarding features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2178](https://github.com/Pycord-Development/pycord/pull/2178))
 - Added `applied_tags` parameter to `Webhook.send()` method.
   ([#2322](https://github.com/Pycord-Development/pycord/pull/2322))
-- Fully implemented Onboarding related features.
+- Added support for guild onboarding related features.
   ([#2127](https://github.com/Pycord-Development/pycord/pull/2127))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2178](https://github.com/Pycord-Development/pycord/pull/2178))
 - Added `applied_tags` parameter to `Webhook.send()` method.
   ([#2322](https://github.com/Pycord-Development/pycord/pull/2322))
+- Fully implemented Onboarding related features.
+  ([#2127](https://github.com/Pycord-Development/pycord/pull/2127))
 
 ### Changed
 

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -53,6 +53,7 @@ from .member import *
 from .mentions import *
 from .message import *
 from .object import *
+from .onboarding import *
 from .partial_emoji import *
 from .permissions import *
 from .player import *

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -939,6 +939,17 @@ class ApplicationRoleConnectionMetadataType(Enum):
     boolean_equal = 7
     boolean_not_equal = 8
 
+class PromptType(Enum):
+    """Guild Onboarding Prompt Type"""
+
+    multiple_choice = 0
+    dropdown = 1
+
+class OnboardingMode(Enum):
+    """Guild Onboarding Mode"""
+
+    default = 0
+    advanced = 1
 
 T = TypeVar("T")
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -496,7 +496,7 @@ class AuditLogAction(Enum):
             AuditLogAction.onboarding_question_update: AuditLogActionCategory.update,
             AuditLogAction.onboarding_update: AuditLogActionCategory.update,
             AuditLogAction.server_guide_create: AuditLogActionCategory.create,
-            AuditLogAction.server_guide_update: AuditLogActionCategory.update
+            AuditLogAction.server_guide_update: AuditLogActionCategory.update,
         }
         return lookup[self]
 
@@ -953,17 +953,20 @@ class ApplicationRoleConnectionMetadataType(Enum):
     boolean_equal = 7
     boolean_not_equal = 8
 
+
 class PromptType(Enum):
     """Guild Onboarding Prompt Type"""
 
     multiple_choice = 0
     dropdown = 1
 
+
 class OnboardingMode(Enum):
     """Guild Onboarding Mode"""
 
     default = 0
     advanced = 1
+
 
 T = TypeVar("T")
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -542,8 +542,12 @@ class AuditLogAction(Enum):
             return "application_command_permission"
         elif v < 146:
             return "auto_moderation_rule"
+        elif v < 152:
+            return "monetization"
         elif v < 168:
             return "onboarding"
+        elif v < 192:
+            return "server_guide"
 
 
 class UserFlags(Enum):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -67,6 +67,8 @@ __all__ = (
     "AutoModActionType",
     "AutoModKeywordPresetType",
     "ApplicationRoleConnectionMetadataType",
+    "PromptType",
+    "OnboardingMode",
 )
 
 
@@ -425,6 +427,11 @@ class AuditLogAction(Enum):
     auto_moderation_block_message = 143
     auto_moderation_flag_to_channel = 144
     auto_moderation_user_communication_disabled = 145
+    onboarding_question_create = 163
+    onboarding_question_update = 164
+    onboarding_update = 165
+    server_guide_create = 190
+    server_guide_update = 191
 
     @property
     def category(self) -> AuditLogActionCategory | None:
@@ -485,6 +492,11 @@ class AuditLogAction(Enum):
             AuditLogAction.auto_moderation_block_message: None,
             AuditLogAction.auto_moderation_flag_to_channel: None,
             AuditLogAction.auto_moderation_user_communication_disabled: None,
+            AuditLogAction.onboarding_question_create: AuditLogActionCategory.create,
+            AuditLogAction.onboarding_question_update: AuditLogActionCategory.update,
+            AuditLogAction.onboarding_update: AuditLogActionCategory.update,
+            AuditLogAction.server_guide_create: AuditLogActionCategory.create,
+            AuditLogAction.server_guide_update: AuditLogActionCategory.update
         }
         return lookup[self]
 
@@ -525,6 +537,8 @@ class AuditLogAction(Enum):
             return "application_command_permission"
         elif v < 146:
             return "auto_moderation_rule"
+        elif v < 168:
+            return "onboarding"
 
 
 class UserFlags(Enum):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -432,7 +432,7 @@ class AuditLogAction(Enum):
     creator_monetization_terms_accepted = 151
     onboarding_question_create = 163
     onboarding_question_update = 164
-    onboarding_update = 165
+    onboarding_update = 167
     server_guide_create = 190
     server_guide_update = 191
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -973,6 +973,7 @@ class OnboardingMode(Enum):
     default = 0
     advanced = 1
 
+
 class ReactionType(Enum):
     """The reaction type"""
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3845,3 +3845,55 @@ class Guild(Hashable):
         """
         data = await self._state.http.get_onboarding(self.id)
         return Onboarding(data=data, guild=self)
+
+    async def edit_onboarding(self, **options):
+        """|coro|
+
+        A shorthand for :attr:`Onboarding.edit` without fetching the onboarding flow.
+
+        You must have the :attr:`~Permissions.manage_guild` and :attr:`~Permissions.manage_roles` permissions in the
+        guild to do this.
+
+        Parameters
+        ----------
+
+        prompts: Optional[List[:class:`OnboardingPrompt`]]
+            The new list of prompts for this flow.
+        default_channels: Optional[List[:class:`Snowflake`]]
+            The new default channels that users are opted into.
+        enabled: Optional[:class:`bool`]
+            Whether onboarding should be enabled.
+        mode: Optional[:class:`OnboardingMode`]
+            The new onboarding mode. 
+        reason: Optional[:class:`str`]
+            The reason that shows up on Audit log.
+
+        Raises
+        ------
+
+        HTTPException
+            Editing the onboarding flow failed somehow.
+        Forbidden
+            You don't have permissions to edit the onboarding flow.
+        NotFound
+            This onboarding flow does not exist.
+        """
+
+        fields: dict[str, Any] = {}
+        if prompts is not MISSING:
+            fields["prompts"] = [prompt.to_dict() for prompt in prompts]
+
+        if default_channels is not MISSING:
+            fields["default_channel_ids"] = [channel.id for channel in default_channels]
+
+        if enabled is not MISSING:
+            fields["enabled"] = enabled
+
+        if mode is not MISSING:
+            fields["mode"] = mode.value
+
+        new = await self._state.http.edit_onboarding(
+            self.id, fields, reason=reason
+        )
+
+        return Onboarding(data=new, guild=self)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3868,7 +3868,8 @@ class Guild(Hashable):
         default_channels: Optional[List[:class:`Snowflake`]]
             The new default channels that users are opted into.
         enabled: Optional[:class:`bool`]
-            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`.
+            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`
+            and at least 7 ``default_channels``.
         mode: Optional[:class:`OnboardingMode`]
             The new onboarding mode. 
         reason: Optional[:class:`str`]

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3844,7 +3844,15 @@ class Guild(Hashable):
         data = await self._state.http.get_onboarding(self.id)
         return Onboarding(data=data, guild=self)
 
-    async def edit_onboarding(self, **options):
+    async def edit_onboarding(
+        self,
+        *,
+        prompts: list[OnboardingPrompt] | None = MISSING,
+        default_channels: list[Snowflake] | None = MISSING,
+        enabled: bool | None = MISSING,
+        mode: OnboardingMode | None = MISSING,
+        reason: str | None = MISSING,
+    ) -> Onboarding:
         """|coro|
 
         A shorthand for :attr:`Onboarding.edit` without fetching the onboarding flow.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3922,7 +3922,6 @@ class Guild(Hashable):
             fields["mode"] = mode.value
 
         new = await self._state.http.edit_onboarding(self.id, fields, reason=reason)
-
         return Onboarding(data=new, guild=self)
 
     async def delete_auto_moderation_rule(

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3894,6 +3894,11 @@ class Guild(Hashable):
         reason: Optional[:class:`str`]
             The reason that shows up on Audit log.
 
+        Returns
+        -------
+        :class:`Onboarding`
+            The updated onboarding flow.
+
         Raises
         ------
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3887,8 +3887,9 @@ class Guild(Hashable):
         default_channels: Optional[List[:class:`Snowflake`]]
             The new default channels that users are opted into.
         enabled: Optional[:class:`bool`]
-            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`
-            and at least 7 ``default_channels``.
+            Whether onboarding should be enabled. Setting this to ``True`` requires
+            the guild to have ``COMMUNITY`` in :attr:`~Guild.features` and at
+            least 7 ``default_channels``.
         mode: Optional[:class:`OnboardingMode`]
             The new onboarding mode.
         reason: Optional[:class:`str`]

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3838,8 +3838,6 @@ class Guild(Hashable):
         ------
         HTTPException
             Retrieving the onboarding flow failed somehow.
-        NotFound
-            The guild doesn't have onboarding or community feature is disabled.
         """
         data = await self._state.http.get_onboarding(self.id)
         return Onboarding(data=data, guild=self)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3827,8 +3827,6 @@ class Guild(Hashable):
 
         Returns the :class:`Onboarding` flow for the guild.
 
-        The guild must have ``COMMUNITY`` in :attr:`~Guild.features`.
-
         .. versionadded:: 2.5
 
         Returns
@@ -3862,7 +3860,7 @@ class Guild(Hashable):
         default_channels: Optional[List[:class:`Snowflake`]]
             The new default channels that users are opted into.
         enabled: Optional[:class:`bool`]
-            Whether onboarding should be enabled.
+            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`.
         mode: Optional[:class:`OnboardingMode`]
             The new onboarding mode. 
         reason: Optional[:class:`str`]
@@ -3875,8 +3873,6 @@ class Guild(Hashable):
             Editing the onboarding flow failed somehow.
         Forbidden
             You don't have permissions to edit the onboarding flow.
-        NotFound
-            This onboarding flow does not exist.
         """
 
         fields: dict[str, Any] = {}

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -71,6 +71,7 @@ from .invite import Invite
 from .iterators import AuditLogIterator, BanIterator, MemberIterator
 from .member import Member, VoiceState
 from .mixins import Hashable
+from .onboarding import Onboarding
 from .permissions import PermissionOverwrite
 from .role import Role
 from .scheduled_events import ScheduledEvent, ScheduledEventLocation
@@ -3820,3 +3821,27 @@ class Guild(Hashable):
             self.id, payload, reason=reason
         )
         return AutoModRule(state=self._state, data=data)
+
+    async def onboarding(self):
+        """|coro|
+
+        Returns the :class:`Onboarding` flow for the guild.
+
+        The guild must have ``COMMUNITY`` in :attr:`~Guild.features`.
+
+        .. versionadded:: 2.5
+
+        Returns
+        -------
+        :class:`Onboarding`
+            The onboarding flow for the guild.
+
+        Raises
+        ------
+        HTTPException
+            Retrieving the onboarding flow failed somehow.
+        NotFound
+            The guild doesn't have onboarding or community feature is disabled.
+        """
+        data = await self._state.http.get_onboarding(self.id)
+        return Onboarding(data=data, guild=self)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3871,7 +3871,7 @@ class Guild(Hashable):
             Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`
             and at least 7 ``default_channels``.
         mode: Optional[:class:`OnboardingMode`]
-            The new onboarding mode. 
+            The new onboarding mode.
         reason: Optional[:class:`str`]
             The reason that shows up on Audit log.
 
@@ -3897,8 +3897,6 @@ class Guild(Hashable):
         if mode is not MISSING:
             fields["mode"] = mode.value
 
-        new = await self._state.http.edit_onboarding(
-            self.id, fields, reason=reason
-        )
+        new = await self._state.http.edit_onboarding(self.id, fields, reason=reason)
 
         return Onboarding(data=new, guild=self)

--- a/discord/http.py
+++ b/discord/http.py
@@ -2878,9 +2878,7 @@ class HTTPClient:
 
     # Onboarding
 
-    def get_onboarding(
-        self, guild_id: Snowflake
-    ) -> Response[onboarding.Onboarding]:
+    def get_onboarding(self, guild_id: Snowflake) -> Response[onboarding.Onboarding]:
         return self.request(
             Route("GET", "/guilds/{guild_id}/onboarding", guild_id=guild_id)
         )

--- a/discord/http.py
+++ b/discord/http.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
         invite,
         member,
         message,
+        onboarding,
         role,
         scheduled_events,
         sticker,
@@ -2874,6 +2875,31 @@ class HTTPClient:
             application_id=application_id,
         )
         return self.request(r, json=payload)
+
+    # Onboarding
+
+    def get_onboarding(
+        self, guild_id: Snowflake
+    ) -> Response[onboarding.Onboarding]:
+        return self.request(
+            Route("GET", "/guilds/{guild_id}/onboarding", guild_id=guild_id)
+        )
+
+    def edit_onboarding(
+        self, guild_id: Snowflake, payload: Any, *, reason: str | None = None
+    ) -> Response[onboarding.Onboarding]:
+        keys = (
+            "prompts",
+            "default_channel_ids",
+            "enabled",
+            "mode",
+        )
+        payload = {key: val for key, val in payload.items() if key in keys}
+        return self.request(
+            Route("PUT", "/guilds/{guild_id}/onboarding", guild_id=guild_id),
+            json=payload,
+            reason=reason,
+        )
 
     # Misc
 

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -274,7 +274,8 @@ class Onboarding:
         default_channels: Optional[List[:class:`Snowflake`]]
             The new default channels that users are opted into.
         enabled: Optional[:class:`bool`]
-            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`.
+            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`
+            and at least 7 ``default_channels``.
         mode: Optional[:class:`OnboardingMode`]
             The new onboarding mode. 
         reason: Optional[:class:`str`]

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 from .enums import OnboardingMode, PromptType, try_enum
 from .partial_emoji import PartialEmoji
-from .utils import MISSING, _get_as_snowflake, cached_property, get, generate_snowflake
+from .utils import MISSING, _get_as_snowflake, cached_property, generate_snowflake, get
 
 if TYPE_CHECKING:
     from .abc import Snowflake
@@ -100,29 +100,21 @@ class PromptOption:
         }
         if self.emoji:
             if isinstance(self.emoji, str):
-                dict_["emoji"] = {
-                    'id': None,
-                    'name': self.emoji,
-                    'animated': False
-                }
+                dict_["emoji"] = {"id": None, "name": self.emoji, "animated": False}
                 dict_["emoji_name"] = self.emoji
                 dict_["emoji_id"] = None
                 dict_["emoji_animated"] = False
             else:
                 dict_["emoji"] = {
-                    'id': self.emoji.id,
-                    'name': self.emoji.name,
-                    'animated': self.emoji.is_animated
+                    "id": self.emoji.id,
+                    "name": self.emoji.name,
+                    "animated": self.emoji.is_animated,
                 }
                 dict_["emoji_name"] = self.emoji.name
                 dict_["emoji_id"] = self.emoji.id
                 dict_["emoji_animated"] = self.emoji.is_animated
         else:
-            dict_["emoji"] = {
-                "id": None,
-                "name": None,
-                "animated": False
-            }
+            dict_["emoji"] = {"id": None, "name": None, "animated": False}
             dict_["emoji_name"] = None
             dict_["emoji_id"] = None
             dict_["emoji_animated"] = False

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -47,7 +47,7 @@ __all__ = (
 )
 
 class PromptOption:
-    """Represents an onboarding prompt displayed in :class:`Onboarding`
+    """Represents an onboarding prompt option displayed in :class:`OnboardingPrompt`
 
     .. versionadded:: 2.5
 

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -1,0 +1,251 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Pycord Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, overload
+
+from .partial_emoji import _EmojiTag
+from .utils import _get_as_snowflake, get
+from .enums import PromptType, OnboardingMode, try_enum
+
+if TYPE_CHECKING:
+    from .abc import Snowflake
+    from .emoji import Emoji
+    from .guild import Guild
+    from .partial_emoji import PartialEmoji
+    from .types.onboarding import Onboarding as OnboardingPayload
+    from .types.onboarding import OnboardingPrompt as OnboardingPromptPayload
+    from .types.onboarding import PromptOption as PromptOptionPayload
+
+__all__ = (
+    "Onboarding",
+    "OnboardingPrompt",
+    "PromptOption",
+    "PromptType",
+)
+
+class PromptOption:
+    """Represents an onboarding prompt displayed in :class:`Onboarding`
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+
+    id: :class:`int`
+        The id of the prompt option.
+    channels: List[:class:`Snowflake`]
+        The channels assigned to the user when they select this option.
+    roles: List[:class:`Snowflake`]
+        The roles assigned to the user when they select this option.
+    emoji: :class:`Emoji`
+        The emoji displayed with the option.
+    title: :class`str`
+        The option's title.
+    description: Optional[:class:`str`]
+        The option's description.
+    """
+
+    def __init__(
+        self,
+        title: str
+        channels: list[Snowflake] | None = None,
+        roles: list[Snowflake] | None = None,
+        description: str | None = None,
+        emoji: Emoji | PartialEmoji | None = None,
+        id: int | None = None, 
+    ):
+        self.id: int | None = id
+        self.title: str = title
+        self.channels: list[Snowflake] = channels or []
+        self.roles: list[Snowflake] = roles or []
+        self.description: str | None = description
+        self.emoji: Emoji | PartialEmoji | None = emoji
+
+    def __repr__(self):
+        return f"<PromptOption id={self.id} title={self.title}) channels={self.channels} roles={self.roles}>"
+
+    def to_dict(self) -> PromptOptionPayload:
+        dict_: PromptOptionPayload = {
+            "title": self.title,
+            "description": self.description,
+            "channel_ids": [channel.id for channel in self.channels],
+            "role_ids": [role.id for role in self.roles],
+            "emoji": None
+        }
+        if self.emoji:
+            dict_["emoji"] = self.emoji.to_dict()
+        if self.id:
+            dict_["id"] = str(self.id)
+
+        return dict_
+
+    @classmethod
+    def _from_dict(
+        cls, data: PromptOptionPayload, guild: Guild
+    ) -> PromptOption:
+        channel_ids = [int(channel_id) for channel_id in data.get("channel_ids", [])]
+        channels = [guild.get_channel(channel_id) for channel_id in channel_ids]
+        role_ids = [int(role_id) for role_id in data.get("role_ids", [])]
+        roles = [guild.get_role(role_id) for role_id in role_ids]
+        title = data.get("title")
+        description = data.get("description")
+        emoji = data.get("emoji")
+        if emoji:
+            emoji = Emoji._from_data(emoji)
+        return cls(channels=channels, roles=roles, title=title, description=description, emoji=emoji, id=id)  # type: ignore
+
+class OnboardingPrompt:
+    """Represents an onboarding prompt displayed in :class:`Onboarding`
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+
+    id: :class:`int`
+        The id of the prompt.
+    type: :class:`PromptType`
+        The type of onboarding prompt.
+    options: List[:class:`PromptOption`]
+        The list of options available in the prompt.
+    title: :class:`str`
+        The prompt's title.
+    single_select: :class:`bool`
+        Whether the user is limited to selecting one option on this prompt.
+    required: :class:`bool`
+        Whether the user is required to answer this prompt.
+    in_onboarding: :class:`bool`
+        Whether this prompt is displayed in the initial onboarding flow.
+    """
+
+    def __init__(
+        self,
+        type: PromptType,
+        title: str,
+        options: list[PromptOption],
+        single_select: bool,
+        required: bool,
+        in_onboarding: bool,
+        id: int | None = None,  # Currently optional as users can manually create these
+    ):
+        self.id: int | None = id
+        self.type: PromptType = try_enum(type)
+        self.options: list[PromptOption] = [
+            PromptOption._from_dict(option, self._guild)
+            for option in data.get("options", [])
+        ]
+        self.title: str = title
+        self.single_select: bool = single_select
+        self.required: bool = required
+        self.in_onboarding: bool = in_onboarding
+
+    def __repr__(self):
+        return f"<OnboardingPrompt (title={self.title} required={self.required})>"
+
+    def to_dict(self) -> OnboardingPromptPayload:
+        dict_: OnboardingPromptPayload = {
+            "type": self.type.value,
+            "title": self.title,
+            "single_select": self.single_select,
+            "required": self.required,
+            "in_onboarding": self.in_onboarding,
+            "options": [option.to_dict() for option in self.options]
+        }
+        if self.id:
+            dict_["id"] = str(self.id)
+
+        return dict_
+
+    @classmethod
+    def _from_dict(
+        cls, data: OnboardingPromptPayload, guild: Guild
+    ) -> OnboardingPrompt:
+        id = data.get("id")
+        type = try_enum(data.get("type"))
+        title = data.get("title")
+        single_select = data.get("single_select")
+        required = data.get("required")
+        in_onboarding = data.get("in_onboarding")
+        options = [PromptOption._from_dict(option) for option in data.get("options", [])]
+
+        return cls(type=type, title=title, single_select=single_select, required=required, in_onboarding=in_onboarding, options=options, id=id)  # type: ignore
+
+
+class Onboarding:
+    """Represents the Onboarding flow for a guild.
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+
+    prompts: List[:class:`OnboardingPrompt`]
+        A list of prompts displayed in the onboarding flow.
+    enabled: :class:`bool`
+        Whether onboarding is enabled in the guild.
+    mode: :class:`OnboardingMode`
+        The current onboarding mode.
+    """
+
+    def __init__(self, data: OnboardingPayload, guild: Guild):
+        self._guild = guild
+        self._update(data)
+
+    def __repr__(self):
+        return (
+            "<Onboarding" enabled={self.enabled} default_channels={self.default_channels_channels}>"
+        )
+
+    def _update(self, data: OnboardingPayload):
+        self.guild_id: Snowflake = data["guild_id"]
+        self.prompts: list[OnboardingPrompt] = [
+            OnboardingPrompt._from_dict(prompt, self._guild)
+            for prompt in data.get("prompts", [])
+        ]
+        self.default_channel_ids: list[int] = [int(c) for c in data["default_channel_ids"]]
+        self.enabled: bool = data["enabled"]
+        self.mode: OnboardingMode = try_enum(data.get("mode"))
+
+    @property
+    def guild(self) -> Guild:
+        """The guild this onboarding flow belongs to."""
+        return self._guild
+
+    @cached_property
+    def default_channels(
+        self,
+    ) -> list[TextChannel | ForumChannel | VoiceChannel | Object]:
+        """The channels that members are opted into by default.
+
+        If a channel is not found in the guild's cache,
+        then it will be returned as an :class:`Object`.
+        """
+        if self.guild is None:
+            return [Object(channel_id) for channel_id in self.default_channel_ids]
+        return [
+            self.guild.get_channel(channel_id) or Object(channel_id)
+            for channel_id in self.default_channel_ids
+        ]

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -24,12 +24,12 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload
 from random import randint
+from typing import TYPE_CHECKING
 
+from .enums import OnboardingMode, PromptType, try_enum
 from .partial_emoji import PartialEmoji
-from .utils import _get_as_snowflake, get, MISSING, cached_property
-from .enums import PromptType, OnboardingMode, try_enum
+from .utils import MISSING, _get_as_snowflake, cached_property, get
 
 if TYPE_CHECKING:
     from .abc import Snowflake
@@ -46,6 +46,7 @@ __all__ = (
     "PromptOption",
     "PromptType",
 )
+
 
 class PromptOption:
     """Represents an onboarding prompt option displayed in :class:`OnboardingPrompt`
@@ -76,7 +77,7 @@ class PromptOption:
         roles: list[Snowflake] | None = None,
         description: str | None = None,
         emoji: Emoji | PartialEmoji | None = None,
-        id: int | None = None, 
+        id: int | None = None,
     ):
         # ID is required when making edits, but it can be any snowflake that isn't already used by another prompt during edits
         self.id: int | None = id or randint(10000000000000000)
@@ -96,7 +97,7 @@ class PromptOption:
             "channel_ids": [channel.id for channel in self.channels],
             "role_ids": [role.id for role in self.roles],
             "emoji": None,
-            "id": str(self.id)
+            "id": str(self.id),
         }
         if self.emoji:
             dict_["emoji"] = self.emoji.to_dict()
@@ -104,9 +105,7 @@ class PromptOption:
         return dict_
 
     @classmethod
-    def _from_dict(
-        cls, data: PromptOptionPayload, guild: Guild
-    ) -> PromptOption:
+    def _from_dict(cls, data: PromptOptionPayload, guild: Guild) -> PromptOption:
         channel_ids = [int(channel_id) for channel_id in data.get("channel_ids", [])]
         channels = [guild.get_channel(channel_id) for channel_id in channel_ids]
         role_ids = [int(role_id) for role_id in data.get("role_ids", [])]
@@ -115,11 +114,14 @@ class PromptOption:
         description = data.get("description")
         emoji = data.get("emoji")
         if emoji:
-            if emoji.get("name"):  # You can currently get emoji as {'id': None, 'name': None, 'animated': False} ...
+            if emoji.get(
+                "name"
+            ):  # You can currently get emoji as {'id': None, 'name': None, 'animated': False} ...
                 emoji = PartialEmoji.from_dict(emoji)
             else:
                 emoji = None
         return cls(channels=channels, roles=roles, title=title, description=description, emoji=emoji, id=id)  # type: ignore
+
 
 class OnboardingPrompt:
     """Represents an onboarding prompt displayed in :class:`Onboarding`
@@ -192,7 +194,9 @@ class OnboardingPrompt:
         single_select = data.get("single_select")
         required = data.get("required")
         in_onboarding = data.get("in_onboarding")
-        options = [PromptOption._from_dict(option, guild) for option in data.get("options", [])]
+        options = [
+            PromptOption._from_dict(option, guild) for option in data.get("options", [])
+        ]
 
         return cls(type=type, title=title, single_select=single_select, required=required, in_onboarding=in_onboarding, options=options, id=id)  # type: ignore
 
@@ -218,9 +222,7 @@ class Onboarding:
         self._update(data)
 
     def __repr__(self):
-        return (
-            f"<Onboarding enabled={self.enabled} default_channels={self.default_channels_channels}>"
-        )
+        return f"<Onboarding enabled={self.enabled} default_channels={self.default_channels_channels}>"
 
     def _update(self, data: OnboardingPayload):
         self.guild_id: Snowflake = data["guild_id"]
@@ -228,7 +230,9 @@ class Onboarding:
             OnboardingPrompt._from_dict(prompt, self._guild)
             for prompt in data.get("prompts", [])
         ]
-        self.default_channel_ids: list[int] = [int(c) for c in data["default_channel_ids"]]
+        self.default_channel_ids: list[int] = [
+            int(c) for c in data["default_channel_ids"]
+        ]
         self.enabled: bool = data["enabled"]
         self.mode: OnboardingMode = try_enum(OnboardingMode, data.get("mode"))
 
@@ -280,7 +284,7 @@ class Onboarding:
             Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`
             and at least 7 ``default_channels``.
         mode: Optional[:class:`OnboardingMode`]
-            The new onboarding mode. 
+            The new onboarding mode.
         reason: Optional[:class:`str`]
             The reason that shows up on Audit log.
 

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, overload
 
 from .partial_emoji import _EmojiTag
-from .utils import _get_as_snowflake, get, MISSING
+from .utils import _get_as_snowflake, get, MISSING, cached_property
 from .enums import PromptType, OnboardingMode, try_enum
 
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ class PromptOption:
 
     def __init__(
         self,
-        title: str
+        title: str,
         channels: list[Snowflake] | None = None,
         roles: list[Snowflake] | None = None,
         description: str | None = None,

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -274,7 +274,7 @@ class Onboarding:
         default_channels: Optional[List[:class:`Snowflake`]]
             The new default channels that users are opted into.
         enabled: Optional[:class:`bool`]
-            Whether onboarding should be enabled.
+            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`.
         mode: Optional[:class:`OnboardingMode`]
             The new onboarding mode. 
         reason: Optional[:class:`str`]

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -216,7 +216,7 @@ class Onboarding:
 
     def __repr__(self):
         return (
-            "<Onboarding" enabled={self.enabled} default_channels={self.default_channels_channels}>"
+            "<Onboarding enabled={self.enabled} default_channels={self.default_channels_channels}>"
         )
 
     def _update(self, data: OnboardingPayload):

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -46,7 +46,6 @@ __all__ = (
     "Onboarding",
     "OnboardingPrompt",
     "PromptOption",
-    "PromptType",
 )
 
 

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -216,7 +216,7 @@ class Onboarding:
 
     def __repr__(self):
         return (
-            "<Onboarding enabled={self.enabled} default_channels={self.default_channels_channels}>"
+            f"<Onboarding enabled={self.enabled} default_channels={self.default_channels_channels}>"
         )
 
     def _update(self, data: OnboardingPayload):

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -25,9 +25,10 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, overload
+from random import randint
 
 from .partial_emoji import PartialEmoji
-from .utils import _get_as_snowflake, get, MISSING, cached_property, generate_snowflake
+from .utils import _get_as_snowflake, get, MISSING, cached_property
 from .enums import PromptType, OnboardingMode, try_enum
 
 if TYPE_CHECKING:
@@ -78,7 +79,7 @@ class PromptOption:
         id: int | None = None, 
     ):
         # ID is required when making edits, but it can be any snowflake that isn't already used by another prompt during edits
-        self.id: int | None = id or generate_snowflake()
+        self.id: int | None = id or randint(10000000000000000)
         self.title: str = title
         self.channels: list[Snowflake] = channels or []
         self.roles: list[Snowflake] = roles or []
@@ -155,7 +156,7 @@ class OnboardingPrompt:
         id: int | None = None,  # Currently optional as users can manually create these
     ):
         # ID is required when making edits, but it can be any snowflake that isn't already used by another prompt during edits
-        self.id: int | None = id or generate_snowflake()
+        self.id: int | None = id or randint(10000000000000000)
         self.type: PromptType = type
         if isinstance(self.type, int):
             self.type = try_enum(PromptType, self.type)

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -33,11 +33,11 @@ from .utils import MISSING, _get_as_snowflake, cached_property, get
 
 if TYPE_CHECKING:
     from .abc import Snowflake
+    from .channel import ForumChannel, TextChannel, VoiceChannel
     from .emoji import Emoji
     from .guild import Guild
     from .object import Object
     from .partial_emoji import PartialEmoji
-    from .channel import TextChannel, VoiceChannel, ForumChannel
     from .types.onboarding import Onboarding as OnboardingPayload
     from .types.onboarding import OnboardingPrompt as OnboardingPromptPayload
     from .types.onboarding import PromptOption as PromptOptionPayload

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 from .enums import OnboardingMode, PromptType, try_enum
 from .partial_emoji import PartialEmoji
-from .utils import MISSING, _get_as_snowflake, cached_property, generate_snowflake, get
+from .utils import MISSING, cached_property, generate_snowflake, get
 
 if TYPE_CHECKING:
     from .abc import Snowflake
@@ -122,7 +122,7 @@ class PromptOption:
         description = data.get("description")
 
         _emoji: dict[str, Any] = data.get("emoji") or {}
-        if emoji_name := _emoji.get("name"):
+        if "name" in _emoji:
             # Emoji object is {'id': None, 'name': None, 'animated': False} ...
             emoji = PartialEmoji.from_dict(_emoji)
             if emoji.id:
@@ -287,12 +287,13 @@ class Onboarding:
         default_channels: Optional[List[:class:`Snowflake`]]
             The new default channels that users are opted into.
         enabled: Optional[:class:`bool`]
-            Whether onboarding should be enabled. Setting this to True requires the guild to have ``COMMUNITY`` in :attr:`~Guild.features`
-            and at least 7 ``default_channels``.
+            Whether onboarding should be enabled. Setting this to ``True`` requires
+            the guild to have ``COMMUNITY`` in :attr:`~Guild.features` and at
+            least 7 ``default_channels``.
         mode: Optional[:class:`OnboardingMode`]
             The new onboarding mode.
         reason: Optional[:class:`str`]
-            The reason that shows up on Audit log.
+            The reason for editing this onboarding flow. Shows up on the audit log.
 
         Returns
         -------
@@ -301,7 +302,6 @@ class Onboarding:
 
         Raises
         ------
-
         HTTPException
             Editing the onboarding flow failed somehow.
         Forbidden
@@ -335,7 +335,8 @@ class Onboarding:
         single_select: bool,
         required: bool,
         in_onboarding: bool,
-        reason: str | None = MISSING,
+        *,
+        reason: str | None = None,
     ):
         """|coro|
 
@@ -359,7 +360,7 @@ class Onboarding:
         in_onboarding: :class:`bool`
             Whether this prompt is displayed in the initial onboarding flow.
         reason: Optional[:class:`str`]
-            The reason that shows up on Audit log.
+            The reason for adding this prompt. Shows up on the audit log.
 
         Returns
         -------
@@ -383,7 +384,8 @@ class Onboarding:
     async def append_prompt(
         self,
         prompt: OnboardingPrompt,
-        reason: str | None = MISSING,
+        *,
+        reason: str | None = None,
     ):
         """|coro|
 
@@ -397,7 +399,7 @@ class Onboarding:
         prompt: :class:`OnboardingPrompt`
             The onboarding prompt to append.
         reason: Optional[:class:`str`]
-            The reason that shows up on Audit log.
+            The reason for appending this prompt. Shows up on the audit log.
 
         Returns
         -------
@@ -439,6 +441,7 @@ class Onboarding:
     async def delete_prompt(
         self,
         id: int,
+        *,
         reason: str | None = MISSING,
     ):
         """|coro|
@@ -453,7 +456,7 @@ class Onboarding:
         id: :class:`int`
             The ID of the prompt to delete.
         reason: Optional[:class:`str`]
-            The reason that shows up on Audit log.
+            The reason for deleting this prompt. Shows up on the audit log.
 
         Returns
         -------

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -219,7 +219,7 @@ class Onboarding:
     """
 
     def __init__(self, data: OnboardingPayload, guild: Guild):
-        self._guild = guild
+        self.guild = guild
         self._update(data)
 
     def __repr__(self):
@@ -228,7 +228,7 @@ class Onboarding:
     def _update(self, data: OnboardingPayload):
         self.guild_id: Snowflake = data["guild_id"]
         self.prompts: list[OnboardingPrompt] = [
-            OnboardingPrompt._from_dict(prompt, self._guild)
+            OnboardingPrompt._from_dict(prompt, self.guild)
             for prompt in data.get("prompts", [])
         ]
         self.default_channel_ids: list[int] = [
@@ -236,11 +236,6 @@ class Onboarding:
         ]
         self.enabled: bool = data["enabled"]
         self.mode: OnboardingMode = try_enum(OnboardingMode, data.get("mode"))
-
-    @property
-    def guild(self) -> Guild:
-        """The guild this onboarding flow belongs to."""
-        return self._guild
 
     @cached_property
     def default_channels(

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -80,7 +80,7 @@ class PromptOption:
         id: int | None = None,
     ):
         # ID is required when making edits, but it can be any snowflake that isn't already used by another prompt during edits
-        self.id: int | None = int(id) if id else generate_snowflake()
+        self.id: int = int(id) if id else generate_snowflake()
         self.title: str = title
         self.channels: list[Snowflake] = channels or []
         self.roles: list[Snowflake] = roles or []
@@ -166,7 +166,8 @@ class OnboardingPrompt:
         id: int | None = None,  # Currently optional as users can manually create these
     ):
         # ID is required when making edits, but it can be any snowflake that isn't already used by another prompt during edits
-        self.id: int | None = int(id) if id else generate_snowflake()
+        self.id: int = int(id) if id else generate_snowflake()
+
         self.type: PromptType = type
         if isinstance(self.type, int):
             self.type = try_enum(PromptType, self.type)
@@ -322,7 +323,6 @@ class Onboarding:
             self.guild.id, fields, reason=reason
         )
         self._update(new)
-
         return self
 
     async def add_prompt(
@@ -366,7 +366,6 @@ class Onboarding:
 
         Raises
         ------
-
         HTTPException
             Editing the onboarding flow failed somehow.
         Forbidden
@@ -405,7 +404,6 @@ class Onboarding:
 
         Raises
         ------
-
         HTTPException
             Editing the onboarding flow failed somehow.
         Forbidden
@@ -473,6 +471,7 @@ class Onboarding:
         to_delete = self.get_prompt(id)
         if not to_delete:
             raise ValueError("Prompt with the given ID was not found.")
+
         prompts = self.prompts[:]
         prompts.remove(to_delete)
         return await self.edit(prompts=prompts, reason=reason)

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -100,9 +100,9 @@ class PromptOption:
         }
         if self.emoji:
             dict_["emoji"] = {
-                'id': str(self.emoji.id) if self.emoji.id else None,
-                'name': self.emoji.name,
-                'animated': self.emoji.animated
+                "id": str(self.emoji.id) if self.emoji.id else None,
+                "name": self.emoji.name,
+                "animated": self.emoji.animated,
             }
             dict_["emoji_name"] = self.emoji.name
             if self.emoji.id:
@@ -121,7 +121,7 @@ class PromptOption:
         title = data.get("title")
         description = data.get("description")
         _emoji = data.get("emoji", {}) or {}
-        if (emoji_name := _emoji.get("name")):
+        if emoji_name := _emoji.get("name"):
             # Emoji object is {'id': None, 'name': None, 'animated': False} ...
             emoji = PartialEmoji.from_dict(_emoji)
             if emoji.id:
@@ -325,7 +325,7 @@ class Onboarding:
         self._update(new)
 
         return self
-    
+
     async def add_prompt(
         self,
         type: PromptType,
@@ -374,10 +374,12 @@ class Onboarding:
             You don't have permissions to edit the onboarding flow.
         """
 
-        prompt = OnboardingPrompt(type, title, options, single_select, required, in_onboarding)
+        prompt = OnboardingPrompt(
+            type, title, options, single_select, required, in_onboarding
+        )
         prompts = self.prompts + [prompt]
         return await self.edit(prompts=prompts, reason=reason)
-    
+
     async def append_prompt(
         self,
         prompt: OnboardingPrompt,
@@ -413,7 +415,7 @@ class Onboarding:
 
         prompts = self.prompts + [prompt]
         return await self.edit(prompts=prompts, reason=reason)
-    
+
     def get_prompt(
         self,
         id: int,
@@ -431,11 +433,10 @@ class Onboarding:
         -------
         :class:`OnboardingPrompt`
             The matching prompt, or None if it didn't exist.
-            
         """
 
         return get(self.prompts, id=id)
-    
+
     async def delete_prompt(
         self,
         id: int,
@@ -472,7 +473,7 @@ class Onboarding:
 
         to_delete = self.get_prompt(id)
         if not to_delete:
-            raise ValueError('Prompt with the given ID was not found.')
+            raise ValueError("Prompt with the given ID was not found.")
         prompts = self.prompts[:]
         prompts.remove(to_delete)
         return await self.edit(prompts=prompts, reason=reason)

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -65,7 +65,7 @@ class PromptOption:
         The roles assigned to the user when they select this option.
     emoji: Union[:class:`Emoji`, :class:`PartialEmoji`]
         The emoji displayed with the option.
-    title: :class`str`
+    title: :class:`str`
         The option's title.
     description: Optional[:class:`str`]
         The option's description.
@@ -296,8 +296,6 @@ class Onboarding:
             Editing the onboarding flow failed somehow.
         Forbidden
             You don't have permissions to edit the onboarding flow.
-        NotFound
-            This onboarding flow does not exist.
         """
 
         fields: dict[str, Any] = {}

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from random import randint
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .enums import OnboardingMode, PromptType, try_enum
 from .partial_emoji import PartialEmoji
@@ -35,7 +35,9 @@ if TYPE_CHECKING:
     from .abc import Snowflake
     from .emoji import Emoji
     from .guild import Guild
+    from .object import Object
     from .partial_emoji import PartialEmoji
+    from .channel import TextChannel, VoiceChannel, ForumChannel
     from .types.onboarding import Onboarding as OnboardingPayload
     from .types.onboarding import OnboardingPrompt as OnboardingPromptPayload
     from .types.onboarding import PromptOption as PromptOptionPayload

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -152,7 +152,7 @@ class OnboardingPrompt:
         id: int | None = None,  # Currently optional as users can manually create these
     ):
         self.id: int | None = id
-        self.type: PromptType = try_enum(type)
+        self.type: PromptType = try_enum(PromptType, type)
         self.options: list[PromptOption] = [
             PromptOption._from_dict(option, self._guild)
             for option in data.get("options", [])
@@ -184,7 +184,7 @@ class OnboardingPrompt:
         cls, data: OnboardingPromptPayload, guild: Guild
     ) -> OnboardingPrompt:
         id = data.get("id")
-        type = try_enum(data.get("type"))
+        type = try_enum(PromptType, data.get("type"))
         title = data.get("title")
         single_select = data.get("single_select")
         required = data.get("required")
@@ -227,7 +227,7 @@ class Onboarding:
         ]
         self.default_channel_ids: list[int] = [int(c) for c in data["default_channel_ids"]]
         self.enabled: bool = data["enabled"]
-        self.mode: OnboardingMode = try_enum(data.get("mode"))
+        self.mode: OnboardingMode = try_enum(OnboardingMode, data.get("mode"))
 
     @property
     def guild(self) -> Guild:

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -49,7 +49,7 @@ __all__ = (
 
 
 class PromptOption:
-    """Represents an onboarding prompt option displayed in :class:`OnboardingPrompt`
+    """Represents an onboarding prompt option displayed in :class:`OnboardingPrompt`.
 
     .. versionadded:: 2.5
 
@@ -120,7 +120,8 @@ class PromptOption:
         roles = [guild.get_role(role_id) for role_id in role_ids]
         title = data.get("title")
         description = data.get("description")
-        _emoji = data.get("emoji", {}) or {}
+
+        _emoji: dict[str, Any] = data.get("emoji") or {}
         if emoji_name := _emoji.get("name"):
             # Emoji object is {'id': None, 'name': None, 'animated': False} ...
             emoji = PartialEmoji.from_dict(_emoji)
@@ -128,11 +129,12 @@ class PromptOption:
                 emoji = get(guild.emojis, id=emoji.id) or emoji
         else:
             emoji = None
+
         return cls(channels=channels, roles=roles, title=title, description=description, emoji=emoji, id=id)  # type: ignore
 
 
 class OnboardingPrompt:
-    """Represents an onboarding prompt displayed in :class:`Onboarding`
+    """Represents an onboarding prompt displayed in :class:`Onboarding`.
 
     .. versionadded:: 2.5
 
@@ -211,7 +213,7 @@ class OnboardingPrompt:
 
 
 class Onboarding:
-    """Represents the Onboarding flow for a guild.
+    """Represents the onboarding flow for a guild.
 
     .. versionadded:: 2.5
 

--- a/discord/onboarding.py
+++ b/discord/onboarding.py
@@ -227,7 +227,6 @@ class Onboarding:
 
     def __init__(self, data: OnboardingPayload, guild: Guild):
         self.guild = guild
-        print(data)
         self._update(data)
 
     def __repr__(self):

--- a/discord/types/onboarding.py
+++ b/discord/types/onboarding.py
@@ -25,13 +25,14 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from typing import Literal, TypedDict
-from .._typed_dict import NotRequired
 
+from .._typed_dict import NotRequired
 from .emoji import Emoji
 from .snowflake import Snowflake, SnowflakeList
 
 PromptType = Literal[0, 1]
 OnboardingMode = Literal[0, 1]
+
 
 class Onboarding(TypedDict):
     guild_id: Snowflake
@@ -39,6 +40,7 @@ class Onboarding(TypedDict):
     default_channel_ids: SnowflakeList
     enabled: bool
     mode: OnboardingMode
+
 
 class OnboardingPrompt(TypedDict):
     id: Snowflake
@@ -48,6 +50,7 @@ class OnboardingPrompt(TypedDict):
     single_select: bool
     required: bool
     in_onboarding: bool
+
 
 class PromptOption(TypedDict):
     id: Snowflake

--- a/discord/types/onboarding.py
+++ b/discord/types/onboarding.py
@@ -1,0 +1,58 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Pycord Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+from .._typed_dict import NotRequired
+
+from .emoji import Emoji
+from .snowflake import Snowflake, SnowflakeList
+
+PromptType = Literal[0, 1]
+OnboardingMode = Literal[0, 1]
+
+class Onboarding(TypedDict):
+    guild_id: Snowflake
+    prompts: list[OnboardingPrompt]
+    default_channel_ids: SnowflakeList
+    enabled: bool
+    mode: OnboardingMode
+
+class OnboardingPrompt(TypedDict):
+    id: Snowflake
+    type: PromptType
+    options: list[PromptOption]
+    title: str
+    single_select: bool
+    required: bool
+    in_onboarding: bool
+
+class PromptOption(TypedDict):
+    id: Snowflake
+    channel_ids: SnowflakeList
+    role_ids: SnowflakeList
+    emoji: Emoji
+    title: str
+    description: NotRequired[str]

--- a/discord/types/onboarding.py
+++ b/discord/types/onboarding.py
@@ -56,6 +56,9 @@ class PromptOption(TypedDict):
     id: Snowflake
     channel_ids: SnowflakeList
     role_ids: SnowflakeList
-    emoji: Emoji
+    emoji: NotRequired[Emoji]
+    emoji_id: NotRequired[Snowflake]
+    emoji_name: NotRequired[str]
+    emoji_animated: NotRequired[bool]
     title: str
     description: NotRequired[str]

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -2280,3 +2280,31 @@ of :class:`enum.Enum`.
     .. attribute:: slurs
 
         Represents the slurs keyword preset rule.
+
+.. class:: PromptType
+
+    Represents how each prompt's options are displayed.
+
+    .. versionadded:: 2.5
+
+    .. attribute:: multiple_choice
+
+        The options will appear in a grid form, showing the name and description.
+
+    .. attribute:: dropdown
+
+        The options will appear in a dropdown (similar to select menus), but without the description displayed.
+
+.. class:: OnboardingMode
+
+    Represents the current mode of the guild's onboarding flow.
+
+    .. versionadded:: 2.5
+
+    .. attribute:: default
+
+        Only default channels are counted towards the Onboarding requirements.
+
+    .. attribute:: advanced
+
+        Both default channels and questions (``OnboardingPrompt``s) will count towards the Onboarding requirements.

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -2293,7 +2293,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: dropdown
 
-        The options will appear in a dropdown (similar to select menus), but without the description displayed.
+        The options will appear in a dropdown (similar to select menus), but without the description displayed. This is **enforced** if there are more than 12 options in the prompt.
 
 .. class:: OnboardingMode
 

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -224,6 +224,24 @@ Welcome Screen
 .. autoclass:: WelcomeScreenChannel()
     :members:
 
+Onboarding
+~~~~~~~~~~~~~~
+
+.. attributetable:: Onboarding
+
+.. autoclass:: Onboarding()
+    :members:
+
+.. attributetable:: OnboardingPrompt
+
+.. autoclass:: OnboardingPrompt()
+    :members:
+
+.. attributetable:: PromptOption
+
+.. autoclass:: PromptOption()
+    :members:
+
 Integration
 ~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Construction hammered a hole through my ceiling and woke me up way too early so i implemented onboarding, probably.

- All relevant [types and enums](https://discord.com/developers/docs/resources/guild#guild-onboarding-object)
- [GET](https://discord.com/developers/docs/resources/guild#get-guild-onboarding) endpoint - `await guild.onboarding()`
- PUT endpoint - `await Onboarding.edit(...)` or `await guild.edit_onboarding(...)` to avoid multiple requests
- Updated some audit log events

References:
- discord/discord-api-docs#5915
- discord/discord-api-docs#6101
- discord/discord-api-docs#6041

There is some jank due to this feature still being incomplete(?), but everything should be working. Probably needs more review due to inconsistent typing and lack of knowledge on the endpoint (`emoji`??).
- You can edit onboarding even if you aren't in a community server
- All `OnboardingPrompt`s and `PromptOption`s require a (sometimes unique) snowflake to edit even if created by the user, but it can be any value; since it isn't relevant for the user to submit one, `randint` (lol) will be used when not supplied. 

Example: Adding a prompt to an existing onboarding flow
```py
flow = await guild.onboarding()
prompts = flow.prompts
new_prompt = OnboardingPrompt(
    title="Pick a colour!",
    required=True,
    single_select=True,  # Single vs. multiple choice
    in_onboarding=False,  # Don't show to user on join
    options=[
        PromptOption(title="Red", emoji="🍎", roles=[guild.get_role(RED_ROLE_ID)]),
        PromptOption(title="Blue", description="water", channels=[guild.get_channel(BLUE_CHANNEL_ID)])
    ]
)
prompts.append(new_prompt)
await flow.edit(prompts=prompts)
```
Perhaps it would be beneficial to add further functions out of the API scope like `Onboarding.add_prompt` etc. etc.
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
