### PR TITLE
fix(typing): proper VoiceClient.play() return value

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -638,7 +638,7 @@ class VoiceClient(VoiceProtocol):
         self,
         source: AudioSource,
         *,
-        after: Callable[[Exception | None], Any] = None,
+        after: Callable[[Exception | None], Any] | None = None,
         wait_finish: Literal[True],
     ) -> asyncio.Future:
         ...

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -647,7 +647,7 @@ class VoiceClient(VoiceProtocol):
         self,
         source: AudioSource,
         *,
-        after: Callable[[Exception | None], Any] = None,
+        after: Callable[[Exception | None], Any] | None = None,
         wait_finish: bool = False,
     ) -> None | asyncio.Future:
         """Plays an :class:`AudioSource`.

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -630,7 +630,8 @@ class VoiceClient(VoiceProtocol):
         *,
         after: Callable[[Exception | None], Any] = None,
         wait_finish: Literal[False] = False,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     @overload
     def play(
@@ -639,7 +640,8 @@ class VoiceClient(VoiceProtocol):
         *,
         after: Callable[[Exception | None], Any] = None,
         wait_finish: Literal[True],
-    ) -> asyncio.Future: ...
+    ) -> asyncio.Future:
+        ...
 
     def play(
         self,

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -46,7 +46,7 @@ import socket
 import struct
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Literal, overload
 
 from . import opus, utils
 from .backoff import ExponentialBackoff
@@ -623,13 +623,31 @@ class VoiceClient(VoiceProtocol):
             user_id
         ]
 
+    @overload
+    def play(
+        self,
+        source: AudioSource,
+        *,
+        after: Callable[[Exception | None], Any] = None,
+        wait_finish: Literal[False] = False,
+    ) -> None: ...
+
+    @overload
+    def play(
+        self,
+        source: AudioSource,
+        *,
+        after: Callable[[Exception | None], Any] = None,
+        wait_finish: Literal[True],
+    ) -> asyncio.Future: ...
+
     def play(
         self,
         source: AudioSource,
         *,
         after: Callable[[Exception | None], Any] = None,
         wait_finish: bool = False,
-    ) -> None:
+    ) -> None | asyncio.Future:
         """Plays an :class:`AudioSource`.
 
         The finalizer, ``after`` is called after the source has been exhausted

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -628,7 +628,7 @@ class VoiceClient(VoiceProtocol):
         self,
         source: AudioSource,
         *,
-        after: Callable[[Exception | None], Any] = None,
+        after: Callable[[Exception | None], Any] | None = None,
         wait_finish: Literal[False] = False,
     ) -> None:
         ...


### PR DESCRIPTION
## Summary

Properly annotate return value of `VoiceClient.play`

Consider this code:

```py
import discord


bot = discord.Bot()


@bot.event
async def on_ready() -> None:
    g = bot.guilds[0]
    ch = g.voice_channels[0]
    c: discord.VoiceClient = await ch.connect()

    # valid
    c.play(discord.FFmpegOpusAudio("something.mp3"))
    await c.play(discord.FFmpegOpusAudio("something.mp3"), wait_finish=True)

    # invalid
    await c.play(discord.FFmpegOpusAudio("something.mp3"))


bot.run("")
```

Mypy says:

```
repro4.py:15: error: "play" of "VoiceClient" does not return a value  [func-returns-value]
repro4.py:18: error: "play" of "VoiceClient" does not return a value  [func-returns-value]
Found 2 errors in 1 file (checked 1 source file)
```

After applying the fix:

```
repro4.py:18: error: Incompatible types in "await" (actual type "None", expected type "Awaitable[Any]")  [misc]
Found 1 error in 1 file (checked 1 source file)
```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
