### PR TITLE
fix: attribute error in command serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
+- Fix `AttributeError` when serializing commands with Annotated typehint
+  ([#2243](https://github.com/Pycord-Development/pycord/pull/2243))
 
 ## [2.4.1] - 2023-03-20
 
@@ -699,8 +701,6 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1350](https://github.com/Pycord-Development/pycord/pull/1350))
 - Make `TextChannel._get_channel` async.
   ([#1358](https://github.com/Pycord-Development/pycord/pull/1358))
-- Fix `AttributeError` when serializing commands with Annotated typehint
-  ([#2243](https://github.com/Pycord-Development/pycord/pull/2243))
 
 ## [2.0.0-beta.7] - 2022-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -699,6 +699,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#1350](https://github.com/Pycord-Development/pycord/pull/1350))
 - Make `TextChannel._get_channel` async.
   ([#1358](https://github.com/Pycord-Development/pycord/pull/1358))
+- Fix `AttributeError` when serializing commands with Annotated typehint
+  ([#2243](https://github.com/Pycord-Development/pycord/pull/2243))
 
 ## [2.0.0-beta.7] - 2022-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
-- Fix `AttributeError` when serializing commands with Annotated typehint
+- Fixed `AttributeError` when serializing commands with `Annotated` type hints.
   ([#2243](https://github.com/Pycord-Development/pycord/pull/2243))
 
 ## [2.4.1] - 2023-03-20

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -746,10 +746,12 @@ class SlashCommand(ApplicationCommand):
                 option = next(option_gen, Option())
                 # Handle Optional
                 if self._is_typing_optional(type_hint):
-                    option.input_type = get_args(type_hint)[0]
+                    option.input_type = SlashCommandOptionType.from_datatype(
+                        get_args(type_hint)[0]
+                    )
                     option.default = None
                 else:
-                    option.input_type = type_hint
+                    option.input_type = SlashCommandOptionType.from_datatype(type_hint)
 
             if self._is_typing_union(option):
                 if self._is_typing_optional(option):

--- a/tests/test_typing_annotated.py
+++ b/tests/test_typing_annotated.py
@@ -15,7 +15,9 @@ def test_typing_annotated():
     bot = discord.Bot()
     bot.add_application_command(cmd)
     dict_result = cmd.to_dict()
-    assert dict_result.get("options")[0].get("type") == SlashCommandOptionType.string.value
+    assert (
+        dict_result.get("options")[0].get("type") == SlashCommandOptionType.string.value
+    )
 
 
 def test_typing_annotated_decorator():
@@ -40,7 +42,7 @@ def test_typing_annotated_cog():
 
         @slash_command()
         async def echo(
-                self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
+            self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
         ):
             await ctx.respond(txt)
 
@@ -65,7 +67,7 @@ def test_typing_annotated_cog_slashgroup():
 
         @grp.command()
         async def echo(
-                self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
+            self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
         ):
             await ctx.respond(txt)
 

--- a/tests/test_typing_annotated.py
+++ b/tests/test_typing_annotated.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
-import pytest
 from typing_extensions import Annotated
 
 import discord
-from discord import ApplicationContext
+from discord import SlashCommandOptionType
 from discord.commands.core import SlashCommand, slash_command
 
 
@@ -15,6 +14,8 @@ def test_typing_annotated():
     cmd = SlashCommand(echo)
     bot = discord.Bot()
     bot.add_application_command(cmd)
+    dict_result = cmd.to_dict()
+    assert dict_result.get("options")[0].get("type") == SlashCommandOptionType.string.value
 
 
 def test_typing_annotated_decorator():
@@ -23,6 +24,12 @@ def test_typing_annotated_decorator():
     @bot.slash_command()
     async def echo(ctx, txt: Annotated[str, discord.Option(description="Some text")]):
         await ctx.respond(txt)
+
+    dict_result = echo.to_dict()
+
+    option = dict_result.get("options")[0]
+    assert option.get("type") == SlashCommandOptionType.string.value
+    assert option.get("description") == "Some text"
 
 
 def test_typing_annotated_cog():
@@ -33,12 +40,19 @@ def test_typing_annotated_cog():
 
         @slash_command()
         async def echo(
-            self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
+                self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
         ):
             await ctx.respond(txt)
 
     bot = discord.Bot()
-    bot.add_cog(echoCog(bot))
+    cog = echoCog(bot)
+    bot.add_cog(cog)
+
+    dict_result = cog.echo.to_dict()
+
+    option = dict_result.get("options")[0]
+    assert option.get("type") == SlashCommandOptionType.string.value
+    assert option.get("description") == "Some text"
 
 
 def test_typing_annotated_cog_slashgroup():
@@ -51,12 +65,19 @@ def test_typing_annotated_cog_slashgroup():
 
         @grp.command()
         async def echo(
-            self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
+                self, ctx, txt: Annotated[str, discord.Option(description="Some text")]
         ):
             await ctx.respond(txt)
 
     bot = discord.Bot()
-    bot.add_cog(echoCog(bot))
+    cog = echoCog(bot)
+    bot.add_cog(cog)
+
+    dict_result = cog.echo.to_dict()
+
+    option = dict_result.get("options")[0]
+    assert option.get("type") == SlashCommandOptionType.string.value
+    assert option.get("description") == "Some text"
 
 
 def test_typing_annotated_optional():
@@ -67,6 +88,11 @@ def test_typing_annotated_optional():
     bot = discord.Bot()
     bot.add_application_command(cmd)
 
+    dict_result = cmd.to_dict()
+
+    option = dict_result.get("options")[0]
+    assert option.get("type") == SlashCommandOptionType.string.value
+
 
 def test_no_annotation():
     async def echo(ctx, txt: str):
@@ -76,6 +102,11 @@ def test_no_annotation():
     bot = discord.Bot()
     bot.add_application_command(cmd)
 
+    dict_result = cmd.to_dict()
+
+    option = dict_result.get("options")[0]
+    assert option.get("type") == SlashCommandOptionType.string.value
+
 
 def test_annotated_no_option():
     async def echo(ctx, txt: Annotated[str, "..."]):
@@ -84,3 +115,8 @@ def test_annotated_no_option():
     cmd = SlashCommand(echo)
     bot = discord.Bot()
     bot.add_application_command(cmd)
+
+    dict_result = cmd.to_dict()
+
+    option = dict_result.get("options")[0]
+    assert option.get("type") == SlashCommandOptionType.string.value


### PR DESCRIPTION
## Summary
When Serializing commands which have a `Annotated` annotation it comes to a AttributeError because the type information is not wrapped in SlashCommand type.

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
