### PR TITLE
feat: add applied_tags parameter to Webhook.send()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `default_reaction_emoji` parameter to `Guild.create_forum_channel()` and
   `ForumChannel.edit()` methods.
   ([#2178](https://github.com/Pycord-Development/pycord/pull/2178))
+- Added `applied_tags` parameter to `Webhook.send()` method.
+  ([#2322](https://github.com/Pycord-Development/pycord/pull/2322))
 
 ### Changed
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -621,7 +621,7 @@ def handle_message_parameters(
     embed: Embed | None = MISSING,
     embeds: list[Embed] = MISSING,
     view: View | None = MISSING,
-    applied_tags: [Snowflake] = MISSING,
+    applied_tags: list[Snowflake] = MISSING,
     allowed_mentions: AllowedMentions | None = MISSING,
     previous_allowed_mentions: AllowedMentions | None = None,
     suppress: bool = False,
@@ -1570,7 +1570,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
-        applied_tags: [Snowflake] = MISSING,
+        applied_tags: list[Snowflake] = MISSING,
         wait: Literal[True],
         delete_after: float = None,
     ) -> WebhookMessage:
@@ -1593,7 +1593,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
-        applied_tags: [Snowflake] = MISSING,
+        applied_tags: list[Snowflake] = MISSING,
         wait: Literal[False] = ...,
         delete_after: float = None,
     ) -> None:
@@ -1615,7 +1615,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
-        applied_tags: [Snowflake] = MISSING,
+        applied_tags: list[Snowflake] = MISSING,
         wait: bool = False,
         delete_after: float = None,
     ) -> WebhookMessage | None:
@@ -1686,7 +1686,7 @@ class Webhook(BaseWebhook):
         thread_name: :class:`str`
             The name of the thread to create. Only works for forum channels.
 
-            .. versionadded:: 2.6
+            .. versionadded:: 2.5
         applied_tags: List[:class:`Snowflake`]
             A list of tags to apply to the message. Only works for threads.
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1686,11 +1686,11 @@ class Webhook(BaseWebhook):
         thread_name: :class:`str`
             The name of the thread to create. Only works for forum channels.
 
-            .. versionadded:: 2.5
+            .. versionadded:: 2.0
         applied_tags: List[:class:`Snowflake`]
             A list of tags to apply to the message. Only works for threads.
 
-            .. versionadded:: 2.0
+            .. versionadded:: 2.5
         delete_after: :class:`float`
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent.

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1715,7 +1715,8 @@ class Webhook(BaseWebhook):
         InvalidArgument
             Either there was no token associated with this webhook, ``ephemeral`` was passed
             with the improper webhook type, there was no state attached with this webhook when
-            giving it a view, or you specified both ``thread_name`` and ``thread``.
+            giving it a view, you specified both ``thread_name`` and ``thread``, or ``applied_tags``
+            was passed with neither ``thread_name`` nor ``thread`` specified.
         """
 
         if self.token is None:

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -621,6 +621,7 @@ def handle_message_parameters(
     embed: Embed | None = MISSING,
     embeds: list[Embed] = MISSING,
     view: View | None = MISSING,
+    applied_tags: [Snowflake] = MISSING,
     allowed_mentions: AllowedMentions | None = MISSING,
     previous_allowed_mentions: AllowedMentions | None = None,
     suppress: bool = False,
@@ -653,6 +654,9 @@ def handle_message_parameters(
 
     flags = MessageFlags(suppress_embeds=suppress, ephemeral=ephemeral)
     payload["flags"] = flags.value
+
+    if applied_tags is not MISSING:
+        payload["applied_tags"] = applied_tags
 
     if allowed_mentions:
         if previous_allowed_mentions is not None:
@@ -1566,6 +1570,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
+        applied_tags: [Snowflake] = MISSING,
         wait: Literal[True],
         delete_after: float = None,
     ) -> WebhookMessage:
@@ -1588,6 +1593,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
+        applied_tags: [Snowflake] = MISSING,
         wait: Literal[False] = ...,
         delete_after: float = None,
     ) -> None:
@@ -1609,6 +1615,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         thread_name: str | None = None,
+        applied_tags: [Snowflake] = MISSING,
         wait: bool = False,
         delete_after: float = None,
     ) -> WebhookMessage | None:
@@ -1679,6 +1686,10 @@ class Webhook(BaseWebhook):
         thread_name: :class:`str`
             The name of the thread to create. Only works for forum channels.
 
+            .. versionadded:: 2.6
+        applied_tags: List[:class:`Snowflake`]
+            A list of tags to apply to the message. Only works for threads.
+
             .. versionadded:: 2.0
         delete_after: :class:`float`
             If provided, the number of seconds to wait in the background
@@ -1721,6 +1732,9 @@ class Webhook(BaseWebhook):
         if thread and thread_name:
             raise InvalidArgument("You cannot specify both a thread and thread_name")
 
+        if applied_tags and not (thread or thread_name):
+            raise InvalidArgument("You cannot specify applied_tags without a thread")
+
         application_webhook = self.type is WebhookType.application
         if ephemeral and not application_webhook:
             raise InvalidArgument(
@@ -1749,6 +1763,7 @@ class Webhook(BaseWebhook):
             embeds=embeds,
             ephemeral=ephemeral,
             view=view,
+            applied_tags=applied_tags,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
         )


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Added applied_tags parameter to Webhook.send(), allowing for forum channel tags to be applied through a webhook.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
