### PR TITLE
fix: setting options using default syntax makes option optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed application command options causing errors if declared through the option
   decorator or kwarg.
   ([#2332](https://github.com/Pycord-Development/pycord/issues/2332))
+- Fixed options declared using the 'default' syntax always being optional.
+  ([#2333](https://github.com/Pycord-Development/pycord/issues/2333))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -760,24 +760,23 @@ class SlashCommand(ApplicationCommand):
 
             if not isinstance(option, Option):
                 if isinstance(p_obj.default, Option):
-                    p_obj.default.input_type = SlashCommandOptionType.from_datatype(
-                        option
-                    )
+                    if p_obj.default.input_type is None:
+                        p_obj.default.input_type = SlashCommandOptionType.from_datatype(
+                            option
+                        )
                     option = p_obj.default
                 else:
                     option = Option(option)
 
             if option.default is None and not p_obj.default == inspect.Parameter.empty:
-                if isinstance(p_obj.default, type) and issubclass(
+                if isinstance(p_obj.default, Option):
+                    pass
+                elif isinstance(p_obj.default, type) and issubclass(
                     p_obj.default, (DiscordEnum, Enum)
                 ):
                     option = Option(p_obj.default)
-                elif (
-                    isinstance(p_obj.default, Option)
-                    and not (default := p_obj.default.default) is None
-                ):
-                    option.default = default
                 else:
+                    print('a')
                     option.default = p_obj.default
                     option.required = False
             if option.name is None:

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -776,7 +776,6 @@ class SlashCommand(ApplicationCommand):
                 ):
                     option = Option(p_obj.default)
                 else:
-                    print('a')
                     option.default = p_obj.default
                     option.required = False
             if option.name is None:


### PR DESCRIPTION
## Summary

Setting options like so:
```py
@discord.slash_command()
async def test(ctx, test=discord.Option(int, name="test")):
    await ctx.respond(f"Test: {test}")
```
would result in the option being optional, with the default value being the option itself (`<discord.commands.Option name=test>`)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
