### PR TITLE
fix: `ScheduledEvent.creator_id` returning incorrect type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed missing `delete_after` parameter in overload type-hinting for `send` method in
   `Webhook` class. ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
 - Fixed `fix: ScheduledEvent.creator_id` returning `str` instead of `int`.
-  ([#TBD](https://github.com/Pycord-Development/pycord/pull/TBD))
+  ([#2162](https://github.com/Pycord-Development/pycord/pull/2162))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2148](https://github.com/Pycord-Development/pycord/pull/2148))
 - Fixed missing `delete_after` parameter in overload type-hinting for `send` method in
   `Webhook` class. ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
+- Fixed `fix: ScheduledEvent.creator_id` returning `str` instead of `int`.
+  ([#TBD](https://github.com/Pycord-Development/pycord/pull/TBD))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2148](https://github.com/Pycord-Development/pycord/pull/2148))
 - Fixed missing `delete_after` parameter in overload type-hinting for `send` method in
   `Webhook` class. ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
-- Fixed `fix: ScheduledEvent.creator_id` returning `str` instead of `int`.
+- Fixed `ScheduledEvent.creator_id` returning `str` instead of `int`.
   ([#2162](https://github.com/Pycord-Development/pycord/pull/2162))
 
 ## [2.4.1] - 2023-03-20

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -158,7 +158,7 @@ class ScheduledEvent(Hashable):
         The number of users that have marked themselves as interested in the event.
     creator_id: Optional[:class:`int`]
         The ID of the user who created the event.
-        It may be ``None`` because events created before October 25th, 2021, haven't
+        It may be ``None`` because events created before October 25th, 2021 haven't
         had their creators tracked.
     creator: Optional[:class:`User`]
         The resolved user object of who created the event.

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -209,7 +209,7 @@ class ScheduledEvent(Hashable):
             ScheduledEventStatus, data.get("status")
         )
         self.subscriber_count: int | None = data.get("user_count", None)
-        self.creator_id = data.get("creator_id", None)
+        self.creator_id = int(data.get("creator_id", None))
         self.creator: Member | None = creator
 
         entity_metadata = data.get("entity_metadata")

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -209,7 +209,7 @@ class ScheduledEvent(Hashable):
             ScheduledEventStatus, data.get("status")
         )
         self.subscriber_count: int | None = data.get("user_count", None)
-        self.creator_id = int(data.get("creator_id", None))
+        self.creator_id: int | None = utils._get_as_snowflake(data, "creator_id")
         self.creator: Member | None = creator
 
         entity_metadata = data.get("entity_metadata")


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
#2160

Technically, not incorrect, but inconsistent with the rest of the library.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
