### PR TITLE
refactor: Purge all un needed __ne__ methods

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -432,9 +432,6 @@ class Game(BaseActivity):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Game) and other.name == self.name
 
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
     def __hash__(self) -> int:
         return hash(self.name)
 
@@ -541,9 +538,6 @@ class Streaming(BaseActivity):
             and other.name == self.name
             and other.url == self.url
         )
-
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
 
     def __hash__(self) -> int:
         return hash(self.name)
@@ -653,9 +647,6 @@ class Spotify:
             and other._sync_id == self._sync_id
             and other.start == self.start
         )
-
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
 
     def __hash__(self) -> int:
         return hash(self._session_id)
@@ -828,9 +819,6 @@ class CustomActivity(BaseActivity):
             and other.name == self.name
             and other.emoji == self.emoji
         )
-
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
 
     def __hash__(self) -> int:
         return hash((self.name, str(self.emoji)))

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -86,9 +86,6 @@ class Colour:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Colour) and self.value == other.value
 
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
     def __str__(self) -> str:
         return f"#{self.value:0>6x}"
 

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -147,9 +147,6 @@ class Emoji(_EmojiTag, AssetMixin):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, _EmojiTag) and self.id == other.id
 
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
     def __hash__(self) -> int:
         return self.id >> 22
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -116,9 +116,6 @@ class BaseFlags:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, self.__class__) and self.value == other.value
 
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
     def __hash__(self) -> int:
         return hash(self.value)
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -344,9 +344,6 @@ class Member(discord.abc.Messageable, _UserTag):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, _UserTag) and other.id == self.id
 
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
     def __hash__(self) -> int:
         return hash(self._user)
 

--- a/discord/partial_emoji.py
+++ b/discord/partial_emoji.py
@@ -202,9 +202,6 @@ class PartialEmoji(_EmojiTag, AssetMixin):
             return self.id == other.id
         return False
 
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
     def __hash__(self) -> int:
         return hash((self.id, self.name))
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -123,9 +123,6 @@ class BaseUser(_UserTag):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, _UserTag) and other.id == self.id
 
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
     def __hash__(self) -> int:
         return self.id >> 22
 


### PR DESCRIPTION
## Summary

This was made to remove all the `__ne__` dunder methods that returned `not __eq__`. This is because if there is no `__ne__` python will anyways return the value of `not __eq__`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
