### PR TITLE
feat: VoiceClient.play wait_finish parameter for awaiting end of stream

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   #          - --remove-duplicate-keys
   #          - --remove-unused-variables
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.9.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
@@ -77,7 +77,7 @@ repos:
   #      - id: mypy
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v3.0.0
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `suppress` and `allowed_mentions` parameters to `Webhook` and
   `InteractionResponse` edit methods.
   ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
-- Added `wait_end` coroutine method to `VoiceClient`.
+- Added `VoiceClient.wait_end` coroutine method.
+  ([#2194](https://github.com/Pycord-Development/pycord/pull/2194))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `suppress` and `allowed_mentions` parameters to `Webhook` and
   `InteractionResponse` edit methods.
   ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
+- Added `wait_end` coroutine method to `VoiceClient`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `suppress` and `allowed_mentions` parameters to `Webhook` and
   `InteractionResponse` edit methods.
   ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
-- Added `VoiceClient.wait_end` coroutine method.
+- Added `wait_finish` parameter to `VoiceClient` for awaiting the end of a play.
   ([#2194](https://github.com/Pycord-Development/pycord/pull/2194))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `suppress` and `allowed_mentions` parameters to `Webhook` and
   `InteractionResponse` edit methods.
   ([#2138](https://github.com/Pycord-Development/pycord/pull/2138))
-- Added `wait_finish` parameter to `VoiceClient` for awaiting the end of a play.
+- Added `wait_finish` parameter to `VoiceClient.play` for awaiting the end of a play.
   ([#2194](https://github.com/Pycord-Development/pycord/pull/2194))
 
 ### Changed

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -552,19 +552,18 @@ class VoiceClient(VoiceProtocol):
         .. versionadded:: v2.5
 
         Parameters
-        -----------
+        ----------
         timeout: float | None
             Optional timeout in seconds.
 
         Raises
-        -----------
+        ------
         TimeoutError
             Timeout of ``timeout`` seconds exceeded.
         """
-        if (
-            self._player is not None and not
-            (
-                await self._state.loop.run_in_executor(None, self._player._end.wait, timeout)
+        if self._player is not None and not (
+            await self._state.loop.run_in_executor(
+                None, self._player._end.wait, timeout
             )
         ):
             raise TimeoutError(f"Timeout of {timeout} seconds exceeded")

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -544,6 +544,31 @@ class VoiceClient(VoiceProtocol):
         """
         await self.channel.guild.change_voice_state(channel=channel)
 
+    async def wait_end(self, timeout: float | None = None) -> None:
+        """|coro|
+
+        Waits for audio player to stop streaming.
+
+        .. versionadded:: v2.5
+
+        Parameters
+        -----------
+        timeout: float | None
+            Optional timeout in seconds.
+
+        Raises
+        -----------
+        TimeoutError
+            Timeout of ``timeout`` seconds exceeded.
+        """
+        if (
+            self._player is not None and not
+            (
+                await self._state.loop.run_in_executor(None, self._player._end.wait, timeout)
+            )
+        ):
+            raise TimeoutError(f"Timeout of {timeout} seconds exceeded")
+
     def is_connected(self) -> bool:
         """Indicates if the voice client is connected to voice."""
         return self._connected.is_set()


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Added ``wait_finish``parameter to ``VoiceClient.play``, which will return an awaitable if ``True``, that can be used to wait for the audio to stop playing. If set to ``False`` (default), the function will not block and ``None`` will be returned

Example:
```py
import discord
import secret

client = discord.Client()

@client.listen("on_ready")
async def start():
    guild = client.get_guild(863071397207212052)

    channel: discord.VoiceChannel = guild.get_channel(1132373179210399844)

    def callback(exc):
        pass

    voice_client = await channel.connect()
    res = await voice_client.play(
        discord.PCMVolumeTransformer(discord.FFmpegPCMAudio("VoiceMessage.mp3"), 0.25),
        after=callback,
        wait_finish=True
    )
    print(f"Set exception: {res}")

    voice_client.play(
        discord.PCMVolumeTransformer(discord.FFmpegPCMAudio("VoiceMessage.mp3"), 0.25),
        after=callback,
        wait_finish=False
     )

client.run(secret.TOKEN)

```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
