### PR TITLE
fix: `AttributeError` when failing to establish initial websocket connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2257](https://github.com/Pycord-Development/pycord/issues/2257))
 - Fixed `AuditLogIterator` not respecting the `after` parameter.
   ([#2295](https://github.com/Pycord-Development/pycord/issues/2295))
-- Fixed `AttributeError` in `client.connect` when user has unstable internet
+- Fixed `AttributeError` when failing to establish initial websocket connection.
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 
 ## [2.4.1] - 2023-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,9 @@ These changes are available on the `master` branch, but have not yet been releas
   classes. ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
 
 ### Fixed
-- Fixed `AttributeError` when user has unstable internet ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
+
+- Fixed `AttributeError` when user has unstable internet
+  ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ These changes are available on the `master` branch, but have not yet been releas
   classes. ([#2063](https://github.com/Pycord-Development/pycord/pull/2063))
 
 ### Fixed
-
+- Fixed `AttributeError` when user has unstable internet ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,8 +126,6 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed `AttributeError` when user has unstable internet
-  ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
@@ -205,6 +203,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2257](https://github.com/Pycord-Development/pycord/issues/2257))
 - Fixed `AuditLogIterator` not respecting the `after` parameter.
   ([#2295](https://github.com/Pycord-Development/pycord/issues/2295))
+- Fixed `AttributeError` in `client.connect` when user has unstable internet
+  ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -653,6 +653,8 @@ class Client:
                 # Always try to RESUME the connection
                 # If the connection is not RESUME-able then the gateway will invalidate the session.
                 # This is apparently what the official Discord client does.
+                if self.ws is None:
+                    continue
                 ws_params.update(
                     sequence=self.ws.sequence, resume=True, session=self.ws.session_id
                 )


### PR DESCRIPTION
## Summary

Fixes #2300 

## Information
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
