### PR TITLE
fix: offset-aware time when preparing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2113](https://github.com/Pycord-Development/pycord/issues/2113))
 - Fixed `Option` not working on bridge commands because `ext.commands.Command` doesn't
   recognize them. ([#2256](https://github.com/Pycord-Development/pycord/pull/2256))
+- Fixed offset-aware tasks causing `TypeError` when being prepared.
+  ([#2271](https://github.com/Pycord-Development/pycord/pull/2271))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -619,9 +619,9 @@ class Loop(Generic[LF]):
             now
             if now is not MISSING
             else datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
-        ).timetz()
+        )
         for idx, time in enumerate(self._time):
-            if time >= time_now:
+            if time >= time_now.astimezone(time.tzinfo).timetz():
                 self._time_index = idx
                 break
         else:


### PR DESCRIPTION
## Summary
Fixes #1990.

## Information
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
