### PR TITLE
chore: allow versions of aiohttp that are non-breaking forever

### DIFF
--- a/requirements/_.txt
+++ b/requirements/_.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.6.0,<3.10.0
+aiohttp>=3.6.0,<4.0
 typing_extensions>=4,<5; python_version < "3.11"


### PR DESCRIPTION
## Summary

From Pycord 2.5 and above, this would mean we no longer need to update the aiohttp version unless it is a major version with breaking changes (aiohttp luckily follows semver.)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
