### PR TITLE
fix: uncatch exception in bot.py: on_connect()

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1175,8 +1175,11 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
         self._after_invoke = None
 
     async def on_connect(self):
-        if self.auto_sync_commands:
-            await self.sync_commands()
+        try:
+            if self.auto_sync_commands:
+                await self.sync_commands()
+        except Exception:
+            _log.exception("on_connect: Exception occurred during syncing commands.")
 
     async def on_interaction(self, interaction):
         await self.process_application_commands(interaction)


### PR DESCRIPTION
## Summary

This error can occur and can't be catch by users.
```
Ignoring exception in on_connect
Traceback (most recent call last):
  File "~/.local/lib/python3.10/site-packages/discord/client.py", line 378, in _run_event
    await coro(*args, **kwargs)
  File "~/.local/lib/python3.10/site-packages/discord/bot.py", line 1167, in on_connect
    raise e
  File "~/.local/lib/python3.10/site-packages/discord/bot.py", line 1165, in on_connect
    await self.sync_commands()
  File "~/.local/lib/python3.10/site-packages/discord/bot.py", line 719, in sync_commands
    registered_commands = await self.register_commands(
  File "~/.local/lib/python3.10/site-packages/discord/bot.py", line 527, in register_commands
    prefetched_commands = await self._bot.http.get_global_commands(
  File "~/.local/lib/python3.10/site-packages/discord/http.py", line 367, in request
    raise NotFound(response, data)
discord.errors.NotFound: 404 Not Found (error code: 10002): Application inconnue
```

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
