### PR TITLE
fix: add user argument to paginator.edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
+- Fixed `Paginator.edit` to no longer set user to the bot. 
+  ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
-- Fixed `Paginator.edit` to no longer set user to the bot. 
+- Fixed `Paginator.edit` to no longer set user to the bot.
   ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+### Added
+
+- Added `user` argument to `Paginator.edit`.
+  ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
+
 ### Fixed
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -29,8 +29,8 @@ from typing import List
 import discord
 from discord.ext.bridge import BridgeContext
 from discord.ext.commands import Context
-from discord.user import User
 from discord.member import Member
+from discord.user import User
 
 __all__ = (
     "PaginatorButton",

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -29,6 +29,8 @@ from typing import List
 import discord
 from discord.ext.bridge import BridgeContext
 from discord.ext.commands import Context
+from discord.user import User
+from discord.member import Member
 
 __all__ = (
     "PaginatorButton",
@@ -1035,6 +1037,7 @@ class Paginator(discord.ui.View):
         suppress: bool | None = None,
         allowed_mentions: discord.AllowedMentions | None = None,
         delete_after: float | None = None,
+        user: User | Member | None = None,
     ) -> discord.Message | None:
         """Edits an existing message to replace it with the paginator contents.
 
@@ -1060,6 +1063,8 @@ class Paginator(discord.ui.View):
             are used instead.
         delete_after: Optional[:class:`float`]
             If set, deletes the paginator after the specified time.
+        user: Optional[Union[:class:`~discord.User`, :class:`~discord.Member`]]
+            If set, changes the user that this paginator belongs to.
 
         Returns
         -------
@@ -1079,7 +1084,7 @@ class Paginator(discord.ui.View):
         if page_content.custom_view:
             self.update_custom_view(page_content.custom_view)
 
-        self.user = message.author
+        self.user = user or self.user
 
         try:
             self.message = await message.edit(


### PR DESCRIPTION
## Summary

Fixes #2381 
`Paginator.edit` sets `self.user` to the message author... but since you can only edit your own messages, `user` is set to the bot and so breaks author_check. This changes it so you can specify any user for paginator.edit, otherwise uses the existing user if it was already set.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
