### PR TITLE
fix: Replace deprecated pkg_resources with importlib.metadata to clear DeprecationWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
-- Fixed a `DeprecationWarning` from being displayed when running `python -m discord -v`
+- Fixed a deprecation warning from being displayed when running `python -m discord -v`
   by replacing the deprecated module.
   ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
+- Fixed a `DeprecationWarning` from being displayed when running `python -m discord -v` by replacing the depricated module. ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
 - Fixed a `DeprecationWarning` from being displayed when running `python -m discord -v`
-  by replacing the depricated module.
+  by replacing the deprecated module.
   ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
-- Fixed a `DeprecationWarning` from being displayed when running `python -m discord -v` by replacing the depricated module. ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))
+- Fixed a `DeprecationWarning` from being displayed when running `python -m discord -v`
+  by replacing the depricated module.
+  ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))
 
 ### Changed
 

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -24,13 +24,13 @@ DEALINGS IN THE SOFTWARE.
 """
 
 import argparse
+import importlib.metadata
 import platform
 import sys
 from pathlib import Path
 from typing import Tuple
 
 import aiohttp
-import importlib.metadata
 
 import discord
 

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Tuple
 
 import aiohttp
-import pkg_resources
+import importlib.metadata
 
 import discord
 
@@ -47,9 +47,9 @@ def show_version() -> None:
         "- py-cord v{0.major}.{0.minor}.{0.micro}-{0.releaselevel}".format(version_info)
     )
     if version_info.releaselevel != "final":
-        pkg = pkg_resources.get_distribution("py-cord")
-        if pkg:
-            entries.append(f"    - py-cord pkg_resources: v{pkg.version}")
+        version = importlib.metadata.version("py-cord")
+        if version:
+            entries.append(f"    - py-cord importlib.metadata: v{version}")
 
     entries.append(f"- aiohttp v{aiohttp.__version__}")
     uname = platform.uname()


### PR DESCRIPTION
## Summary
Replaced `pkg_resources` with `importlib.metadata` as favoured [here](https://setuptools.pypa.io/en/latest/pkg_resources.html). Hence replacing `get_distribution()` with `version()`.

This clears the following deprecation warning:
```
/home/username/pycord/venv/lib/python3.11/site-packages/discord/__main__.py:33: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
