### PR TITLE
feat: add `banner` to `ClientUser.edit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+### Added
+- Added `banner` parameter to `ClientUser.edit`.
+  ([#2396](https://github.com/Pycord-Development/pycord/pull/2396))
+
 ### Fixed
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ possible (see our [Version Guarantees] for more info).
 These changes are available on the `master` branch, but have not yet been released.
 
 ### Added
+
 - Added `banner` parameter to `ClientUser.edit`.
   ([#2396](https://github.com/Pycord-Development/pycord/pull/2396))
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -422,7 +422,7 @@ class ClientUser(BaseUser):
 
     # TODO: Username might not be able to edit anymore.
     async def edit(
-        self, *, username: str = MISSING, avatar: bytes = MISSING
+        self, *, username: str = MISSING, avatar: bytes = MISSING, banner: bytes = MISSING
     ) -> ClientUser:
         """|coro|
 
@@ -430,12 +430,12 @@ class ClientUser(BaseUser):
 
         .. note::
 
-            To upload an avatar, a :term:`py:bytes-like object` must be passed in that
+            To upload an avatar or banner, a :term:`py:bytes-like object` must be passed in that
             represents the image being uploaded. If this is done through a file
             then the file must be opened via ``open('some_filename', 'rb')`` and
             the :term:`py:bytes-like object` is given through the use of ``fp.read()``.
 
-            The only image formats supported for uploading is JPEG and PNG.
+            The only image formats supported for uploading is JPEG and PNG and GIF.
 
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited client user is returned.
@@ -447,6 +447,9 @@ class ClientUser(BaseUser):
         avatar: :class:`bytes`
             A :term:`py:bytes-like object` representing the image to upload.
             Could be ``None`` to denote no avatar.
+        banner: :class:`bytes`
+            A :term:`py:bytes-like object` representing the image to upload.
+            Could be ``None`` to denote no banner.
 
         Returns
         -------
@@ -458,7 +461,7 @@ class ClientUser(BaseUser):
         HTTPException
             Editing your profile failed.
         InvalidArgument
-            Wrong image format passed for ``avatar``.
+            Wrong image format passed for ``avatar`` or ``banner``.
         """
         payload: dict[str, Any] = {}
         if username is not MISSING:
@@ -468,6 +471,11 @@ class ClientUser(BaseUser):
             payload["avatar"] = None
         elif avatar is not MISSING:
             payload["avatar"] = _bytes_to_base64_data(avatar)
+
+        if banner is None:
+            payload["banner"] = None
+        elif banner is not MISSING:
+            payload["banner"] = _bytes_to_base64_data(banner)
 
         data: UserPayload = await self._state.http.edit_profile(payload)
         return ClientUser(state=self._state, data=data)

--- a/discord/user.py
+++ b/discord/user.py
@@ -444,7 +444,7 @@ class ClientUser(BaseUser):
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited client user is returned.
 
-        .. versionchanges:: 2.6
+        .. versionchanged:: 2.6
             The ``banner`` keyword-only parameter was added.
 
         Parameters

--- a/discord/user.py
+++ b/discord/user.py
@@ -439,7 +439,7 @@ class ClientUser(BaseUser):
             then the file must be opened via ``open('some_filename', 'rb')`` and
             the :term:`py:bytes-like object` is given through the use of ``fp.read()``.
 
-            The only image formats supported for uploading is JPEG and PNG and GIF.
+            The only image formats supported for uploading are JPEG, PNG, and GIF.
 
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited client user is returned.

--- a/discord/user.py
+++ b/discord/user.py
@@ -443,7 +443,7 @@ class ClientUser(BaseUser):
 
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited client user is returned.
-            
+
         .. versionchanges:: 2.6
             The ``banner`` keyword-only parameter was added.
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -443,6 +443,9 @@ class ClientUser(BaseUser):
 
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited client user is returned.
+            
+        .. versionchanges:: 2.6
+            The ``banner`` keyword-only parameter was added.
 
         Parameters
         ----------

--- a/discord/user.py
+++ b/discord/user.py
@@ -422,7 +422,11 @@ class ClientUser(BaseUser):
 
     # TODO: Username might not be able to edit anymore.
     async def edit(
-        self, *, username: str = MISSING, avatar: bytes = MISSING, banner: bytes = MISSING
+        self,
+        *,
+        username: str = MISSING,
+        avatar: bytes = MISSING,
+        banner: bytes = MISSING,
     ) -> ClientUser:
         """|coro|
 


### PR DESCRIPTION
Added "banner" to the edit function.

Till now the official discord docs are not updated, but its is working.

ref: https://github.com/discord/discord-api-docs/pull/6710

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
