### PR TITLE
fix: NameError in interaction edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2392](https://github.com/Pycord-Development/pycord/pull/2392))
 - Fixed `Paginator.edit` to no longer set user to the bot.
   ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
+- Fixed `NameError` in some instances of `Interaction`.
+  ([#2402](https://github.com/Pycord-Development/pycord/pull/2402))
 
 ### Changed
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -34,13 +34,13 @@ from .enums import InteractionResponseType, InteractionType, try_enum
 from .errors import ClientException, InteractionResponded, InvalidArgument
 from .file import File
 from .flags import MessageFlags
+from .guild import Guild
 from .member import Member
 from .message import Attachment, Message
 from .monetization import Entitlement
 from .object import Object
 from .permissions import Permissions
 from .user import User
-from .guild import Guild
 from .webhook.async_ import (
     Webhook,
     WebhookMessage,

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -40,6 +40,7 @@ from .monetization import Entitlement
 from .object import Object
 from .permissions import Permissions
 from .user import User
+from .guild import Guild
 from .webhook.async_ import (
     Webhook,
     WebhookMessage,
@@ -69,7 +70,6 @@ if TYPE_CHECKING:
     from .client import Client
     from .commands import OptionChoice
     from .embeds import Embed
-    from .guild import Guild
     from .mentions import AllowedMentions
     from .state import ConnectionState
     from .threads import Thread


### PR DESCRIPTION
## Summary

Moves a guild import out of typechecking to avoid issues when guild isn't already set on `Interaction`s
![image](https://github.com/Pycord-Development/pycord/assets/41271523/41a0054f-adb7-432b-ad92-cff55ab3d385)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
