### PR TITLE
fix: ffmpeg terminated prematurely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
+- Fixed ffmpeg being terminated prematurely when piping audio stream.
+  ([#2240](https://github.com/Pycord-Development/pycord/pull/2240))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/player.py
+++ b/discord/player.py
@@ -227,7 +227,7 @@ class FFmpegAudio(AudioSource):
             # arbitrarily large read size
             data = source.read(8192)
             if not data:
-                self._process.terminate()
+                self._stdin.close()
                 return
             try:
                 self._stdin.write(data)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

See issue #2205 

When streaming audio from a pipe the ffmpeg process would be terminated immediately
if there was no data left to read from the pipe. This lead to some of the audio being cut off before being fully processed by ffmpeg

This PR closes the ffmpeg process stdin instead and lets ffmpeg close itself gracefully

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
