### PR TITLE
fix: change default attribute of `SlashCommandGroup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2257](https://github.com/Pycord-Development/pycord/issues/2257))
 - Fixed `AuditLogIterator` not respecting the `after` parameter.
   ([#2295](https://github.com/Pycord-Development/pycord/issues/2295))
+- Fixed `MISSING` attribute of command under a subcommand group under a command group
+  ([#2302](https://github.com/Pycord-Development/pycord/issues/2302))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,7 +206,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` when failing to establish initial websocket connection.
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by `command.cog` being `MISSING`.
-  ([#2302](https://github.com/Pycord-Development/pycord/issues/2302))
+  ([#2303](https://github.com/Pycord-Development/pycord/issues/2303))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2295](https://github.com/Pycord-Development/pycord/issues/2295))
 - Fixed `AttributeError` when failing to establish initial websocket connection.
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
-- Fixed `MISSING` attribute of command under a subcommand group under a command group
+- Fixed `AttributeError` caused by `command.cog` being `MISSING`.
   ([#2302](https://github.com/Pycord-Development/pycord/issues/2302))
 
 ## [2.4.1] - 2023-03-20

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -254,7 +254,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         convert the arguments beforehand, so take care to pass the correct
         arguments in.
         """
-        if self.cog is not None:
+        if self.cog is not None and self.cog is not MISSING:
             return await self.callback(self.cog, ctx, *args, **kwargs)
         return await self.callback(ctx, *args, **kwargs)
 
@@ -392,7 +392,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             predicates = self.parent.checks + predicates
 
         cog = self.cog
-        if cog is not None:
+        if cog is not None and cog is not MISSING:
             local_check = cog._get_overridden_method(cog.cog_check)
             if local_check is not None:
                 ret = await maybe_coroutine(local_check, ctx)
@@ -414,13 +414,13 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             pass
         else:
             injected = wrap_callback(coro)
-            if cog is not None:
+            if cog is not None and cog is not MISSING:
                 await injected(cog, ctx, error)
             else:
                 await injected(ctx, error)
 
         try:
-            if cog is not None:
+            if cog is not None and cog is not MISSING:
                 local = cog.__class__._get_overridden_method(cog.cog_command_error)
                 if local is not None:
                     wrapped = wrap_callback(local)
@@ -544,7 +544,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
                 await self._after_invoke(ctx)  # type: ignore
 
         # call the cog local hook if applicable:
-        if cog is not None:
+        if cog is not None and cog is not MISSING:
             hook = cog.__class__._get_overridden_method(cog.cog_after_invoke)
             if hook is not None:
                 await hook(ctx)
@@ -998,7 +998,7 @@ class SlashCommand(ApplicationCommand):
             if o._parameter_name not in kwargs:
                 kwargs[o._parameter_name] = o.default
 
-        if self.cog is not None:
+        if self.cog is not None and self.cog is not MISSING:
             await self.callback(self.cog, ctx, **kwargs)
         elif self.parent is not None and self.attached_to_group is True:
             await self.callback(self.parent, ctx, **kwargs)

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -846,7 +846,7 @@ class SlashCommand(ApplicationCommand):
 
     @property
     def cog(self):
-        return getattr(self, "_cog", MISSING)
+        return getattr(self, "_cog", None)
 
     @cog.setter
     def cog(self, val):
@@ -1238,10 +1238,7 @@ class SlashCommandGroup(ApplicationCommand):
         return as_dict
 
     def add_command(self, command: SlashCommand) -> None:
-        # check if subcommand has no cog set
-        # also check if cog is MISSING because it
-        # might not have been set by the cog yet
-        if command.cog is MISSING and self.cog is not MISSING:
+        if command.cog is None and self.cog is not None:
             command.cog = self.cog
 
         self.subcommands.append(command)

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1162,7 +1162,7 @@ class SlashCommandGroup(ApplicationCommand):
 
         self._before_invoke = None
         self._after_invoke = None
-        self.cog = MISSING
+        self.cog = None
         self.id = None
 
         # Permissions

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -254,7 +254,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         convert the arguments beforehand, so take care to pass the correct
         arguments in.
         """
-        if self.cog:
+        if self.cog is not None:
             return await self.callback(self.cog, ctx, *args, **kwargs)
         return await self.callback(ctx, *args, **kwargs)
 
@@ -392,7 +392,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             predicates = self.parent.checks + predicates
 
         cog = self.cog
-        if cog:
+        if cog is not None:
             local_check = cog._get_overridden_method(cog.cog_check)
             if local_check is not None:
                 ret = await maybe_coroutine(local_check, ctx)
@@ -414,13 +414,13 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             pass
         else:
             injected = wrap_callback(coro)
-            if cog:
+            if cog is not None:
                 await injected(cog, ctx, error)
             else:
                 await injected(ctx, error)
 
         try:
-            if cog:
+            if cog is not None:
                 local = cog.__class__._get_overridden_method(cog.cog_command_error)
                 if local is not None:
                     wrapped = wrap_callback(local)
@@ -544,7 +544,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
                 await self._after_invoke(ctx)  # type: ignore
 
         # call the cog local hook if applicable:
-        if cog:
+        if cog is not None:
             hook = cog.__class__._get_overridden_method(cog.cog_after_invoke)
             if hook is not None:
                 await hook(ctx)
@@ -998,7 +998,7 @@ class SlashCommand(ApplicationCommand):
             if o._parameter_name not in kwargs:
                 kwargs[o._parameter_name] = o.default
 
-        if self.cog:
+        if self.cog is not None:
             await self.callback(self.cog, ctx, **kwargs)
         elif self.parent is not None and self.attached_to_group is True:
             await self.callback(self.parent, ctx, **kwargs)

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -254,7 +254,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         convert the arguments beforehand, so take care to pass the correct
         arguments in.
         """
-        if self.cog is not None and self.cog is not MISSING:
+        if self.cog:
             return await self.callback(self.cog, ctx, *args, **kwargs)
         return await self.callback(ctx, *args, **kwargs)
 
@@ -392,7 +392,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             predicates = self.parent.checks + predicates
 
         cog = self.cog
-        if cog is not None and cog is not MISSING:
+        if cog:
             local_check = cog._get_overridden_method(cog.cog_check)
             if local_check is not None:
                 ret = await maybe_coroutine(local_check, ctx)
@@ -414,13 +414,13 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             pass
         else:
             injected = wrap_callback(coro)
-            if cog is not None and cog is not MISSING:
+            if cog:
                 await injected(cog, ctx, error)
             else:
                 await injected(ctx, error)
 
         try:
-            if cog is not None and cog is not MISSING:
+            if cog:
                 local = cog.__class__._get_overridden_method(cog.cog_command_error)
                 if local is not None:
                     wrapped = wrap_callback(local)
@@ -544,7 +544,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
                 await self._after_invoke(ctx)  # type: ignore
 
         # call the cog local hook if applicable:
-        if cog is not None and cog is not MISSING:
+        if cog:
             hook = cog.__class__._get_overridden_method(cog.cog_after_invoke)
             if hook is not None:
                 await hook(ctx)
@@ -998,7 +998,7 @@ class SlashCommand(ApplicationCommand):
             if o._parameter_name not in kwargs:
                 kwargs[o._parameter_name] = o.default
 
-        if self.cog is not None and self.cog is not MISSING:
+        if self.cog:
             await self.callback(self.cog, ctx, **kwargs)
         elif self.parent is not None and self.attached_to_group is True:
             await self.callback(self.parent, ctx, **kwargs)


### PR DESCRIPTION
## Summary

Fixes #2302 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
