### PR TITLE
fix: add accurate type hints to `HistoryIterator`

### DIFF
--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -370,7 +370,9 @@ class HistoryIterator(_AsyncIterator["Message"]):
         """Retrieve messages and update next parameters."""
         raise NotImplementedError
 
-    async def _retrieve_messages_before_strategy(self, retrieve: int) -> list[MessagePayload]:
+    async def _retrieve_messages_before_strategy(
+        self, retrieve: int
+    ) -> list[MessagePayload]:
         """Retrieve messages using before parameter."""
         before = self.before.id if self.before else None
         data: list[MessagePayload] = await self.logs_from(
@@ -382,7 +384,9 @@ class HistoryIterator(_AsyncIterator["Message"]):
             self.before = Object(id=int(data[-1]["id"]))
         return data
 
-    async def _retrieve_messages_after_strategy(self, retrieve: int) -> list[MessagePayload]:
+    async def _retrieve_messages_after_strategy(
+        self, retrieve: int
+    ) -> list[MessagePayload]:
         """Retrieve messages using after parameter."""
         after = self.after.id if self.after else None
         data: list[MessagePayload] = await self.logs_from(
@@ -394,7 +398,9 @@ class HistoryIterator(_AsyncIterator["Message"]):
             self.after = Object(id=int(data[0]["id"]))
         return data
 
-    async def _retrieve_messages_around_strategy(self, retrieve: int) -> list[MessagePayload]:
+    async def _retrieve_messages_around_strategy(
+        self, retrieve: int
+    ) -> list[MessagePayload]:
         """Retrieve messages using around parameter."""
         if self.around:
             around = self.around.id if self.around else None

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -335,7 +335,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         except asyncio.QueueEmpty:
             raise NoMoreItems()
 
-    def _get_retrieve(self):
+    def _get_retrieve(self) -> bool:
         l = self.limit
         if l is None or l > 100:
             r = 100
@@ -366,11 +366,11 @@ class HistoryIterator(_AsyncIterator["Message"]):
                     self.state.create_message(channel=channel, data=element)
                 )
 
-    async def _retrieve_messages(self, retrieve) -> list[Message]:
+    async def _retrieve_messages(self, retrieve: int) -> list[MessagePayload]:
         """Retrieve messages and update next parameters."""
         raise NotImplementedError
 
-    async def _retrieve_messages_before_strategy(self, retrieve):
+    async def _retrieve_messages_before_strategy(self, retrieve: int) -> list[MessagePayload]:
         """Retrieve messages using before parameter."""
         before = self.before.id if self.before else None
         data: list[MessagePayload] = await self.logs_from(
@@ -382,7 +382,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
             self.before = Object(id=int(data[-1]["id"]))
         return data
 
-    async def _retrieve_messages_after_strategy(self, retrieve):
+    async def _retrieve_messages_after_strategy(self, retrieve: int) -> list[MessagePayload]:
         """Retrieve messages using after parameter."""
         after = self.after.id if self.after else None
         data: list[MessagePayload] = await self.logs_from(
@@ -394,7 +394,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
             self.after = Object(id=int(data[0]["id"]))
         return data
 
-    async def _retrieve_messages_around_strategy(self, retrieve):
+    async def _retrieve_messages_around_strategy(self, retrieve: int) -> list[MessagePayload]:
         """Retrieve messages using around parameter."""
         if self.around:
             around = self.around.id if self.around else None


### PR DESCRIPTION
## Summary

Reading the code, it was a bit confusing to see ` -> list[Message]` while it should be ` -> list[MessagePayload]` in that context.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
