### PR TITLE
fix: skip BridgeContext when parsing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2332](https://github.com/Pycord-Development/pycord/issues/2332))
 - Fixed options declared using the 'default' syntax always being optional.
   ([#2333](https://github.com/Pycord-Development/pycord/issues/2333))
+- Fixed `BridgeContext` type hints raising an exception for unsupported option type.
+  ([#2337](https://github.com/Pycord-Development/pycord/pull/2337))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -28,8 +28,6 @@ import types
 from collections import namedtuple
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, Union
 
-from .ext.bridge import BridgeContext
-
 __all__ = (
     "Enum",
     "ChannelType",
@@ -810,6 +808,7 @@ class SlashCommandOptionType(Enum):
             return cls.number
 
         from .commands.context import ApplicationContext
+        from .ext.bridge import BridgeContext
 
         if not issubclass(
             datatype, (ApplicationContext, BridgeContext)

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -28,6 +28,8 @@ import types
 from collections import namedtuple
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, Union
 
+from .ext.bridge import BridgeContext
+
 __all__ = (
     "Enum",
     "ChannelType",
@@ -810,7 +812,7 @@ class SlashCommandOptionType(Enum):
         from .commands.context import ApplicationContext
 
         if not issubclass(
-            datatype, ApplicationContext
+            datatype, (ApplicationContext, BridgeContext)
         ):  # TODO: prevent ctx being passed here in cog commands
             raise TypeError(
                 f"Invalid class {datatype} used as an input type for an Option"


### PR DESCRIPTION
## Summary
Fixes #2335.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
