### PR TITLE
fix: `AttributeError` when comparing commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,8 +203,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2257](https://github.com/Pycord-Development/pycord/issues/2257))
 - Fixed `AuditLogIterator` not respecting the `after` parameter.
   ([#2295](https://github.com/Pycord-Development/pycord/issues/2295))
-- Fixed `ApplicationCommand` equality comparison method not being entirely precise
-  and causing `AttributeError`s due to its structure.
+- Fixed `ApplicationCommand` equality comparison method not being entirely precise and
+  causing `AttributeError`s due to its structure.
   ([#2299](https://github.com/Pycord-Development/pycord/issues/2299))
 
 ## [2.4.1] - 2023-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2257](https://github.com/Pycord-Development/pycord/issues/2257))
 - Fixed `AuditLogIterator` not respecting the `after` parameter.
   ([#2295](https://github.com/Pycord-Development/pycord/issues/2295))
+- Fixed `ApplicationCommand` equality comparison method not being entirely precise
+  and causing `AttributeError`s due to its structure.
+  ([#2299](https://github.com/Pycord-Development/pycord/issues/2299))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,8 +205,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2295](https://github.com/Pycord-Development/pycord/issues/2295))
 - Fixed `AttributeError` when failing to establish initial websocket connection.
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
-- Fixed `ApplicationCommand` equality comparison method not being entirely precise and
-  causing `AttributeError`s due to its structure.
+- Fixed `AttributeError` when comparing application commands with non-command objects.
   ([#2299](https://github.com/Pycord-Development/pycord/issues/2299))
 
 ## [2.4.1] - 2023-03-20

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -235,10 +235,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"
 
     def __eq__(self, other) -> bool:
-        return (
-            isinstance(other, self.__class__)
-            and self.to_dict() == other.to_dict()
-        )
+        return isinstance(other, self.__class__) and self.to_dict() == other.to_dict()
 
     async def __call__(self, ctx, *args, **kwargs):
         """|coro|

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -235,7 +235,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"
 
     def __eq__(self, other) -> bool:
-        return isinstance(other, self.__class__) and self.to_dict() == other.to_dict()
+        return isinstance(other, self.__class__) and self.qualified_name == other.qualified_name and self.guild_ids == other.guild_ids
 
     async def __call__(self, ctx, *args, **kwargs):
         """|coro|

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -235,15 +235,9 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"
 
     def __eq__(self, other) -> bool:
-        if (
-            getattr(self, "id", None) is not None
-            and getattr(other, "id", None) is not None
-        ):
-            check = self.id == other.id
-        else:
-            check = self.name == other.name and self.guild_ids == other.guild_ids
         return (
-            isinstance(other, self.__class__) and self.parent == other.parent and check
+            isinstance(other, self.__class__)
+            and self.to_dict() == other.to_dict()
         )
 
     async def __call__(self, ctx, *args, **kwargs):

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -235,7 +235,11 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         return f"<discord.commands.{self.__class__.__name__} name={self.name}>"
 
     def __eq__(self, other) -> bool:
-        return isinstance(other, self.__class__) and self.qualified_name == other.qualified_name and self.guild_ids == other.guild_ids
+        return (
+            isinstance(other, self.__class__)
+            and self.qualified_name == other.qualified_name
+            and self.guild_ids == other.guild_ids
+        )
 
     async def __call__(self, ctx, *args, **kwargs):
         """|coro|


### PR DESCRIPTION
## Summary
Fixes `AttributeError`s that occur when comparing application commands with non-command objects.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
