### PR TITLE
fix(pages): default buttons reappearing on page change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,6 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed `self.use_default_buttons` being assumed truthy by `Paginator.update`
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))
@@ -210,6 +209,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2301](https://github.com/Pycord-Development/pycord/pull/2301))
 - Fixed `AttributeError` caused by `command.cog` being `MISSING`.
   ([#2303](https://github.com/Pycord-Development/pycord/issues/2303))
+- Fixed `self.use_default_buttons` being assumed truthy by `Paginator.update`.
+  ([#2319](https://github.com/Pycord-Development/pycord/pull/2319))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fixed `self.use_default_buttons` being assumed truthy by `Paginator.update`
 - Fixed `AttributeError` caused by
   [#1957](https://github.com/Pycord-Development/pycord/pull/1957) when using listeners
   in cogs. ([#1989](https://github.com/Pycord-Development/pycord/pull/1989))

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -569,7 +569,7 @@ class Paginator(discord.ui.View):
             self.buttons = {}
             for button in custom_buttons:
                 self.add_button(button)
-        else:
+        elif self.use_default_buttons:
             self.buttons = {}
             self.add_default_buttons()
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -560,18 +560,18 @@ class Paginator(discord.ui.View):
         self.loop_pages = loop_pages if loop_pages is not None else self.loop_pages
         self.custom_view: discord.ui.View = None if custom_view is None else custom_view
         self.timeout: float = timeout if timeout is not None else self.timeout
+        self.custom_buttons = custom_buttons if custom_buttons is not None else self.custom_buttons
         self.trigger_on_display = (
             trigger_on_display
             if trigger_on_display is not None
             else self.trigger_on_display
         )
-        if custom_buttons and not self.use_default_buttons:
-            self.buttons = {}
-            for button in custom_buttons:
-                self.add_button(button)
-        elif self.use_default_buttons:
-            self.buttons = {}
+        self.buttons = {}
+        if self.use_default_buttons:
             self.add_default_buttons()
+        elif self.custom_buttons:
+            for button in self.custom_buttons:
+                self.add_button(button)
 
         await self.goto_page(self.current_page, interaction=interaction)
 
@@ -679,9 +679,12 @@ class Paginator(discord.ui.View):
         self.update_buttons()
         self.current_page = page_number
         if self.show_indicator:
-            self.buttons["page_indicator"][
-                "object"
-            ].label = f"{self.current_page + 1}/{self.page_count + 1}"
+            try:
+                self.buttons["page_indicator"][
+                    "object"
+                ].label = f"{self.current_page + 1}/{self.page_count + 1}"
+            except KeyError:
+                pass
 
         page = self.pages[page_number]
         page = self.get_page_content(page)
@@ -843,9 +846,12 @@ class Paginator(discord.ui.View):
                     button["object"].label = button["label"]
         self.clear_items()
         if self.show_indicator:
-            self.buttons["page_indicator"][
-                "object"
-            ].label = f"{self.current_page + 1}/{self.page_count + 1}"
+            try:
+                self.buttons["page_indicator"][
+                    "object"
+                ].label = f"{self.current_page + 1}/{self.page_count + 1}"
+            except KeyError:
+                pass
         for key, button in self.buttons.items():
             if key != "page_indicator":
                 if button["hidden"]:

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -560,7 +560,9 @@ class Paginator(discord.ui.View):
         self.loop_pages = loop_pages if loop_pages is not None else self.loop_pages
         self.custom_view: discord.ui.View = None if custom_view is None else custom_view
         self.timeout: float = timeout if timeout is not None else self.timeout
-        self.custom_buttons = custom_buttons if custom_buttons is not None else self.custom_buttons
+        self.custom_buttons = (
+            custom_buttons if custom_buttons is not None else self.custom_buttons
+        )
         self.trigger_on_display = (
             trigger_on_display
             if trigger_on_display is not None


### PR DESCRIPTION
## Summary

Fixes `use_default_buttons` being ignored when updating a paginator.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
