### PR TITLE
fix: type-hinting in ScheduledEvent.subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
+- Fixed the type-hinting of `ScheduledEvent.subscribers` to reflect actual
+  behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2400))
 - Fixed a deprecation warning from being displayed when running `python -m discord -v`
   by replacing the deprecated module.
   ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed the type-hinting of `Member.move_to` and `Member.edit` to reflect actual
   behavior. ([#2386](https://github.com/Pycord-Development/pycord/pull/2386))
-- Fixed the type-hinting of `ScheduledEvent.subscribers` to reflect actual behavior.
-  ([#2400](https://github.com/Pycord-Development/pycord/pull/2400))
 - Fixed a deprecation warning from being displayed when running `python -m discord -v`
   by replacing the deprecated module.
   ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))
 - Fixed `Paginator.edit` to no longer set user to the bot.
   ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
+- Fixed the type-hinting of `ScheduledEvent.subscribers` to reflect actual behavior.
+  ([#2400](https://github.com/Pycord-Development/pycord/pull/2400))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+## [2.5.0] - 2024-03-02
+
 ### Added
 
 - Added method to start bot via async context manager.
@@ -778,7 +780,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fix py3.10 UnionType checks issue.
   ([#1240](https://github.com/Pycord-Development/pycord/pull/1240))
 
-[unreleased]: https://github.com/Pycord-Development/pycord/compare/v2.4.1...HEAD
+[unreleased]: https://github.com/Pycord-Development/pycord/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/Pycord-Development/pycord/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/Pycord-Development/pycord/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Pycord-Development/pycord/compare/v2.3.3...v2.4.0
 [2.3.3]: https://github.com/Pycord-Development/pycord/compare/v2.3.2...v2.3.3

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -854,8 +854,8 @@ class ScheduledEventSubscribersIterator(_AsyncIterator[Union["User", "Member"]])
         event: ScheduledEvent,
         limit: int | None,
         with_member: bool = False,
-        before: datetime.datetime | int = None,
-        after: datetime.datetime | int = None,
+        before: datetime.datetime | int | None = None,
+        after: datetime.datetime | int | None = None,
     ):
         if isinstance(before, datetime.datetime):
             before = Object(id=time_snowflake(before, high=False))

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -852,7 +852,7 @@ class ScheduledEventSubscribersIterator(_AsyncIterator[Union["User", "Member"]])
     def __init__(
         self,
         event: ScheduledEvent,
-        limit: int,
+        limit: int | None,
         with_member: bool = False,
         before: datetime.datetime | int = None,
         after: datetime.datetime | int = None,

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -486,7 +486,7 @@ class ScheduledEvent(Hashable):
         as_member: bool = False,
         before: Snowflake | datetime.datetime | None = None,
         after: Snowflake | datetime.datetime | None = None,
-    ) -> AsyncIterator:
+    ) -> ScheduledEventSubscribersIterator:
         """Returns an :class:`AsyncIterator` representing the users or members subscribed to the event.
 
         The ``after`` and ``before`` parameters must represent member

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -482,7 +482,7 @@ class ScheduledEvent(Hashable):
     def subscribers(
         self,
         *,
-        limit: int = 100,
+        limit: int | None = 100,
         as_member: bool = False,
         before: Snowflake | datetime.datetime | None = None,
         after: Snowflake | datetime.datetime | None = None,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,5 +4,5 @@ sphinxcontrib-websupport==1.2.4
 myst-parser==1.0.0
 sphinxext-opengraph==0.9.1
 sphinx-copybutton==0.5.2
-furo@ git+https://github.com/pradyunsg/furo@193643f
+furo==2023.3.23
 sphinx-autodoc-typehints==1.23.0


### PR DESCRIPTION
## Summary

Fixed type-hinting for `ScheduledEvent.subscribers` parameter `limit: Optional[:class:int]`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
