### PR TITLE
fix: slash options broken when declared explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2299](https://github.com/Pycord-Development/pycord/issues/2299))
 - Fixed `AttributeError` when copying groups on startup.
   ([#2331](https://github.com/Pycord-Development/pycord/issues/2331))
+- Fixed application command options causing errors if declared through the option decorator or kwarg.
+  ([#2332](https://github.com/Pycord-Development/pycord/issues/2332))
 
 ## [2.4.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2299](https://github.com/Pycord-Development/pycord/issues/2299))
 - Fixed `AttributeError` when copying groups on startup.
   ([#2331](https://github.com/Pycord-Development/pycord/issues/2331))
-- Fixed application command options causing errors if declared through the option decorator or kwarg.
+- Fixed application command options causing errors if declared through the option
+  decorator or kwarg.
   ([#2332](https://github.com/Pycord-Development/pycord/issues/2332))
 
 ## [2.4.1] - 2023-03-20

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -688,7 +688,8 @@ class SlashCommand(ApplicationCommand):
 
         self.attached_to_group: bool = False
 
-        self.options: list[Option] = kwargs.get("options", [])
+        self._options_kwargs = kwargs.get("options", [])
+        self.options: list[Option] = []
         self._validate_parameters()
 
         try:
@@ -704,7 +705,7 @@ class SlashCommand(ApplicationCommand):
 
     def _validate_parameters(self):
         params = self._get_signature_parameters()
-        if kwop := self.options:
+        if kwop := self._options_kwargs:
             self.options = self._match_option_param_names(params, kwop)
         else:
             self.options = self._parse_options(params)
@@ -727,6 +728,8 @@ class SlashCommand(ApplicationCommand):
     def _parse_options(self, params, *, check_params: bool = True) -> list[Option]:
         if check_params:
             params = self._check_required_params(params)
+        else:
+            params = iter(params.items())
 
         final_options = []
         for p_name, p_obj in params:
@@ -790,6 +793,7 @@ class SlashCommand(ApplicationCommand):
         return final_options
 
     def _match_option_param_names(self, params, options):
+        options = list(options)
         params = self._check_required_params(params)
 
         check_annotations: list[Callable[[Option, type], bool]] = [
@@ -855,8 +859,7 @@ class SlashCommand(ApplicationCommand):
             or value is None
             and old_cog is not None
         ):
-            params = self._get_signature_parameters()
-            self.options = self._parse_options(params)
+            self._validate_parameters()
 
     @property
     def is_subcommand(self) -> bool:


### PR DESCRIPTION
## Summary

Fixes command options being dysfunctional when declared through decorators or the `options` kwarg in `SlashCommand`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
