### PR TITLE
fix: parse options

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -123,9 +123,6 @@ class ApplicationCommandMixin(ABC):
         if isinstance(command, SlashCommand) and command.is_subcommand:
             raise TypeError("The provided command is a sub-command of group")
 
-        if command.cog is MISSING:
-            command._set_cog(None)
-
         if self._bot.debug_guilds and command.guild_ids is None:
             command.guild_ids = self._bot.debug_guilds
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -694,6 +694,7 @@ class SlashCommand(ApplicationCommand):
         self.attached_to_group: bool = False
 
         self.options: list[Option] = kwargs.get("options", [])
+        self._validate_parameters()
 
         try:
             checks = func.__commands_checks__


### PR DESCRIPTION
## Summary
https://github.com/Pycord-Development/pycord/commit/fc7b1042c4a9a942b9996dfe96f56aac059e179c stopped the setter method of `SlashCommand.cog` from being executed, causing `._validate_parameters` to be never run and options to be never parsed.

## Information
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.