### PR TITLE
feat: Allow users to run one command to install both packages for speedup and voice support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ possible (see our [Version Guarantees] for more info).
 These changes are available on the `master` branch, but have not yet been released.
 
 ### Added
+
 - Added one command to install both packages for speedup and voice support.
   ([#2261](https://github.com/Pycord-Development/pycord/pull/2261))
 - Added possibility to start bot via async context manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ possible (see our [Version Guarantees] for more info).
 These changes are available on the `master` branch, but have not yet been released.
 
 ### Added
-
+- Added one command to install both packages for speedup and voice support.
+  ([#2261](https://github.com/Pycord-Development/pycord/pull/2261))
 - Added possibility to start bot via async context manager.
   ([#1801](https://github.com/Pycord-Development/pycord/pull/1801))
 - Added new parameters (`author`, `footer`, `image`, `thumbnail`) to `discord.Embed`.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -56,6 +56,11 @@ To get voice support, you should use ``py-cord[voice]`` instead of ``py-cord``, 
 
     python3 -m pip install -U py-cord[voice]
 
+
+To get both voice support and speedup with one command, you should use ``py-cord[all]`` instead of ``py-cord``, e.g. ::
+
+    python3 -m pip install -U py-cord[all]
+
 On Linux environments, installing voice requires getting the following dependencies:
 
 - `libffi <https://github.com/libffi/libffi>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = {file = "requirements/_.txt"}
 docs = {file = "requirements/docs.txt"}
 speed = {file = "requirements/speed.txt"}
 voice = {file = "requirements/voice.txt"}
+all = {file = "requirements/all.txt"}
 
 [tool.setuptools_scm]
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -1,4 +1,3 @@
--r dev.txt
--r docs.txt
--r speed.txt
--r voice.txt
+msgspec~=0.18.4
+aiohttp[speedups]
+PyNaCl>=1.3.0,<1.6


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR allows users to run one command to install both packages for speedup and voice support, eg:
`python3 -m pip install py-cord[all]`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters). (kinda, it adds a new install method)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...). (kinda, it updates docs and pyproject)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
