### PR TITLE
feat: implement Avatar Decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2106](https://github.com/Pycord-Development/pycord/pull/2106))
 - Added Annotated forms support for typehinting slash command options.
   ([#2124](https://github.com/Pycord-Development/pycord/pull/2124))
+- Added `User.avatar_decoration`.
+  ([#2131](https://github.com/Pycord-Development/pycord/pull/2131))
 
 ### Changed
 

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -185,9 +185,14 @@ class Asset(AssetMixin):
     @classmethod
     def _from_avatar_decoration(cls, state, user_id: int, avatar_decoration: str) -> Self:
         animated = avatar_decoration.startswith("a_")
+        endpoint = (
+            "avatar-decoration-presets"
+            if avatar_decoration.startswith(("v3", "v2")) 
+            else "avatar-decorations/{user_id}"
+        )
         return cls(
             state,
-            url=f"{cls.BASE}/avatar-decorations/{user_id}/{avatar_decoration}.png?size=1024",
+            url=f"{cls.BASE}/{endpoint}/{avatar_decoration}.png?size=1024",
             key=avatar_decoration,
             animated=animated,
         )

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -183,6 +183,16 @@ class Asset(AssetMixin):
         )
 
     @classmethod
+    def _from_avatar_decoration(cls, state, user_id: int, avatar_decoration: str) -> Self:
+        animated = avatar_decoration.startswith("a_")
+        return cls(
+            state,
+            url=f"{cls.BASE}/avatar-decorations/{user_id}/{avatar_decoration}.png?size=1024",
+            key=avatar_decoration,
+            animated=animated,
+        )
+
+    @classmethod
     def _from_guild_avatar(
         cls, state, guild_id: int, member_id: int, avatar: str
     ) -> Asset:

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -189,8 +189,8 @@ class Asset(AssetMixin):
         animated = avatar_decoration.startswith("a_")
         endpoint = (
             "avatar-decoration-presets"
-            if avatar_decoration.startswith(("v3", "v2"))
-            else f"avatar-decorations/{user_id}"
+            # if avatar_decoration.startswith(("v3", "v2"))
+            # else f"avatar-decorations/{user_id}"
         )
         return cls(
             state,

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -185,7 +185,7 @@ class Asset(AssetMixin):
     @classmethod
     def _from_avatar_decoration(
         cls, state, user_id: int, avatar_decoration: str
-    ) -> Self:
+    ) -> Asset:
         animated = avatar_decoration.startswith("a_")
         endpoint = (
             "avatar-decoration-presets"

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -183,11 +183,13 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_avatar_decoration(cls, state, user_id: int, avatar_decoration: str) -> Self:
+    def _from_avatar_decoration(
+        cls, state, user_id: int, avatar_decoration: str
+    ) -> Self:
         animated = avatar_decoration.startswith("a_")
         endpoint = (
             "avatar-decoration-presets"
-            if avatar_decoration.startswith(("v3", "v2")) 
+            if avatar_decoration.startswith(("v3", "v2"))
             else "avatar-decorations/{user_id}"
         )
         return cls(

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -190,7 +190,7 @@ class Asset(AssetMixin):
         endpoint = (
             "avatar-decoration-presets"
             if avatar_decoration.startswith(("v3", "v2"))
-            else "avatar-decorations/{user_id}"
+            else f"avatar-decorations/{user_id}"
         )
         return cls(
             state,

--- a/discord/user.py
+++ b/discord/user.py
@@ -85,7 +85,7 @@ class BaseUser(_UserTag):
         _avatar: str | None
         _banner: str | None
         _accent_colour: int | None
-        _avatar_decoration: str | None
+        _avatar_decoration: dict | None
         _public_flags: int
 
     def __init__(self, *, state: ConnectionState, data: UserPayload) -> None:
@@ -136,7 +136,7 @@ class BaseUser(_UserTag):
         self._avatar = data["avatar"]
         self._banner = data.get("banner", None)
         self._accent_colour = data.get("accent_color", None)
-        self._avatar_decoration = data.get("avatar_decoration", None)
+        self._avatar_decoration = data.get("avatar_decoration_data", None)
         self._public_flags = data.get("public_flags", 0)
         self.bot = data.get("bot", False)
         self.system = data.get("system", False)
@@ -234,7 +234,7 @@ class BaseUser(_UserTag):
         if self._avatar_decoration is None:
             return None
         return Asset._from_avatar_decoration(
-            self._state, self.id, self._avatar_decoration
+            self._state, self.id, self._avatar_decoration.get('asset')
         )
 
     @property

--- a/discord/user.py
+++ b/discord/user.py
@@ -234,7 +234,7 @@ class BaseUser(_UserTag):
         if self._avatar_decoration is None:
             return None
         return Asset._from_avatar_decoration(
-            self._state, self.id, self._avatar_decoration.get('asset')
+            self._state, self.id, self._avatar_decoration.get("asset")
         )
 
     @property

--- a/discord/user.py
+++ b/discord/user.py
@@ -236,7 +236,9 @@ class BaseUser(_UserTag):
         """
         if self._avatar_decoration is None:
             return None
-        return Asset._from_avatar_decoration(self._state, self.id, self._avatar_decoration)
+        return Asset._from_avatar_decoration(
+            self._state, self.id, self._avatar_decoration
+        )
 
     @property
     def accent_colour(self) -> Colour | None:

--- a/discord/user.py
+++ b/discord/user.py
@@ -233,9 +233,6 @@ class BaseUser(_UserTag):
         """Returns the user's avatar decoration, if available.
 
         .. versionadded:: 2.5
-
-        .. note::
-            This information is only available via :meth:`Client.fetch_user`.
         """
         if self._avatar_decoration is None:
             return None

--- a/discord/user.py
+++ b/discord/user.py
@@ -70,6 +70,7 @@ class BaseUser(_UserTag):
         "bot",
         "system",
         "_public_flags",
+        "_avatar_decoration",
         "_state",
     )
 
@@ -84,6 +85,7 @@ class BaseUser(_UserTag):
         _avatar: str | None
         _banner: str | None
         _accent_colour: int | None
+        _avatar_decoration: str | None
         _public_flags: int
 
     def __init__(self, *, state: ConnectionState, data: UserPayload) -> None:
@@ -137,6 +139,7 @@ class BaseUser(_UserTag):
         self._avatar = data["avatar"]
         self._banner = data.get("banner", None)
         self._accent_colour = data.get("accent_color", None)
+        self._avatar_decoration = data.get("avatar_decoration", None)
         self._public_flags = data.get("public_flags", 0)
         self.bot = data.get("bot", False)
         self.system = data.get("system", False)
@@ -152,6 +155,7 @@ class BaseUser(_UserTag):
         self._avatar = user._avatar
         self._banner = user._banner
         self._accent_colour = user._accent_colour
+        self._avatar_decoration = user._avatar_decoration
         self.bot = user.bot
         self._state = user._state
         self._public_flags = user._public_flags
@@ -223,6 +227,19 @@ class BaseUser(_UserTag):
         if self._banner is None:
             return None
         return Asset._from_user_banner(self._state, self.id, self._banner)
+
+    @property
+    def avatar_decoration(self) -> Asset | None:
+        """Returns the user's avatar decoration, if available.
+
+        .. versionadded:: 2.5
+
+        .. note::
+            This information is only available via :meth:`Client.fetch_user`.
+        """
+        if self._avatar_decoration is None:
+            return None
+        return Asset._from_avatar_decoration(self._state, self.id, self._avatar_decoration)
 
     @property
     def accent_colour(self) -> Colour | None:


### PR DESCRIPTION
## Summary

Better late than never...?
There seems to be several different endpoints, so I've tried to include them.
Despite no longer being available, you can still get any user's decoration.
Unlike banners, `User.avatar_decoration` is always received without needing to fetch the user.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
