### PR TITLE
feat: Implement Attachmentflags and Attachment expiry attributes

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1525,7 +1525,7 @@ class AttachmentFlags(BaseFlags):
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
 
-    .. versionadded:: 1.3
+    .. versionadded:: 2.5
 
     Attributes
     -----------

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1490,7 +1490,7 @@ class ChannelFlags(BaseFlags):
 
 @fill_with_flags()
 class AttachmentFlags(BaseFlags):
-    r"""Wraps up a Discord Attachmanet flag value.
+    r"""Wraps up the Discord Attachment flags.
 
     See :class:`SystemChannelFlags`.
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -32,6 +32,7 @@ from .enums import UserFlags
 __all__ = (
     "SystemChannelFlags",
     "MessageFlags",
+    "AttachmentFlags",
     "PublicUserFlags",
     "Intents",
     "MemberCacheFlags",
@@ -1485,3 +1486,68 @@ class ChannelFlags(BaseFlags):
         .. versionadded:: 2.2
         """
         return 1 << 4
+
+
+@fill_with_flags()
+class AttachmentFlags(BaseFlags):
+    r"""Wraps up a Discord Attachmanet flag value.
+
+    See :class:`SystemChannelFlags`.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two flags are equal.
+        .. describe:: x != y
+
+            Checks if two flags are not equal.
+        .. describe:: x + y
+
+            Adds two flags together. Equivalent to ``x | y``.
+        .. describe:: x - y
+
+            Subtracts two flags from each other.
+        .. describe:: x | y
+
+            Returns the union of two flags. Equivalent to ``x + y``.
+        .. describe:: x & y
+
+            Returns the intersection of two flags.
+        .. describe:: ~x
+
+            Returns the inverse of a flag.
+        .. describe:: hash(x)
+
+               Return the flag's hash.
+        .. describe:: iter(x)
+
+               Returns an iterator of ``(name, value)`` pairs. This allows it
+               to be, for example, constructed as a dict or a list of pairs.
+
+    .. versionadded:: 1.3
+
+    Attributes
+    -----------
+    value: :class:`int`
+        The raw value. This value is a bit array field of a 53-bit integer
+        representing the currently available flags. You should query
+        flags via the properties rather than using this raw value.
+    """
+
+    __slots__ = ()
+
+    @flag_value
+    def is_clip(self):
+        """:class:`bool`: Returns ``True`` if the attachment is a clip."""
+        return 1 << 0
+
+    @flag_value
+    def is_thumbnail(self):
+        """:class:`bool`: Returns ``True`` if the attachment is a thumbnail."""
+        return 1 << 1
+
+    @flag_value
+    def is_remix(self):
+        """:class:`bool`: Returns ``True`` if the attachment has been remixed."""
+        return 1 << 2

--- a/discord/message.py
+++ b/discord/message.py
@@ -231,13 +231,13 @@ class Attachment(Hashable):
         self._is: str | None = None
         self.hm: str | None = None
 
-        q = urlparse(self.url).query
+        query = urlparse(self.url).query
         extras = ["_ex", "_is", "hm"]
-        if qs := parse_qs(q):
+        if query_params := parse_qs(query):
             for attr in extras:
-                v = "".join(qs.get(attr.replace("_", ""), []))
-                if v:
-                    setattr(self, attr, v)
+                value = "".join(query_params.get(attr.replace("_", ""), []))
+                if value:
+                    setattr(self, attr, value)
 
     @property
     def expires_at(self) -> datetime.datetime:

--- a/discord/message.py
+++ b/discord/message.py
@@ -29,7 +29,6 @@ import datetime
 import io
 import re
 from os import PathLike
-from urllib.parse import urlparse, parse_qs
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -40,6 +39,7 @@ from typing import (
     Union,
     overload,
 )
+from urllib.parse import parse_qs, urlparse
 
 from . import utils
 from .components import _component_factory
@@ -48,7 +48,7 @@ from .emoji import Emoji
 from .enums import ChannelType, MessageType, try_enum
 from .errors import InvalidArgument
 from .file import File
-from .flags import MessageFlags, AttachmentFlags
+from .flags import AttachmentFlags, MessageFlags
 from .guild import Guild
 from .member import Member
 from .mixins import Hashable
@@ -180,12 +180,12 @@ class Attachment(Hashable):
         The base64 encoded bytearray representing a sampled waveform (currently for voice messages).
 
         .. versionadded:: 2.5
-        
+
     flags: :class:`AttachmentFlags`
         Extra attributes of the attachment.
 
         .. versionadded:: 2.5
-        
+
     hm: :class:`str`
         The unique signature of this attachment's instance.
 
@@ -230,12 +230,12 @@ class Attachment(Hashable):
         self._ex: str | None = None
         self._is: str | None = None
         self.hm: str | None = None
-        
+
         q = urlparse(self.url).query
-        extras = ['_ex', '_is', 'hm']
-        if (qs := parse_qs(q)):
+        extras = ["_ex", "_is", "hm"]
+        if qs := parse_qs(q):
             for attr in extras:
-                v = ''.join(qs.get(attr.replace('_', ''), []))
+                v = "".join(qs.get(attr.replace("_", ""), []))
                 if v:
                     setattr(self, attr, v)
 

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -74,6 +74,7 @@ class Attachment(TypedDict):
     proxy_url: str
     duration_secs: NotRequired[float]
     waveform: NotRequired[str]
+    flags: NotRequired[int]
 
 
 MessageActivityType = Literal[1, 2, 3, 5]

--- a/docs/api/data_classes.rst
+++ b/docs/api/data_classes.rst
@@ -118,6 +118,11 @@ Flags
 .. autoclass:: MessageFlags()
     :members:
 
+.. attributetable:: AttachmentFlags
+
+.. autoclass:: AttachmentFlags()
+    :members:
+
 .. attributetable:: PublicUserFlags
 
 .. autoclass:: PublicUserFlags()


### PR DESCRIPTION
## Summary

- Adds Attachment flags for clips, thumbnails and remix
- Adds attributes for the new attachment URL expiry rules, the most relevant being `Attachment.expires_at` and `Attachment.issued_at`. `Attachment.hm` is included for completion.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
