### PR TITLE
fix: cog can still be MISSING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,9 +206,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed `AttributeError` when failing to establish initial websocket connection.
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by `command.cog` being `MISSING`.
-  ([#2303](https://github.com/Pycord-Development/pycord/issues/2303))
-- Fixed command options instantiated from @bot.slash_command().
-  ([#2313](https://github.com/Pycord-Development/pycord/issues/2313))
+  ([#2303](https://github.com/Pycord-Development/pycord/issues/2303) &
+  [#2313](https://github.com/Pycord-Development/pycord/issues/2313))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by `command.cog` being `MISSING`.
   ([#2303](https://github.com/Pycord-Development/pycord/issues/2303))
+- Fixed command options instantiated from @bot.slash_command().
+  ([#2313](https://github.com/Pycord-Development/pycord/issues/2313))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -54,7 +54,7 @@ from .interactions import Interaction
 from .shard import AutoShardedClient
 from .types import interactions
 from .user import User
-from .utils import MISSING, async_all, find, get
+from .utils import async_all, find, get
 
 CoroFunc = Callable[..., Coroutine[Any, Any, Any]]
 CFT = TypeVar("CFT", bound=CoroFunc)
@@ -122,9 +122,6 @@ class ApplicationCommandMixin(ABC):
         """
         if isinstance(command, SlashCommand) and command.is_subcommand:
             raise TypeError("The provided command is a sub-command of group")
-
-        if command.cog is MISSING:
-            command._set_cog(None)
 
         if self._bot.debug_guilds and command.guild_ids is None:
             command.guild_ids = self._bot.debug_guilds
@@ -267,9 +264,9 @@ class ApplicationCommandMixin(ABC):
                             for data in match["options"]
                             if data["name"] == subcommand.name
                         ),
-                        MISSING,
+                        None,
                     )
-                    if match_ is not MISSING and _check_command(subcommand, match_):
+                    if match_ and _check_command(subcommand, match_):
                         return True
             else:
                 as_dict = cmd.to_dict()
@@ -298,17 +295,15 @@ class ApplicationCommandMixin(ABC):
                         falsy_vals = (False, [])
                         for opt in value:
                             cmd_vals = (
-                                [val.get(opt, MISSING) for val in as_dict[check]]
+                                [val.get(opt) for val in as_dict[check]]
                                 if check in as_dict
                                 else []
                             )
                             for i, val in enumerate(cmd_vals):
                                 if val in falsy_vals:
-                                    cmd_vals[i] = MISSING
-                            if match.get(
-                                check, MISSING
-                            ) is not MISSING and cmd_vals != [
-                                val.get(opt, MISSING) for val in match[check]
+                                    cmd_vals[i] = None
+                            if match.get(check) and cmd_vals != [
+                                val.get(opt) for val in match[check]
                             ]:
                                 # We have a difference
                                 return True


### PR DESCRIPTION
## Summary

https://github.com/Pycord-Development/pycord/issues/2303 partially changed checks of `MISSING` to `None` with the assumption that cog would never be `MISSING`. Cog is `MISSING` for commands instantiated from `@bot.slash_command()`. 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
