### PR TITLE
feat: retry http requests that fail with a 503 status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Added `banner` parameter to `ClientUser.edit`.
   ([#2396](https://github.com/Pycord-Development/pycord/pull/2396))
+- Added automatic retry of HTTP Request that fail with a 503 status code.
+  ([#2395](https://github.com/Pycord-Development/pycord/pull/2395))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Added `banner` parameter to `ClientUser.edit`.
   ([#2396](https://github.com/Pycord-Development/pycord/pull/2396))
-- Added automatic retry of HTTP Request that fail with a 503 status code.
-  ([#2395](https://github.com/Pycord-Development/pycord/pull/2395))
 
 ### Fixed
 
@@ -29,6 +27,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Changed the type of `Guild.bitrate_limit` to `int`.
   ([#2387](https://github.com/Pycord-Development/pycord/pull/2387))
+- HTTP requests that fail with a 503 status are now re-tried.
+  ([#2395](https://github.com/Pycord-Development/pycord/pull/2395))
 
 ## [2.5.0] - 2024-03-02
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -357,8 +357,8 @@ class HTTPClient:
 
                             continue
 
-                        # we've received a 500, 502, or 504, unconditional retry
-                        if response.status in {500, 502, 504}:
+                        # we've received a 500, 502, 503, or 504, unconditional retry
+                        if response.status in {500, 502, 503, 504}:
                             await asyncio.sleep(1 + tries * 2)
                             continue
 


### PR DESCRIPTION
## Summary

Added the 503 status code to the retry-mechanism as a (temporary) solution for Discord's frequent server issues lately.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
