### PR TITLE
feat: add creator monetization-related audit log action types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ These changes are available on the `master` branch, but have not yet been releas
   [Raw Event payloads](https://docs.pycord.dev/en/master/api/models.html#events).
   ([#2023](https://github.com/Pycord-Development/pycord/pull/2023))
 - Added and documented missing `AuditLogAction` enums.
-  ([#2030](https://github.com/Pycord-Development/pycord/pull/2030), [#TBD](https://github.com/Pycord-Development/pycord/pull/TBD))
+  ([#2030](https://github.com/Pycord-Development/pycord/pull/2030),
+  [#TBD](https://github.com/Pycord-Development/pycord/pull/TBD))
 - `AuditLogDiff` now supports AutoMod related models.
   ([#2030](https://github.com/Pycord-Development/pycord/pull/2030))
 - Added `Interaction.respond` and `Interaction.edit` as shortcut responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ These changes are available on the `master` branch, but have not yet been releas
   [Raw Event payloads](https://docs.pycord.dev/en/master/api/models.html#events).
   ([#2023](https://github.com/Pycord-Development/pycord/pull/2023))
 - Added and documented missing `AuditLogAction` enums.
-  ([#2030](https://github.com/Pycord-Development/pycord/pull/2030))
+  ([#2030](https://github.com/Pycord-Development/pycord/pull/2030), [#TBD](https://github.com/Pycord-Development/pycord/pull/TBD))
 - `AuditLogDiff` now supports AutoMod related models.
   ([#2030](https://github.com/Pycord-Development/pycord/pull/2030))
 - Added `Interaction.respond` and `Interaction.edit` as shortcut responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2023](https://github.com/Pycord-Development/pycord/pull/2023))
 - Added and documented missing `AuditLogAction` enums.
   ([#2030](https://github.com/Pycord-Development/pycord/pull/2030),
-  [#TBD](https://github.com/Pycord-Development/pycord/pull/TBD))
+  [#2171](https://github.com/Pycord-Development/pycord/pull/2171))
 - `AuditLogDiff` now supports AutoMod related models.
   ([#2030](https://github.com/Pycord-Development/pycord/pull/2030))
 - Added `Interaction.respond` and `Interaction.edit` as shortcut responses.

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -425,6 +425,8 @@ class AuditLogAction(Enum):
     auto_moderation_block_message = 143
     auto_moderation_flag_to_channel = 144
     auto_moderation_user_communication_disabled = 145
+    creator_monetization_request_created = 150
+    creator_monetization_terms_accepted = 151
 
     @property
     def category(self) -> AuditLogActionCategory | None:
@@ -485,6 +487,8 @@ class AuditLogAction(Enum):
             AuditLogAction.auto_moderation_block_message: None,
             AuditLogAction.auto_moderation_flag_to_channel: None,
             AuditLogAction.auto_moderation_user_communication_disabled: None,
+            AuditLogAction.creator_monetization_request_created: None,
+            AuditLogAction.creator_monetization_terms_accepted: None,
         }
         return lookup[self]
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1579,7 +1579,7 @@ of :class:`enum.Enum`.
         A member was timed out by auto moderation.
 
         .. versionadded:: 2.5
-    
+
     .. attribute:: creator_monetization_request_created
 
         A creator monetization request was created.

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1579,6 +1579,18 @@ of :class:`enum.Enum`.
         A member was timed out by auto moderation.
 
         .. versionadded:: 2.5
+    
+    .. attribute:: creator_monetization_request_created
+
+        A creator monetization request was created.
+
+        .. versionadded:: 2.5
+
+    .. attribute:: creator_monetization_terms_accepted
+
+        The creator monetization terms were accepted.
+
+        .. versionadded:: 2.5
 
 
 .. class:: AuditLogActionCategory


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Implementation details:
discord/discord-api-docs#6071

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
