### PR TITLE
fix: always set Guild._member_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2091](https://github.com/Pycord-Development/pycord/pull/2091))
 - Fixed `AttributeError` when accessing a `Select`'s values when it hasn't been
   interacted with. ([#2104](https://github.com/Pycord-Development/pycord/pull/2104))
+- Fixed `Guild._member_count` sometimes not being set.
+  ([#2145](https://github.com/Pycord-Development/pycord/pull/2145))
 - Fixed `Thread.applied_tags` not being updated.
   ([#2146](https://github.com/Pycord-Development/pycord/pull/2146))
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -383,7 +383,7 @@ class Guild(Hashable):
             ("name", self.name),
             ("shard_id", self.shard_id),
             ("chunked", self.chunked),
-            ("member_count", getattr(self, "_member_count", None)),
+            ("member_count", self._member_count),
         )
         inner = " ".join("%s=%r" % t for t in attrs)
         return f"<Guild {inner}>"
@@ -441,11 +441,7 @@ class Guild(Hashable):
         return role
 
     def _from_data(self, guild: GuildPayload) -> None:
-        # according to Stan, this is always available even if the guild is unavailable
-        # I don't have this guarantee when someone updates the guild.
-        member_count = guild.get("member_count", None)
-        if member_count is not None:
-            self._member_count: int = member_count
+        self._member_count: int | None = guild.get("member_count")
 
         self.name: str = guild.get("name")
         self.verification_level: VerificationLevel = try_enum(
@@ -532,7 +528,7 @@ class Guild(Hashable):
 
         self._sync(guild)
         self._large: bool | None = (
-            None if member_count is None else self._member_count >= 250
+            None if self._member_count is None else self._member_count >= 250
         )
 
         self.owner_id: int | None = utils._get_as_snowflake(guild, "owner_id")
@@ -598,10 +594,7 @@ class Guild(Hashable):
         members, which for this library is set to the maximum of 250.
         """
         if self._large is None:
-            try:
-                return self._member_count >= 250
-            except AttributeError:
-                return len(self._members) >= 250
+            return (self._member_count or len(self._members)) >= 250
         return self._large
 
     @property
@@ -1002,10 +995,9 @@ class Guild(Hashable):
         If this value returns ``False``, then you should request for
         offline members.
         """
-        count = getattr(self, "_member_count", None)
-        if count is None:
+        if self._member_count is None:
             return False
-        return count == len(self._members)
+        return self._member_count == len(self._members)
 
     @property
     def shard_id(self) -> int:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -441,7 +441,11 @@ class Guild(Hashable):
         return role
 
     def _from_data(self, guild: GuildPayload) -> None:
-        self._member_count: int | None = guild.get("member_count")
+        member_count = guild.get("member_count")
+        # Either the payload includes member_count, or it hasn't been set yet.
+        # Prevents valid _member_count from suddenly changing to None
+        if member_count is not None or not hasattr(self, "_member_count"):
+            self._member_count: int | None = member_count
 
         self.name: str = guild.get("name")
         self.verification_level: VerificationLevel = try_enum(

--- a/discord/state.py
+++ b/discord/state.py
@@ -1139,10 +1139,8 @@ class ConnectionState:
         if self.member_cache_flags.joined:
             guild._add_member(member)
 
-        try:
+        if guild._member_count is not None:
             guild._member_count += 1
-        except AttributeError:
-            pass
 
         self.dispatch("member_join", member)
 
@@ -1152,10 +1150,8 @@ class ConnectionState:
 
         guild = self._get_guild(int(data["guild_id"]))
         if guild is not None:
-            try:
+            if guild._member_count is not None:
                 guild._member_count -= 1
-            except AttributeError:
-                pass
 
             member = guild.get_member(user.id)
             if member is not None:


### PR DESCRIPTION
## Summary

Previously, if a guild's `member_count` wasn't provided from the API (e.g. when using `fetch_guild`) the `_member_count` attribute was never set. This makes sure it's set regardless, and adjust other functions in the library to make use of this instead of using `getattr` or try/except.
Fixes #2136 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
