### PR TITLE
fix: add missing  delete_after parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed type-hinting of `author` property of `ApplicationContext` to include typehinting
   of `User` or `Member`.
   ([#2148](https://github.com/Pycord-Development/pycord/pull/2148))
+- Fixed missing `delete_after` parameter in overload type-hinting for `send` method in `Webhook` class.
+  ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,8 +151,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed type-hinting of `author` property of `ApplicationContext` to include typehinting
   of `User` or `Member`.
   ([#2148](https://github.com/Pycord-Development/pycord/pull/2148))
-- Fixed missing `delete_after` parameter in overload type-hinting for `send` method in `Webhook` class.
-  ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
+- Fixed missing `delete_after` parameter in overload type-hinting for `send` method in
+  `Webhook` class. ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1567,6 +1567,7 @@ class Webhook(BaseWebhook):
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
         wait: Literal[True],
+        delete_after: float = None,
     ) -> WebhookMessage:
         ...
 
@@ -1588,6 +1589,7 @@ class Webhook(BaseWebhook):
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
         wait: Literal[False] = ...,
+        delete_after: float = None,
     ) -> None:
         ...
 


### PR DESCRIPTION
## Summary

This fixes a typing error when doing something like

```python
await ctx.defer()
await ctx.followup.send('something', ephemeral=True, delete_after=15)
```

```
error: No overload variant of "send" of "Webhook" matches argument types "str", "bool", "int"  [call-overload]
note: Possible overload variants:
note:     def send(self, content: str = ..., *, username: str = ..., avatar_url: Any = ..., tts: bool = ..., ephemeral: bool = ..., file: File = ..., files: List[File] = ..., embed: Embed = ..., embeds: List[Embed] = ..., allowed_mentions: AllowedMentions = ..., view: View = ..., thread: Snowflake = ..., thread_name: Optional[str] = ..., wait: Literal[True]) -> Coroutine[Any, Any, WebhookMessage]
note:     def send(self, content: str = ..., *, username: str = ..., avatar_url: Any = ..., tts: bool = ..., ephemeral: bool = ..., file: File = ..., files: List[File] = ..., embed: Embed = ..., embeds: List[Embed] = ..., allowed_mentions: AllowedMentions = ..., view: View = ..., thread: Snowflake = ..., thread_name: Optional[str] = ..., wait: Literal[False] = ...) -> Coroutine[Any, Any, None]
```

I guess when the `delete_after` parameter was added it was simply forgotten in the overloads.

## Information

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
