### PR TITLE
fix: update typed dicts for commands

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -781,8 +781,8 @@ class ApplicationCommandMixin(ABC):
                         lambda cmd: cmd.name == i["name"]
                         and cmd.type == i.get("type")
                         and cmd.guild_ids is not None
-                        # TODO: fix this type error (guild_id is not defined in ApplicationCommand Typed Dict)
-                        and int(i["guild_id"]) in cmd.guild_ids,  # type: ignore
+                        and (guild_id := i.get("guild_id"))
+                        and guild_id in cmd.guild_ids,
                         self.pending_application_commands,
                     )
                     if not cmd:

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -47,35 +47,45 @@ ApplicationCommandType = Literal[1, 2, 3]
 
 
 class ApplicationCommand(TypedDict):
-    options: NotRequired[list[ApplicationCommandOption]]
-    type: NotRequired[ApplicationCommandType]
-    name_localized: NotRequired[str]
-    name_localizations: NotRequired[dict[str, str]]
-    description_localized: NotRequired[str]
-    description_localizations: NotRequired[dict[str, str]]
     id: Snowflake
+    type: NotRequired[ApplicationCommandType]
     application_id: Snowflake
+    guild_id: NotRequired[Snowflake]
     name: str
+    name_localizations: NotRequired[dict[str, str] | None]
     description: str
+    description_localizations: NotRequired[dict[str, str] | None]
+    options: NotRequired[list[ApplicationCommandOption]]
+    default_member_permissions: str | None
+    dm_permission: NotRequired[bool]
+    default_permission: NotRequired[bool | None]
+    nsfw: NotRequired[bool]
+    version: Snowflake
 
 
 ApplicationCommandOptionType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
 
 class ApplicationCommandOption(TypedDict):
-    choices: NotRequired[list[ApplicationCommandOptionChoice]]
-    options: NotRequired[list[ApplicationCommandOption]]
-    name_localizations: NotRequired[dict[str, str]]
-    description_localizations: NotRequired[dict[str, str]]
     type: ApplicationCommandOptionType
     name: str
+    name_localizations: NotRequired[dict[str, str] | None]
     description: str
+    description_localizations: NotRequired[dict[str, str] | None]
     required: bool
+    options: NotRequired[list[ApplicationCommandOption]]
+    choices: NotRequired[list[ApplicationCommandOptionChoice]]
+    channel_types: NotRequired[list[ChannelType]]
+    min_value: NotRequired[int | float]
+    max_value: NotRequired[int | float]
+    min_length: NotRequired[int]
+    max_length: NotRequired[int]
+    autocomplete: NotRequired[bool]
 
 
 class ApplicationCommandOptionChoice(TypedDict):
-    name_localizations: NotRequired[dict[str, str]]
     name: str
+    name_localizations: NotRequired[dict[str, str] | None]
     value: str | int
 
 


### PR DESCRIPTION
## Summary
Closes #1741.
To be honest I'm not sure whether this is a patch or a feature.
Also I don't think this requires a changelog as the changes are only internal.

## Information
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
