### PR TITLE
feat: add `suppress` and `allowed_mentions` parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2106](https://github.com/Pycord-Development/pycord/pull/2106))
 - Added Annotated forms support for typehinting slash command options.
   ([#2124](https://github.com/Pycord-Development/pycord/pull/2124))
-- Added `suppress` and `allowed_mentions` parameters to `Webhook` and `InteractionResponse` edit methods.
+- Added `suppress` and `allowed_mentions` parameters to `Webhook` and
+  `InteractionResponse` edit methods.
   ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2106](https://github.com/Pycord-Development/pycord/pull/2106))
 - Added Annotated forms support for typehinting slash command options.
   ([#2124](https://github.com/Pycord-Development/pycord/pull/2124))
+- Added `suppress` and `allowed_mentions` parameters to `Webhook` and `InteractionResponse` edit methods.
+  ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
 
 ### Changed
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -47,13 +47,13 @@ from ..errors import (
     InvalidArgument,
     NotFound,
 )
+from ..flags import MessageFlags
 from ..http import Route
 from ..message import Attachment, Message
 from ..mixins import Hashable
 from ..object import Object
 from ..threads import Thread
 from ..user import BaseUser, User
-from ..flags import MessageFlags
 
 __all__ = (
     "Webhook",

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -652,7 +652,6 @@ def handle_message_parameters(
         payload["username"] = username
 
     flags = MessageFlags(suppress_embeds=suppress, ephemeral=ephemeral)
-
     payload["flags"] = flags.value
 
     if allowed_mentions:

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -623,7 +623,7 @@ def handle_message_parameters(
     view: View | None = MISSING,
     allowed_mentions: AllowedMentions | None = MISSING,
     previous_allowed_mentions: AllowedMentions | None = None,
-    suppress: bool = MISSING,
+    suppress: bool = False,
 ) -> ExecuteWebhookParameters:
     if files is not MISSING and file is not MISSING:
         raise TypeError("Cannot mix file and files keyword arguments.")
@@ -650,16 +650,10 @@ def handle_message_parameters(
         payload["avatar_url"] = str(avatar_url)
     if username:
         payload["username"] = username
-    
-    flags = MessageFlags._from_value(0)
-    
-    if ephemeral:
-        flags.ephemeral = True
-        payload["flags"] = flags.value
-    
-    if suppress is not MISSING:
-        flags.suppress_embeds = suppress
-        payload["flags"] = flags.value
+
+    flags = MessageFlags(suppress_embeds=suppress, ephemeral=ephemeral)
+
+    payload["flags"] = flags.value
 
     if allowed_mentions:
         if previous_allowed_mentions is not None:
@@ -837,6 +831,7 @@ class WebhookMessage(Message):
         attachments: list[Attachment] = MISSING,
         view: View | None = MISSING,
         allowed_mentions: AllowedMentions | None = None,
+        suppress: bool | None = MISSING,
     ) -> WebhookMessage:
         """|coro|
 
@@ -878,6 +873,8 @@ class WebhookMessage(Message):
             the view is removed.
 
             .. versionadded:: 2.0
+        suppress: Optional[:class:`bool`]
+            Whether to suppress embeds for the message.
 
         Returns
         -------
@@ -908,6 +905,9 @@ class WebhookMessage(Message):
         if attachments is MISSING:
             attachments = self.attachments or MISSING
 
+        if suppress is MISSING:
+            suppress = self.flags.suppress_embeds
+
         return await self._state._webhook.edit_message(
             self.id,
             content=content,
@@ -919,6 +919,7 @@ class WebhookMessage(Message):
             view=view,
             allowed_mentions=allowed_mentions,
             thread=thread,
+            suppress=suppress,
         )
 
     async def delete(self, *, delay: float | None = None) -> None:
@@ -1855,7 +1856,7 @@ class Webhook(BaseWebhook):
         view: View | None = MISSING,
         allowed_mentions: AllowedMentions | None = None,
         thread: Snowflake | None = MISSING,
-        suppress: bool = MISSING,
+        suppress: bool = False,
     ) -> WebhookMessage:
         """|coro|
 
@@ -1903,6 +1904,8 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.0
         thread: Optional[:class:`~discord.abc.Snowflake`]
             The thread that contains the message.
+        suppress: :class:`bool`
+            Whether to suppress embeds for the message.
 
         Returns
         -------

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -53,6 +53,7 @@ from ..mixins import Hashable
 from ..object import Object
 from ..threads import Thread
 from ..user import BaseUser, User
+from ..flags import MessageFlags
 
 __all__ = (
     "Webhook",
@@ -622,6 +623,7 @@ def handle_message_parameters(
     view: View | None = MISSING,
     allowed_mentions: AllowedMentions | None = MISSING,
     previous_allowed_mentions: AllowedMentions | None = None,
+    suppress: bool = MISSING,
 ) -> ExecuteWebhookParameters:
     if files is not MISSING and file is not MISSING:
         raise TypeError("Cannot mix file and files keyword arguments.")
@@ -648,8 +650,16 @@ def handle_message_parameters(
         payload["avatar_url"] = str(avatar_url)
     if username:
         payload["username"] = username
+    
+    flags = MessageFlags._from_value(0)
+    
     if ephemeral:
-        payload["flags"] = 64
+        flags.ephemeral = True
+        payload["flags"] = flags.value
+    
+    if suppress is not MISSING:
+        flags.suppress_embeds = suppress
+        payload["flags"] = flags.value
 
     if allowed_mentions:
         if previous_allowed_mentions is not None:
@@ -1845,6 +1855,7 @@ class Webhook(BaseWebhook):
         view: View | None = MISSING,
         allowed_mentions: AllowedMentions | None = None,
         thread: Snowflake | None = MISSING,
+        suppress: bool = MISSING,
     ) -> WebhookMessage:
         """|coro|
 
@@ -1939,6 +1950,7 @@ class Webhook(BaseWebhook):
             view=view,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            suppress=suppress,
         )
 
         thread_id: int | None = None

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -472,6 +472,7 @@ class SyncWebhookMessage(Message):
         file: File = MISSING,
         files: list[File] = MISSING,
         allowed_mentions: AllowedMentions | None = None,
+        suppress: bool | None = MISSING,
     ) -> SyncWebhookMessage:
         """Edits the message.
 
@@ -492,6 +493,8 @@ class SyncWebhookMessage(Message):
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
+        suppress: Optional[:class:`bool`]
+            Whether to suppress embeds for the message.
 
         Returns
         -------
@@ -517,6 +520,9 @@ class SyncWebhookMessage(Message):
         elif isinstance(self.channel, Thread):
             thread = Object(self.channel.id)
 
+        if suppress is MISSING:
+            suppress = self.flags.suppress_embeds
+
         return self._state._webhook.edit_message(
             self.id,
             content=content,
@@ -526,6 +532,7 @@ class SyncWebhookMessage(Message):
             files=files,
             allowed_mentions=allowed_mentions,
             thread=thread,
+            suppress=suppress,
         )
 
     def delete(self, *, delay: float | None = None) -> None:
@@ -952,6 +959,7 @@ class SyncWebhook(BaseWebhook):
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
         wait: Literal[False] = ...,
+        suppress: bool = MISSING,
     ) -> None:
         ...
 
@@ -970,6 +978,7 @@ class SyncWebhook(BaseWebhook):
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
         wait: bool = False,
+        suppress: bool = False,
     ) -> SyncWebhookMessage | None:
         """Sends a message using the webhook.
 
@@ -1022,6 +1031,8 @@ class SyncWebhook(BaseWebhook):
             The name of the thread to create. Only works for forum channels.
 
             .. versionadded:: 2.0
+        suppress: :class:`bool`
+            Whether to suppress embeds for the message.
 
         Returns
         -------
@@ -1070,6 +1081,7 @@ class SyncWebhook(BaseWebhook):
             embeds=embeds,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            suppress=suppress,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
         thread_id: int | None = None
@@ -1151,6 +1163,7 @@ class SyncWebhook(BaseWebhook):
         files: list[File] = MISSING,
         allowed_mentions: AllowedMentions | None = None,
         thread: Snowflake | None = MISSING,
+        suppress: bool = False,
     ) -> SyncWebhookMessage:
         """Edits a message owned by this webhook.
 
@@ -1211,6 +1224,7 @@ class SyncWebhook(BaseWebhook):
             embeds=embeds,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            suppress=suppress,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds `suppress` and `allowed_mentions` parameters to `InteractionResponse.edit_message`.
Also adds `suppress` parameter for editing messages using webhooks.

The `suppress_embeds` flag and `allowed_mentions` are supported for `InteractionResponse.edit_message` https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages

The `suppress_embeds` flags is undocumented for editing message by webhooks, but it works. 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
