### PR TITLE
fix: thread creation payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,8 @@ These changes are available on the `master` branch, but have not yet been releas
   `Webhook` class. ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
 - Fixed `ScheduledEvent.creator_id` returning `str` instead of `int`.
   ([#2162](https://github.com/Pycord-Development/pycord/pull/2162))
+- Fixed initial message inside of the create thread payload sending legacy beta payload.
+  ([#2191](https://github.com/Pycord-Development/pycord/pull/2191))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1183,37 +1183,42 @@ class HTTPClient:
             "auto_archive_duration": auto_archive_duration,
             "invitable": invitable,
         }
-        if content:
-            payload["content"] = content
 
         if applied_tags:
             payload["applied_tags"] = applied_tags
 
+        message = {}
+
+        if content:
+            message["content"] = content
+
         if embed:
-            payload["embeds"] = [embed]
+            message["embeds"] = [embed]
 
         if embeds:
-            payload["embeds"] = embeds
+            message["embeds"] = embeds
 
         if nonce:
-            payload["nonce"] = nonce
+            message["nonce"] = nonce
 
         if allowed_mentions:
-            payload["allowed_mentions"] = allowed_mentions
+            message["allowed_mentions"] = allowed_mentions
 
         if components:
-            payload["components"] = components
+            message["components"] = components
 
         if stickers:
-            payload["sticker_ids"] = stickers
+            message["sticker_ids"] = stickers
 
         if rate_limit_per_user:
-            payload["rate_limit_per_user"] = rate_limit_per_user
+            message["rate_limit_per_user"] = rate_limit_per_user
 
-        # TODO: Once supported by API, remove has_message=true query parameter
+        if message != {}:
+            payload['message'] = message
+
         route = Route(
             "POST",
-            "/channels/{channel_id}/threads?has_message=true",
+            "/channels/{channel_id}/threads",
             channel_id=channel_id,
         )
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1214,7 +1214,7 @@ class HTTPClient:
             message["rate_limit_per_user"] = rate_limit_per_user
 
         if message != {}:
-            payload['message'] = message
+            payload["message"] = message
 
         route = Route(
             "POST",


### PR DESCRIPTION
## Summary

`has_message` is now deprecated and has been replaced with the simple `message` key. This applies that change.

Fixes #2190
Closes #1735

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
