### PR TITLE
feat: Message.enforce_nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2342](https://github.com/Pycord-Development/pycord/pull/2342))
 - Added `invitable` and `slowmode_delay` to `Thread` creation methods.
   ([#2350](https://github.com/Pycord-Development/pycord/pull/2350))
+- Added `Message.enforce_nonce`.
+  ([#2370](https://github.com/Pycord-Development/pycord/pull/2370))
 
 ### Changed
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1346,6 +1346,7 @@ class Messageable:
         stickers: Sequence[GuildSticker | StickerItem] = ...,
         delete_after: float = ...,
         nonce: str | int = ...,
+        enforce_nonce: bool = ...,
         allowed_mentions: AllowedMentions = ...,
         reference: Message | MessageReference | PartialMessage = ...,
         mention_author: bool = ...,
@@ -1365,6 +1366,7 @@ class Messageable:
         stickers: Sequence[GuildSticker | StickerItem] = ...,
         delete_after: float = ...,
         nonce: str | int = ...,
+        enforce_nonce: bool = ...,
         allowed_mentions: AllowedMentions = ...,
         reference: Message | MessageReference | PartialMessage = ...,
         mention_author: bool = ...,
@@ -1384,6 +1386,7 @@ class Messageable:
         stickers: Sequence[GuildSticker | StickerItem] = ...,
         delete_after: float = ...,
         nonce: str | int = ...,
+        enforce_nonce: bool = ...,
         allowed_mentions: AllowedMentions = ...,
         reference: Message | MessageReference | PartialMessage = ...,
         mention_author: bool = ...,
@@ -1403,6 +1406,7 @@ class Messageable:
         stickers: Sequence[GuildSticker | StickerItem] = ...,
         delete_after: float = ...,
         nonce: str | int = ...,
+        enforce_nonce: bool = ...,
         allowed_mentions: AllowedMentions = ...,
         reference: Message | MessageReference | PartialMessage = ...,
         mention_author: bool = ...,
@@ -1423,6 +1427,7 @@ class Messageable:
         stickers=None,
         delete_after=None,
         nonce=None,
+        enforce_nonce=None,
         allowed_mentions=None,
         reference=None,
         mention_author=None,
@@ -1463,6 +1468,10 @@ class Messageable:
         nonce: :class:`int`
             The nonce to use for sending this message. If the message was successfully sent,
             then the message will have a nonce with this value.
+        enforce_nonce: Optional[:class:`bool`]
+            Whether :attr:`nonce` is enforced to be validated.
+
+            .. versionadded:: 2.5
         delete_after: :class:`float`
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent. If the deletion fails,
@@ -1602,6 +1611,7 @@ class Messageable:
                     embed=embed,
                     embeds=embeds,
                     nonce=nonce,
+                    enforce_nonce=nonce,
                     message_reference=reference,
                     stickers=stickers,
                     components=components,
@@ -1627,6 +1637,7 @@ class Messageable:
                     embed=embed,
                     embeds=embeds,
                     nonce=nonce,
+                    enforce_nonce=nonce,
                     allowed_mentions=allowed_mentions,
                     message_reference=reference,
                     stickers=stickers,
@@ -1644,6 +1655,7 @@ class Messageable:
                 embed=embed,
                 embeds=embeds,
                 nonce=nonce,
+                enforce_nonce=nonce,
                 allowed_mentions=allowed_mentions,
                 message_reference=reference,
                 stickers=stickers,

--- a/discord/http.py
+++ b/discord/http.py
@@ -465,6 +465,7 @@ class HTTPClient:
         embed: embed.Embed | None = None,
         embeds: list[embed.Embed] | None = None,
         nonce: str | None = None,
+        enforce_nonce: bool | None = None,
         allowed_mentions: message.AllowedMentions | None = None,
         message_reference: message.MessageReference | None = None,
         stickers: list[sticker.StickerItem] | None = None,
@@ -488,6 +489,9 @@ class HTTPClient:
 
         if nonce:
             payload["nonce"] = nonce
+
+        if enforce_nonce:
+            payload["enforce_nonce"] = enforce_nonce
 
         if allowed_mentions:
             payload["allowed_mentions"] = allowed_mentions
@@ -521,6 +525,7 @@ class HTTPClient:
         embed: embed.Embed | None = None,
         embeds: Iterable[embed.Embed | None] | None = None,
         nonce: str | None = None,
+        enforce_nonce: bool | None = None,
         allowed_mentions: message.AllowedMentions | None = None,
         message_reference: message.MessageReference | None = None,
         stickers: list[sticker.StickerItem] | None = None,
@@ -538,6 +543,8 @@ class HTTPClient:
             payload["embeds"] = embeds
         if nonce:
             payload["nonce"] = nonce
+        if enforce_nonce:
+            payload["enforce_nonce"] = enforce_nonce
         if allowed_mentions:
             payload["allowed_mentions"] = allowed_mentions
         if message_reference:
@@ -581,6 +588,7 @@ class HTTPClient:
         embed: embed.Embed | None = None,
         embeds: list[embed.Embed] | None = None,
         nonce: str | None = None,
+        enforce_nonce: bool | None = None,
         allowed_mentions: message.AllowedMentions | None = None,
         message_reference: message.MessageReference | None = None,
         stickers: list[sticker.StickerItem] | None = None,
@@ -596,6 +604,7 @@ class HTTPClient:
             embed=embed,
             embeds=embeds,
             nonce=nonce,
+            enforce_nonce=enforce_nonce,
             allowed_mentions=allowed_mentions,
             message_reference=message_reference,
             stickers=stickers,

--- a/discord/message.py
+++ b/discord/message.py
@@ -640,6 +640,10 @@ class Message(Hashable):
     nonce: Optional[Union[:class:`str`, :class:`int`]]
         The value used by the discord guild and the client to verify that the message is successfully sent.
         This is not stored long term within Discord's servers and is only used ephemerally.
+    enforce_nonce: Optional[:class:`bool`]
+        Whether :attr:`nonce` is enforced to be validated.
+
+        .. versionadded:: 2.5
     embeds: List[:class:`Embed`]
         A list of embeds the message has.
     channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
@@ -748,6 +752,7 @@ class Message(Hashable):
         "author",
         "attachments",
         "nonce",
+        "enforce_nonce",
         "pinned",
         "role_mentions",
         "type",
@@ -802,6 +807,7 @@ class Message(Hashable):
         self.tts: bool = data["tts"]
         self.content: str = data["content"]
         self.nonce: int | str | None = data.get("nonce")
+        self.enforce_nonce: bool | None = data.get("enforce_nonce")
         self.stickers: list[StickerItem] = [
             StickerItem(data=d, state=state) for d in data.get("sticker_items", [])
         ]
@@ -982,6 +988,9 @@ class Message(Hashable):
 
     def _handle_nonce(self, value: str | int) -> None:
         self.nonce = value
+
+    def _handle_enforce_none(self, value: bool) -> None:
+        self.enforce_nonce = value
 
     def _handle_author(self, author: UserPayload) -> None:
         self.author = self._state.store_user(author)

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -111,6 +111,7 @@ class Message(TypedDict):
     mention_channels: NotRequired[list[ChannelMention]]
     reactions: NotRequired[list[Reaction]]
     nonce: NotRequired[int | str]
+    enforce_nonce: NotRequired[bool]
     webhook_id: NotRequired[Snowflake]
     activity: NotRequired[MessageActivity]
     application: NotRequired[MessageApplication]


### PR DESCRIPTION
## Summary
https://github.com/discord/discord-api-docs/pull/6647

## Information
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
