### PR TITLE
fix(ext.bridge/commands): default arguments with Option don't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
+- Fixed `Option` not working on bridge commands because `ext.commands.Command` doesn't
+  recognize them. ([#2256](https://github.com/Pycord-Development/pycord/pull/2256))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -45,11 +45,11 @@ import discord
 
 from ...commands import (
     ApplicationCommand,
+    Option,
     _BaseCommand,
     message_command,
     slash_command,
     user_command,
-    Option
 )
 from ...enums import ChannelType
 from ...errors import *
@@ -567,7 +567,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             required = param.annotation.required or param.annotation.default is None
             default = param.annotation.default
         else:
-            required = (param.default is param.empty)
+            required = param.default is param.empty
             default = param.default
 
         converter = get_converter(param)

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -564,11 +564,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
     async def transform(self, ctx: Context, param: inspect.Parameter) -> Any:
         if isinstance(param.annotation, Option):
-            required = param.annotation.required or param.annotation.default is None
             default = param.annotation.default
+            required = param.annotation.required or default is None
         else:
-            required = param.default is param.empty
             default = param.default
+            required = default is param.empty
 
         converter = get_converter(param)
         consume_rest_is_special = (


### PR DESCRIPTION
## Summary
Fix #2089
Bridge commands that use discord.Option don't have their default values or "required" attributes recognized by ext.commands.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
