### PR TITLE
fix(commands): fix permission check edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
+- Fixed attribute in permission checks when running a command in a server where the bot
+  only has the applications.commands scope.
+  ([#2113](https://github.com/Pycord-Development/pycord/issues/2113))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,8 +186,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2240](https://github.com/Pycord-Development/pycord/pull/2240))
 - Fixed tasks looping infinitely when `tzinfo` is neither `None` nor UTC.
   ([#2196](https://github.com/Pycord-Development/pycord/pull/2196))
-- Fixed attribute in permission checks when running a command in a server where the bot
-  only has the applications.commands scope.
+- Fixed `AttributeError` when running permission checks without the `bot` scope.
   ([#2113](https://github.com/Pycord-Development/pycord/issues/2113))
 
 ## [2.4.1] - 2023-03-20

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -712,7 +712,10 @@ class GuildChannel:
             return Permissions.all()
 
         default = self.guild.default_role
-        base = Permissions(default.permissions.value)
+        if default:
+            base = Permissions(default.permissions.value)
+        else:
+            base = Permissions.none()
 
         # Handle the role case first
         if isinstance(obj, Role):

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -712,10 +712,7 @@ class GuildChannel:
             return Permissions.all()
 
         default = self.guild.default_role
-        if default:
-            base = Permissions(default.permissions.value)
-        else:
-            base = Permissions.none()
+        base = Permissions(default.permissions.value if default else 0)
 
         # Handle the role case first
         if isinstance(obj, Role):

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -191,10 +191,9 @@ class Interaction:
         self._permissions: int = 0
 
         self._guild: Guild | None = None
-        if self.guild is None and (_guild_data := data.get("guild")):
-            self._guild = Guild(data=data, state=self)
-
-        self._guild_data = _guild_data
+        self._guild_data = data.get("guild")
+        if self.guild is None and self._guild_data:
+            self._guild = Guild(data=self._guild_data, state=self)
 
         # TODO: there's a potential data loss here
         if self.guild_id:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -149,6 +149,8 @@ class Interaction:
         "custom_id",
         "_channel_data",
         "_message_data",
+        "_guild_data",
+        "_guild",
         "_permissions",
         "_app_permissions",
         "_state",
@@ -187,6 +189,11 @@ class Interaction:
 
         self.user: User | Member | None = None
         self._permissions: int = 0
+
+        if (_guild_data := data.get("guild")):
+            self._state._get_create_guild(_guild_data)
+
+        self._guild_data = _guild_data
 
         # TODO: there's a potential data loss here
         if self.guild_id:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -190,8 +190,9 @@ class Interaction:
         self.user: User | Member | None = None
         self._permissions: int = 0
 
-        if (_guild_data := data.get("guild")):
-            self._state._get_create_guild(_guild_data)
+        self._guild: Guild | None = None
+        if self.guild is None and (_guild_data := data.get("guild")):
+            self._guild = Guild(data=data, state=self)
 
         self._guild_data = _guild_data
 
@@ -253,6 +254,8 @@ class Interaction:
     @property
     def guild(self) -> Guild | None:
         """The guild the interaction was sent from."""
+        if self._guild:
+            return self._guild
         return self._state and self._state._get_guild(self.guild_id)
 
     def is_command(self) -> bool:


### PR DESCRIPTION
## Summary
Fixes #2113

Inviting a bot to a server with only the applications.commands scope results in permission checks giving AttributeError because it can't crosscheck permissions of channel and user to the default role of the server (interaction gives a partial guild object).

I decided to fix this by assuming the default role has no permissions (so permission checks always fail)

I also made it so that a guild object is created and accessible from `interaction.guild` but not added to the cache. I was thinking it shouldn't be added to state because this is a weird edge case that pycord v2 doesn't support, and the guild only has "locale", "id", and "features" (which is an empty list).

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.