### PR TITLE
fix: Add missing kwargs to TextChannel.create_thread and similar methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2273](https://github.com/Pycord-Development/pycord/pull/2273))
 - Added `AttachmentFlags` and attachment attributes `expires_at`, `issued_at` and `hm`.
   ([#2342](https://github.com/Pycord-Development/pycord/pull/2342))
+- Added `invitable` and `slowmode_delay` to `Thread` creation methods.
+  ([#2350](https://github.com/Pycord-Development/pycord/pull/2350))
 
 ### Changed
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -868,6 +868,8 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
         message: Snowflake | None = None,
         auto_archive_duration: ThreadArchiveDuration = MISSING,
         type: ChannelType | None = None,
+        slowmode_delay: int | None = None,
+        invitable: bool | None = None,
         reason: str | None = None,
     ) -> Thread:
         """|coro|
@@ -894,6 +896,12 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
             The type of thread to create. If a ``message`` is passed then this parameter
             is ignored, as a thread created with a message is always a public thread.
             By default, this creates a private thread if this is ``None``.
+        slowmode_delay: Optional[:class:`int`]
+            Specifies the slowmode rate limit for users in this thread, in seconds.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
+        invitable: Optional[:class:`bool`]
+            Whether non-moderators can add other non-moderators to this thread.
+            Only available for private threads, where it defaults to True.
         reason: :class:`str`
             The reason for creating a new thread. Shows up on the audit log.
 
@@ -920,6 +928,8 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
                 auto_archive_duration=auto_archive_duration
                 or self.default_auto_archive_duration,
                 type=type.value,
+                rate_limit_per_user=slowmode_delay or 0,
+                invitable=invitable or True,
                 reason=reason,
             )
         else:
@@ -929,6 +939,7 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
                 name=name,
                 auto_archive_duration=auto_archive_duration
                 or self.default_auto_archive_duration,
+                rate_limit_per_user=slowmode_delay or 0,
                 reason=reason,
             )
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -929,7 +929,7 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
                 or self.default_auto_archive_duration,
                 type=type.value,
                 rate_limit_per_user=slowmode_delay or 0,
-                invitable=invitable or True,
+                invitable=invitable,
                 reason=reason,
             )
         else:

--- a/discord/http.py
+++ b/discord/http.py
@@ -1130,11 +1130,13 @@ class HTTPClient:
         *,
         name: str,
         auto_archive_duration: threads.ThreadArchiveDuration,
+        rate_limit_per_user: int,
         reason: str | None = None,
     ) -> Response[threads.Thread]:
         payload = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
+            "rate_limit_per_user": rate_limit_per_user,
         }
 
         route = Route(
@@ -1152,13 +1154,15 @@ class HTTPClient:
         name: str,
         auto_archive_duration: threads.ThreadArchiveDuration,
         type: threads.ThreadType,
-        invitable: bool = True,
+        rate_limit_per_user: int,
+        invitable: bool,
         reason: str | None = None,
     ) -> Response[threads.Thread]:
         payload = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
             "type": type,
+            "rate_limit_per_user": rate_limit_per_user,
             "invitable": invitable,
         }
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -1730,7 +1730,11 @@ class Message(Hashable):
         await self._state.http.clear_reactions(self.channel.id, self.id)
 
     async def create_thread(
-        self, *, name: str, auto_archive_duration: ThreadArchiveDuration = MISSING, slowmode_delay: int = MISSING,
+        self,
+        *,
+        name: str,
+        auto_archive_duration: ThreadArchiveDuration = MISSING,
+        slowmode_delay: int = MISSING,
     ) -> Thread:
         """|coro|
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -1730,7 +1730,7 @@ class Message(Hashable):
         await self._state.http.clear_reactions(self.channel.id, self.id)
 
     async def create_thread(
-        self, *, name: str, auto_archive_duration: ThreadArchiveDuration = MISSING
+        self, *, name: str, auto_archive_duration: ThreadArchiveDuration = MISSING, slowmode_delay: int = MISSING,
     ) -> Thread:
         """|coro|
 
@@ -1747,9 +1747,12 @@ class Message(Hashable):
         ----------
         name: :class:`str`
             The name of the thread.
-        auto_archive_duration: :class:`int`
+        auto_archive_duration:  Optional[:class:`int`]
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+        slowmode_delay: Optional[:class:`int`]
+            Specifies the slowmode rate limit for user in this thread, in seconds.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
 
         Returns
         -------
@@ -1778,6 +1781,7 @@ class Message(Hashable):
             name=name,
             auto_archive_duration=auto_archive_duration
             or default_auto_archive_duration,
+            rate_limit_per_user=slowmode_delay or 0,
         )
 
         self.thread = Thread(guild=self.guild, state=self._state, data=data)


### PR DESCRIPTION
## Summary

Kwargs `invitable` and `slowmode_delay` were largely missing from thread creation methods, despite being included elsewhere. 
(will test later)
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
