### PR TITLE
feat: implement `(Sync)WebhookMessage.thread`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `default_reaction_emoji` parameter to `Guild.create_forum_channel()` and
   `ForumChannel.edit()` methods.
   ([#2178](https://github.com/Pycord-Development/pycord/pull/2178))
+- Added properties `WebhookMessage.thread` and `SyncWebhookMessage.thread`.
+  ([#2314](https://github.com/Pycord-Development/pycord/pull/2314))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by `command.cog` being `MISSING`.
   ([#2303](https://github.com/Pycord-Development/pycord/issues/2303))
+- Fixed `TypeError` caused by `WebhookMessage._thread_id` being `None`.
+  ([#2314](https://github.com/Pycord-Development/pycord/pull/2314))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -960,9 +960,7 @@ class WebhookMessage(Message):
 
             asyncio.create_task(inner_call())
         else:
-            await self._state._webhook.delete_message(
-                self.id, thread_id=self.thread.id
-            )
+            await self._state._webhook.delete_message(self.id, thread_id=self.thread.id)
 
 
 class BaseWebhook(Hashable):

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -54,6 +54,9 @@ from ..mixins import Hashable
 from ..object import Object
 from ..threads import Thread
 from ..user import BaseUser, User
+from ..types.message import Message as MessagePayload
+from ..state import ConnectionState
+from ..abc import MessageableChannel
 
 __all__ = (
     "Webhook",

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -37,6 +37,7 @@ from urllib.parse import quote as urlquote
 import aiohttp
 
 from .. import utils
+from ..abc import MessageableChannel
 from ..asset import Asset
 from ..channel import ForumChannel, PartialMessageable
 from ..enums import WebhookType, try_enum
@@ -52,11 +53,10 @@ from ..http import Route
 from ..message import Attachment, Message
 from ..mixins import Hashable
 from ..object import Object
-from ..threads import Thread
-from ..user import BaseUser, User
-from ..types.message import Message as MessagePayload
 from ..state import ConnectionState
-from ..abc import MessageableChannel
+from ..threads import Thread
+from ..types.message import Message as MessagePayload
+from ..user import BaseUser, User
 
 __all__ = (
     "Webhook",

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -819,6 +819,7 @@ class WebhookMessage(Message):
     """
 
     _state: _WebhookState
+    _thread_id: int | None = None
 
     async def edit(
         self,
@@ -894,7 +895,7 @@ class WebhookMessage(Message):
             There was no token associated with this webhook.
         """
         thread = MISSING
-        if hasattr(self, "_thread_id") and self._thread_id is not None:
+        if self._thread_id is not None:
             thread = Object(self._thread_id)
         elif isinstance(self.channel, Thread):
             thread = Object(self.channel.id)
@@ -942,7 +943,7 @@ class WebhookMessage(Message):
             Deleting the message failed.
         """
         thread_id: int | None = None
-        if hasattr(self, "_thread_id") and self._thread_id is not None:
+        if self._thread_id is not None:
             thread_id = self._thread_id
         elif isinstance(self.channel, Thread):
             thread_id = self.channel.id

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -827,7 +827,7 @@ class WebhookMessage(Message):
         state: ConnectionState,
         channel: MessageableChannel,
         data: MessagePayload,
-        thread_id: int | None = None
+        thread_id: int | None = None,
     ):
         super().__init__(state=state, channel=channel, data=data)
 
@@ -837,7 +837,6 @@ class WebhookMessage(Message):
             self._thread = Object(self.channel.id)
         elif isinstance(self.channel, ForumChannel):
             self._thread = Object(self.id)
-
 
     async def edit(
         self,
@@ -967,7 +966,9 @@ class WebhookMessage(Message):
 
             asyncio.create_task(inner_call())
         else:
-            await self._state._webhook.delete_message(self.id, thread_id=self._thread.id)
+            await self._state._webhook.delete_message(
+                self.id, thread_id=self._thread.id
+            )
 
 
 class BaseWebhook(Hashable):

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -894,7 +894,7 @@ class WebhookMessage(Message):
             There was no token associated with this webhook.
         """
         thread = MISSING
-        if hasattr(self, "_thread_id"):
+        if hasattr(self, "_thread_id") and self._thread_id is not None:
             thread = Object(self._thread_id)
         elif isinstance(self.channel, Thread):
             thread = Object(self.channel.id)
@@ -942,7 +942,7 @@ class WebhookMessage(Message):
             Deleting the message failed.
         """
         thread_id: int | None = None
-        if hasattr(self, "_thread_id"):
+        if hasattr(self, "_thread_id") and self._thread_id is not None:
             thread_id = self._thread_id
         elif isinstance(self.channel, Thread):
             thread_id = self.channel.id

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -463,7 +463,24 @@ class SyncWebhookMessage(Message):
     """
 
     _state: _WebhookState
-    _thread_id: int | None = None
+    _thread: Object | None = MISSING
+
+    def __init__(
+        self,
+        *,
+        state: ConnectionState,
+        channel: MessageableChannel,
+        data: MessagePayload,
+        thread_id: int | None = None
+    ):
+        super().__init__(state=state, channel=channel, data=data)
+
+        if thread_id is not None:
+            self._thread = Object(thread_id)
+        elif isinstance(self.channel, Thread):
+            self._thread = Object(self.channel.id)
+        elif isinstance(self.channel, ForumChannel):
+            self._thread = Object(self.id)
 
     def edit(
         self,
@@ -1148,8 +1165,6 @@ class SyncWebhook(BaseWebhook):
             thread_id=thread_id,
         )
         msg = self._create_message(data)
-        if isinstance(msg.channel, PartialMessageable):
-            msg._thread_id = thread_id
 
         return msg
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -463,6 +463,7 @@ class SyncWebhookMessage(Message):
     """
 
     _state: _WebhookState
+    _thread_id: int | None = None
 
     def edit(
         self,
@@ -515,7 +516,7 @@ class SyncWebhookMessage(Message):
             There was no token associated with this webhook.
         """
         thread = MISSING
-        if hasattr(self, "_thread_id") and self._thread_id is not None:
+        if self._thread_id is not None:
             thread = Object(self._thread_id)
         elif isinstance(self.channel, Thread):
             thread = Object(self.channel.id)
@@ -555,7 +556,7 @@ class SyncWebhookMessage(Message):
         """
 
         thread_id: int | None = None
-        if hasattr(self, "_thread_id") and self._thread_id is not None:
+        if self._thread_id is not None:
             thread_id = self._thread_id
         elif isinstance(self.channel, Thread):
             thread_id = self.channel.id

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -54,6 +54,9 @@ from ..message import Message
 from ..object import Object
 from ..threads import Thread
 from .async_ import BaseWebhook, _WebhookState, handle_message_parameters
+from ..types.message import Message as MessagePayload
+from ..state import ConnectionState
+from ..abc import MessageableChannel
 
 __all__ = (
     "SyncWebhook",

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -471,7 +471,7 @@ class SyncWebhookMessage(Message):
         state: ConnectionState,
         channel: MessageableChannel,
         data: MessagePayload,
-        thread_id: int | None = None
+        thread_id: int | None = None,
     ):
         super().__init__(state=state, channel=channel, data=data)
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -482,8 +482,6 @@ class SyncWebhookMessage(Message):
             self._thread = Object(thread_id)
         elif isinstance(self.channel, Thread):
             self._thread = Object(self.channel.id)
-        elif isinstance(self.channel, ForumChannel):
-            self._thread = Object(self.id)
 
     def edit(
         self,

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -515,7 +515,7 @@ class SyncWebhookMessage(Message):
             There was no token associated with this webhook.
         """
         thread = MISSING
-        if hasattr(self, "_thread_id"):
+        if hasattr(self, "_thread_id") and self._thread_id is not None:
             thread = Object(self._thread_id)
         elif isinstance(self.channel, Thread):
             thread = Object(self.channel.id)
@@ -555,7 +555,7 @@ class SyncWebhookMessage(Message):
         """
 
         thread_id: int | None = None
-        if hasattr(self, "_thread_id"):
+        if hasattr(self, "_thread_id") and self._thread_id is not None:
             thread_id = self._thread_id
         elif isinstance(self.channel, Thread):
             thread_id = self.channel.id

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 from urllib.parse import quote as urlquote
 
 from .. import utils
+from ..abc import MessageableChannel
 from ..channel import PartialMessageable
 from ..errors import (
     DiscordServerError,
@@ -52,11 +53,10 @@ from ..errors import (
 from ..http import Route
 from ..message import Message
 from ..object import Object
-from ..threads import Thread
-from .async_ import BaseWebhook, _WebhookState, handle_message_parameters
-from ..types.message import Message as MessagePayload
 from ..state import ConnectionState
-from ..abc import MessageableChannel
+from ..threads import Thread
+from ..types.message import Message as MessagePayload
+from .async_ import BaseWebhook, _WebhookState, handle_message_parameters
 
 __all__ = (
     "SyncWebhook",


### PR DESCRIPTION
## Summary

Related to issue #2298
Fixes webhook messages assuming that their `_thread_id` can not be `None` (spoiler; it can)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
