### PR TITLE
fix: parse options again after setting cog

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -710,9 +710,9 @@ class SlashCommand(ApplicationCommand):
     def _validate_parameters(self):
         params = self._get_signature_parameters()
         if kwop := self.options:
-            self.options: list[Option] = self._match_option_param_names(params, kwop)
+            self.options = self._match_option_param_names(params, kwop)
         else:
-            self.options: list[Option] = self._parse_options(params)
+            self.options = self._parse_options(params)
 
     def _check_required_params(self, params):
         params = iter(params.items())
@@ -850,9 +850,13 @@ class SlashCommand(ApplicationCommand):
         return getattr(self, "_cog", None)
 
     @cog.setter
-    def cog(self, val):
-        self._cog = val
-        self._validate_parameters()
+    def cog(self, value):
+        old_cog = self.cog
+        self._cog = value
+
+        if old_cog is None and value is not None or value is None and old_cog is not None:
+            params = self._get_signature_parameters()
+            self.options = self._parse_options(params)
 
     @property
     def is_subcommand(self) -> bool:

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -854,7 +854,12 @@ class SlashCommand(ApplicationCommand):
         old_cog = self.cog
         self._cog = value
 
-        if old_cog is None and value is not None or value is None and old_cog is not None:
+        if (
+            old_cog is None
+            and value is not None
+            or value is None
+            and old_cog is not None
+        ):
             params = self._get_signature_parameters()
             self.options = self._parse_options(params)
 


### PR DESCRIPTION
## Summary
Overlooked case in #2327, now tested with both standalone commands and cog commands.

## Information
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
