### PR TITLE
fix: Proper type-hinting & docstring of `Member.move_to`  and `Member.edit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ These changes are available on the `master` branch, but have not yet been releas
 ### Fixed
 
 - Fixed the type-hinting of `Member.move_to` to reflect actual behavior.
--
 
 ## [2.5.0] - 2024-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ These changes are available on the `master` branch, but have not yet been releas
 ### Fixed
 
 - Fixed the type-hinting of `Member.move_to` to reflect actual behavior.
-- ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
+  ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
 
 ## [2.5.0] - 2024-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed the type-hinting of `Member.move_to` to reflect actual behavior.
+- Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual behavior.
   ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
 
 ## [2.5.0] - 2024-03-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These changes are available on the `master` branch, but have not yet been releas
 ### Fixed
 
 - Fixed the type-hinting of `Member.move_to` to reflect actual behavior.
+- ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
 
 ## [2.5.0] - 2024-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual behavior.
-  ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
+- Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
+  behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+### Fixed
+
+- Fixed the type-hinting of `Member.move_to` to reflect actual
+  behavior.
+- 
 ## [2.5.0] - 2024-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed the type-hinting of `Member.move_to` to reflect actual
-  behavior.
-- 
+- Fixed the type-hinting of `Member.move_to` to reflect actual behavior.
+-
+
 ## [2.5.0] - 2024-03-02
 
 ### Added

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -830,6 +830,11 @@ class Intents(BaseFlags):
 
         - :attr:`VoiceChannel.members`
         - :attr:`VoiceChannel.voice_states`
+        - :attr:`StageChannel.members`
+        - :attr:`StageChannel.speakers`
+        - :attr:`StageChannel.listeners`
+        - :attr:`StageChannel.moderators`
+        - :attr:`StageChannel.voice_states`
         - :attr:`Member.voice`
 
         .. note::

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -539,7 +539,7 @@ class Guild(Hashable):
         )
 
         self.owner_id: int | None = utils._get_as_snowflake(guild, "owner_id")
-        self.afk_channel: VocalGuildChannel | None = self.get_channel(
+        self.afk_channel: VoiceChannel | None = self.get_channel(
             utils._get_as_snowflake(guild, "afk_channel_id")
         )  # type: ignore
 
@@ -3422,7 +3422,7 @@ class Guild(Hashable):
 
         Parameters
         ----------
-        channel: Optional[:class:`VoiceChannel`]
+        channel: Optional[Union[:class:`VoiceChannel`, :class:`StageChannel`]]
             Channel the client wants to join. Use ``None`` to disconnect.
         self_mute: :class:`bool`
             Indicates if the client should be self-muted.

--- a/discord/member.py
+++ b/discord/member.py
@@ -958,7 +958,7 @@ class Member(discord.abc.Messageable, _UserTag):
             await self._state.http.edit_my_voice_state(self.guild.id, payload)
 
     async def move_to(
-        self, channel: VocalGuildChannel, *, reason: str | None = None
+        self, channel: VocalGuildChannel | None, *, reason: str | None = None
     ) -> None:
         """|coro|
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -769,7 +769,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         roles: List[:class:`Role`]
             The member's new list of roles. This *replaces* the roles.
-        voice_channel: Optional[:class:`VoiceChannel`]
+        voice_channel: Optional[Union[:class:`VoiceChannel`, :class:`StageChannel`]]
             The voice channel to move the member to.
             Pass ``None`` to kick them from voice.
         reason: Optional[:class:`str`]
@@ -974,7 +974,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Parameters
         ----------
-        channel: Optional[:class:`VoiceChannel`]
+        channel: Optional[Union[:class:`VoiceChannel`, :class:`StageChannel`]]
             The new voice channel to move the member to.
             Pass ``None`` to kick them from voice.
         reason: Optional[:class:`str`]

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -596,7 +596,7 @@ class AutoModActionExecutionEvent:
         The member that triggered the action, if cached.
     channel_id: Optional[:class:`int`]
         The ID of the channel in which the member's content was posted.
-    channel: Optional[Union[:class:`TextChannel`, :class:`Thread`, :class:`VoiceChannel`]]
+    channel: Optional[Union[:class:`TextChannel`, :class:`Thread`, :class:`VoiceChannel`, :class:`StageChannel`]]
         The channel in which the member's content was posted, if cached.
     message_id: Optional[:class:`int`]
         The ID of the message that triggered the action. This is only available if the


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixed type-hinting and docstring for `Member.move_to` as channel is excepted to be `channel: Optional[:class:VoiceChannel]` and `Member.edit`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
