### PR TITLE
Add a command() decorator for bridge

### DIFF
--- a/discord/ext/bridge/bot.py
+++ b/discord/ext/bridge/bot.py
@@ -98,8 +98,26 @@ class BotBase(ABC):
         command.add_to(self)  # type: ignore
 
         self.bridge_commands.append(command)
-
+        
     def bridge_command(self, **kwargs):
+        """A shortcut decorator that invokes :func:`bridge_command` and adds it to
+        the internal command list via :meth:`~.Bot.add_bridge_command`.
+
+        Returns
+        -------
+        Callable[..., :class:`BridgeCommand`]
+            A decorator that converts the provided method into an :class:`.BridgeCommand`, adds both a slash and
+            traditional (prefix-based) version of the command to the bot, and returns the :class:`.BridgeCommand`.
+        """
+
+        def decorator(func) -> BridgeCommand:
+            result = bridge_command(**kwargs)(func)
+            self.add_bridge_command(result)
+            return result
+
+        return decorator
+        
+    def command(self, **kwargs):
         """A shortcut decorator that invokes :func:`bridge_command` and adds it to
         the internal command list via :meth:`~.Bot.add_bridge_command`.
 


### PR DESCRIPTION
## Summary

Add a shortcut for @bridge.bridge_command() decorator - @bridge.command()

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
