### PR TITLE
feat: add support for custom status

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -160,7 +160,7 @@ class Activity(BaseActivity):
     type: :class:`ActivityType`
         The type of activity currently being done.
     state: Optional[:class:`str`]
-        The user's current state. For example, "In Game".
+        The user's current party status or text used for a custom status.
     details: Optional[:class:`str`]
         The detail of the user's current activity.
     timestamps: Dict[:class:`str`, :class:`int`]
@@ -229,7 +229,6 @@ class Activity(BaseActivity):
         self.assets: ActivityAssets = kwargs.pop("assets", {})
         self.party: ActivityParty = kwargs.pop("party", {})
         self.application_id: int | None = _get_as_snowflake(kwargs, "application_id")
-        self.name: str | None = kwargs.pop("name", None)
         self.url: str | None = kwargs.pop("url", None)
         self.flags: int = kwargs.pop("flags", 0)
         self.sync_id: str | None = kwargs.pop("sync_id", None)
@@ -242,6 +241,9 @@ class Activity(BaseActivity):
             if isinstance(activity_type, ActivityType)
             else try_enum(ActivityType, activity_type)
         )
+        self.name: str | None = kwargs.pop(
+            "name", "Custom Status" if self.type == ActivityType.custom else None
+        )
 
         emoji = kwargs.pop("emoji", None)
         self.emoji: PartialEmoji | None = (
@@ -252,6 +254,7 @@ class Activity(BaseActivity):
         attrs = (
             ("type", self.type),
             ("name", self.name),
+            ("state", self.state),
             ("url", self.url),
             ("details", self.details),
             ("application_id", self.application_id),
@@ -275,6 +278,7 @@ class Activity(BaseActivity):
         ret["type"] = int(self.type)
         if self.emoji:
             ret["emoji"] = self.emoji.to_dict()
+        print(ret)
         return ret
 
     @property

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -221,9 +221,9 @@ class Activity(BaseActivity):
         "buttons",
     )
 
-    def __init__(self, state: str | None = None, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.state: str | None = state
+        self.state: str | None = kwargs.pop("state", None)
         self.details: str | None = kwargs.pop("details", None)
         self.timestamps: ActivityTimestamps = kwargs.pop("timestamps", {})
         self.assets: ActivityAssets = kwargs.pop("assets", {})

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -278,7 +278,6 @@ class Activity(BaseActivity):
         ret["type"] = int(self.type)
         if self.emoji:
             ret["emoji"] = self.emoji.to_dict()
-        print(ret)
         return ret
 
     @property

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -763,6 +763,8 @@ class CustomActivity(BaseActivity):
         The custom activity's name.
     emoji: Optional[:class:`PartialEmoji`]
         The emoji to pass to the activity, if any.
+    state: Optional[:class:`str`]
+        The text used for the custom activity.
     """
 
     __slots__ = ("name", "emoji", "state")
@@ -772,7 +774,7 @@ class CustomActivity(BaseActivity):
     ):
         super().__init__(**extra)
         self.name: str | None = name
-        self.state: str | None = extra.pop("state", None)
+        self.state: str | None = extra.pop("state", name)
         if self.name == "Custom Status":
             self.name = self.state
 

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -221,9 +221,9 @@ class Activity(BaseActivity):
         "buttons",
     )
 
-    def __init__(self, **kwargs):
+    def __init__(self, state: str | None = None, **kwargs):
         super().__init__(**kwargs)
-        self.state: str | None = kwargs.pop("state", None)
+        self.state: str | None = state
         self.details: str | None = kwargs.pop("details", None)
         self.timestamps: ActivityTimestamps = kwargs.pop("timestamps", {})
         self.assets: ActivityAssets = kwargs.pop("assets", {})

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -361,8 +361,8 @@ class Embed:
         fields: list[EmbedField] | None = None,
         author: EmbedAuthor | None = None,
         footer: EmbedFooter | None = None,
-        image: str | None = None,
-        thumbnail: str | None = None,
+        image: str | EmbedMedia | None = None,
+        thumbnail: str | EmbedMedia | None = None,
     ):
         self.colour = colour if colour else color
         self.title = title
@@ -640,9 +640,11 @@ class Embed:
         return EmbedMedia.from_dict(img)
 
     @image.setter
-    def image(self, value: EmbedMedia | None):
+    def image(self, value: str | EmbedMedia | None):
         if value is None:
             self.remove_image()
+        elif isinstance(value, str):
+            self.set_image(url=value)
         elif isinstance(value, EmbedMedia):
             self.set_image(url=value.url)
         else:
@@ -712,9 +714,11 @@ class Embed:
         return EmbedMedia.from_dict(thumb)
 
     @thumbnail.setter
-    def thumbnail(self, value: EmbedMedia | None):
+    def thumbnail(self, value: str | EmbedMedia | None):
         if value is None:
             self.remove_thumbnail()
+        elif isinstance(value, str):
+            self.set_thumbnail(url=value)
         elif isinstance(value, EmbedMedia):
             self.set_thumbnail(url=value.url)
         else:


### PR DESCRIPTION
## Summary
Closes #2204.
Defaults `Activity.name` to `"Custom Status"` if the type is `ActivityType.custom` when initializing, but not sure if this is the best way to do it. This currently requires developers to explicitly set the `type` field to `ActivityType.custom` because it defaults to `ActivityType.unknown`, as seen in the example below:

```py
await bot.change_presence(activity=discord.Activity(type=discord.ActivityType.custom, state="I'm Batman."))
```

I feel like this should be made easier on the developer frontend, resulting with the following:

```py
await bot.change_presence(activity=discord.Activity(state="I'm Batman."))
# or maybe even this:
await bot.change_presence(activity=discord.Activity("I'm Batman."))
```

I'm ready to push the change necessary to implement the last suggestion if the idea is approved.

## Information
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
