### PR TITLE
chore(bridge): use BridgeOption instead of Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2099](https://github.com/Pycord-Development/pycord/pull/2099))
 - Changed the support from `orjson` to `msgspec` in the codebase.
   ([#2170](https://github.com/Pycord-Development/pycord/pull/2170))
+- `BridgeOption` must now be used for arguments in bridge commands.
+  ([#2252](https://github.com/Pycord-Development/pycord/pull/2252))
 
 ### Removed
 

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -591,7 +591,8 @@ BRIDGE_CONVERTER_MAPPING = {
 
 
 class BridgeOption(Option, Converter):
-    """Slash command option for bridge commands. Otherwise equivalent in every way to :class:`discord.Option`."""
+    """Represents a selectable slash command option and a prefixed command argument for bridge commands.
+    """
 
     async def convert(self, ctx, argument: str) -> Any:
         try:

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -592,7 +592,9 @@ BRIDGE_CONVERTER_MAPPING = {
 
 
 class BridgeOption(Option, Converter):
-    """Represents a selectable slash command option and a prefixed command argument for bridge commands."""
+    """A subclass of :class:`discord.Option` which represents a selectable slash
+    command option and a prefixed command argument for bridge commands.
+    """
 
     async def convert(self, ctx, argument: str) -> Any:
         try:

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -591,6 +591,8 @@ BRIDGE_CONVERTER_MAPPING = {
 
 
 class BridgeOption(Option, Converter):
+    """Slash command option for bridge commands. Otherwise equivalent in every way to :class:`discord.Option`."""
+
     async def convert(self, ctx, argument: str) -> Any:
         try:
             if self.converter is not None:
@@ -621,7 +623,3 @@ class BridgeOption(Option, Converter):
             return converted
         except ValueError as exc:
             raise BadArgument() from exc
-
-
-discord.commands.options.Option = BridgeOption
-discord.Option = BridgeOption

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -66,7 +66,7 @@ __all__ = (
     "BridgeSlashCommand",
     "BridgeExtGroup",
     "BridgeSlashGroup",
-    "BridgeContext",
+    "BridgeOption",
     "map_to",
     "guild_only",
     "has_permissions",

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -66,6 +66,7 @@ __all__ = (
     "BridgeSlashCommand",
     "BridgeExtGroup",
     "BridgeSlashGroup",
+    "BridgeContext",
     "map_to",
     "guild_only",
     "has_permissions",

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -591,8 +591,7 @@ BRIDGE_CONVERTER_MAPPING = {
 
 
 class BridgeOption(Option, Converter):
-    """Represents a selectable slash command option and a prefixed command argument for bridge commands.
-    """
+    """Represents a selectable slash command option and a prefixed command argument for bridge commands."""
 
     async def convert(self, ctx, argument: str) -> Any:
         try:

--- a/docs/ext/bridge/api.rst
+++ b/docs/ext/bridge/api.rst
@@ -157,3 +157,9 @@ BridgeContext Subclasses
 .. data:: discord.ext.bridge.Context
 
     Alias of :data:`typing.Union` [ :class:`.BridgeExtContext`, :class:`.BridgeApplicationContext` ] for typing convenience.
+
+Option
+------
+
+BridgeOption
+~~~~~~~~~~~~

--- a/docs/ext/bridge/api.rst
+++ b/docs/ext/bridge/api.rst
@@ -163,3 +163,8 @@ Option
 
 BridgeOption
 ~~~~~~~~~~~~
+
+.. attributetable:: discord.ext.bridge.BridgeOption
+
+.. autoclass:: discord.ext.bridge.BridgeOption
+    :members:


### PR DESCRIPTION
## Summary
Removes "Option" for bridge commands. You should now use BridgeOption

Planned for 2.5

Closes #2089 

## Information

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested. (I can't seem to build docs right now, but I'll figure it out)
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.