### PR TITLE
fix: `Intents.all` returning the wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,8 +180,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
-- Fixed `discord.Intents.all()` returning the wrong value.
-  ([#2195](https://github.com/Pycord-Development/pycord/issues/2195))
+- Fixed `Intents.all()` returning the wrong value.
+  ([#2257](https://github.com/Pycord-Development/pycord/issues/2257))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
+- Fixed `discord.Intents.all()` returning the wrong value. ([#2195](https://github.com/Pycord-Development/pycord/issues/2195))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2192](https://github.com/Pycord-Development/pycord/pull/2192))
 - Fixed `DMChannel.recipient` being `None` and consequently `User.dm_channel` also being
   `None`. ([#2219](https://github.com/Pycord-Development/pycord/pull/2219))
-- Fixed `discord.Intents.all()` returning the wrong value. ([#2195](https://github.com/Pycord-Development/pycord/issues/2195))
+- Fixed `discord.Intents.all()` returning the wrong value.
+  ([#2195](https://github.com/Pycord-Development/pycord/issues/2195))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -636,10 +636,7 @@ class Intents(BaseFlags):
     @classmethod
     def all(cls: type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled."""
-        shifts = list(
-            dict.fromkeys([flag.bit_length() - 1 for flag in cls.VALID_FLAGS.values()])
-        )
-        value = sum(1 << shift for shift in shifts)
+        value = sum(set(1 << (flag.bit_length() - 1) for flag in cls.VALID_FLAGS.values()))
 
         self = cls.__new__(cls)
         self.value = value

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -636,8 +636,9 @@ class Intents(BaseFlags):
     @classmethod
     def all(cls: type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled."""
-        bits = max(cls.VALID_FLAGS.values()).bit_length()
-        value = ((1 << bits) - 1) - (1 << 19) - (1 << 18) - (1 << 17)  # Removing the unused flags
+        shifts = list(dict.fromkeys([flag.bit_length() - 1 for flag in cls.VALID_FLAGS.values()]))
+        value = sum(1 << shift for shift in shifts)
+
         self = cls.__new__(cls)
         self.value = value
         return self

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -636,7 +636,9 @@ class Intents(BaseFlags):
     @classmethod
     def all(cls: type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled."""
-        shifts = list(dict.fromkeys([flag.bit_length() - 1 for flag in cls.VALID_FLAGS.values()]))
+        shifts = list(
+            dict.fromkeys([flag.bit_length() - 1 for flag in cls.VALID_FLAGS.values()])
+        )
         value = sum(1 << shift for shift in shifts)
 
         self = cls.__new__(cls)

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -637,7 +637,7 @@ class Intents(BaseFlags):
     def all(cls: type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled."""
         bits = max(cls.VALID_FLAGS.values()).bit_length()
-        value = (1 << bits) - 1
+        value = ((1 << bits) - 1) - (1 << 19) - (1 << 18) - (1 << 17)  # Removing the unused flags
         self = cls.__new__(cls)
         self.value = value
         return self

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -636,7 +636,7 @@ class Intents(BaseFlags):
     @classmethod
     def all(cls: type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled."""
-        value = sum(set(1 << (flag.bit_length() - 1) for flag in cls.VALID_FLAGS.values()))
+        value = sum({1 << (flag.bit_length() - 1) for flag in cls.VALID_FLAGS.values()})
 
         self = cls.__new__(cls)
         self.value = value


### PR DESCRIPTION
## Summary

This pull request fixes [Issue 2195](https://github.com/Pycord-Development/pycord/issues/2195), with reusable code that gets every flag and removes the unused flags, instead of getting the highest flag.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
