### PR TITLE
fix: TypeErrors raised from Reaction events

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -256,7 +256,7 @@ class RawReactionActionEvent(_RawReprMixin):
         self.burst: bool = data.get("burst")
         self.burst_colours: list = data.get("burst_colors", [])
         self.burst_colors: list = self.burst_colours
-        self.type: ReactionType = try_enum(data.get("type", 0))
+        self.type: ReactionType = try_enum(ReactionType, data.get("type", 0))
 
         try:
             self.guild_id: int | None = int(data["guild_id"])
@@ -333,7 +333,7 @@ class RawReactionClearEmojiEvent(_RawReprMixin):
         self.burst: bool = data.get("burst")
         self.burst_colours: list = data.get("burst_colors", [])
         self.burst_colors: list = self.burst_colours
-        self.type: ReactionType = try_enum(data.get("type", 0))
+        self.type: ReactionType = try_enum(ReactionType, data.get("type", 0))
 
         try:
             self.guild_id: int | None = int(data["guild_id"])


### PR DESCRIPTION
## Summary
idk how i missed this
fixes `try_enum` used in some Reaction Event payloads

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
