### PR TITLE
fix: basic_autocomplete values can be Iterable[OptionChoice]

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -142,6 +142,7 @@ if TYPE_CHECKING:
 
     from .abc import Snowflake
     from .commands.context import AutocompleteContext
+    from .commands.options import OptionChoice
     from .invite import Invite
     from .permissions import Permissions
     from .template import Template
@@ -156,6 +157,7 @@ if TYPE_CHECKING:
 else:
     cached_property = _cached_property
     AutocompleteContext = Any
+    OptionChoice = Any
 
 
 T = TypeVar("T")
@@ -1298,7 +1300,7 @@ def generate_snowflake(dt: datetime.datetime | None = None) -> int:
     return int(dt.timestamp() * 1000 - DISCORD_EPOCH) << 22 | 0x3FFFFF
 
 
-V = Union[Iterable[str], Iterable[int], Iterable[float]]
+V = Union[Iterable[OptionChoice], Iterable[str], Iterable[int], Iterable[float]]
 AV = Awaitable[V]
 Values = Union[V, Callable[[AutocompleteContext], Union[V, AV]], AV]
 AutocompleteFunc = Callable[[AutocompleteContext], AV]


### PR DESCRIPTION
## Summary

Fixes #2163

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
