### PR TITLE
fix: DMChannel.recipient and User.dm_channel being None after calling User.create_dm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,8 @@ These changes are available on the `master` branch, but have not yet been releas
   `Webhook` class. ([#2156](https://github.com/Pycord-Development/pycord/pull/2156))
 - Fixed `ScheduledEvent.creator_id` returning `str` instead of `int`.
   ([#2162](https://github.com/Pycord-Development/pycord/pull/2162))
+- Fixed `DMChannel.recipient` being None and consequently `User.dm_channel` also being None.
+  ([#]())
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2817,7 +2817,7 @@ class DMChannel(discord.abc.Messageable, Hashable):
         self._state: ConnectionState = state
         self.recipient: User | None = None
         if r := data.get("recipients"):
-            self.recipient: state.store_user(r[0])
+            self.recipient = state.store_user(r[0])
         self.me: ClientUser = me
         self.id: int = int(data["id"])
 


### PR DESCRIPTION
## Summary
In the current version (v2.5.0.rc3) the ``User.dm_channel`` is None even after calling ``User.create_dm``.
It is due to a recipient not being assigned to ``DMChannel.recipient``.
<!-- What is this pull request for? Does it fix any issues? -->
```py
import discord
import secret

client = discord.Client()

@client.event
async def on_ready():
    zajcek_user = await client.get_or_fetch_user(145196308985020416)
    print(zajcek_user.dm_channel)
    await zajcek_user.create_dm()
    print(zajcek_user.dm_channel)

    await client.close()

client.run(secret.TOKEN)
```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
