### PR TITLE
fix: `(Sync)WebhookMessage._thread_id` could be `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2333](https://github.com/Pycord-Development/pycord/issues/2333))
 - Fixed `BridgeContext` type hints raising an exception for unsupported option type.
   ([#2337](https://github.com/Pycord-Development/pycord/pull/2337))
+- Fixed `TypeError` due to `(Sync)WebhookMessage._thread_id` being set to `None`.
+  ([#2343](https://github.com/Pycord-Development/pycord/pull/2343))
 
 ## [2.4.1] - 2023-03-20
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1855,7 +1855,7 @@ class Webhook(BaseWebhook):
             thread_id=thread_id,
         )
         msg = self._create_message(data)
-        if isinstance(msg.channel, PartialMessageable):
+        if thread_id and isinstance(msg.channel, PartialMessageable):
             msg._thread_id = thread_id
 
         return msg

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -1147,7 +1147,7 @@ class SyncWebhook(BaseWebhook):
             thread_id=thread_id,
         )
         msg = self._create_message(data)
-        if isinstance(msg.channel, PartialMessageable):
+        if thread_id and isinstance(msg.channel, PartialMessageable):
             msg._thread_id = thread_id
 
         return msg


### PR DESCRIPTION
## Summary
Fixes #2298. `._thread_id` is now only set if it's present (i.e. not `None`).

## Information
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
