### PR TITLE
feat: add once kwarg to Cog.listener

### DIFF
--- a/discord/cog.py
+++ b/discord/cog.py
@@ -379,7 +379,7 @@ class Cog(metaclass=CogMeta):
         )
 
     @classmethod
-    def listener(cls, name: str = MISSING) -> Callable[[FuncT], FuncT]:
+    def listener(cls, name: str = MISSING, once: bool = False) -> Callable[[FuncT], FuncT]:
         """A decorator that marks a function as a listener.
 
         This is the cog equivalent of :meth:`.Bot.listen`.
@@ -389,6 +389,9 @@ class Cog(metaclass=CogMeta):
         name: :class:`str`
             The name of the event being listened to. If not provided, it
             defaults to the function's name.
+        once: :class:`bool`
+            If this listener should only be called once after the cog is loaded.
+            Defaults to false.
 
         Raises
         ------
@@ -411,6 +414,7 @@ class Cog(metaclass=CogMeta):
                 raise TypeError("Listener function must be a coroutine function.")
             actual.__cog_listener__ = True
             to_assign = name or actual.__name__
+            actual._once = once
             try:
                 actual.__cog_listener_names__.append(to_assign)
             except AttributeError:

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -390,7 +390,7 @@ class Cog(metaclass=CogMeta):
             The name of the event being listened to. If not provided, it
             defaults to the function's name.
         once: :class:`bool`
-            If this listener should only be called once after the cog is loaded.
+            If this listener should only be called once after each cog load.
             Defaults to false.
 
         Raises

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -379,7 +379,9 @@ class Cog(metaclass=CogMeta):
         )
 
     @classmethod
-    def listener(cls, name: str = MISSING, once: bool = False) -> Callable[[FuncT], FuncT]:
+    def listener(
+        cls, name: str = MISSING, once: bool = False
+    ) -> Callable[[FuncT], FuncT]:
         """A decorator that marks a function as a listener.
 
         This is the cog equivalent of :meth:`.Bot.listen`.


### PR DESCRIPTION
## Summary

Adds the `once` kwarg to `Cog.listener` as per #2157. But as noted in that request, there's a caveat - due to how it's stored, `once` resets on cog load. Either this PR can go through as is with that warning, or we can slightly rework it to not reset on reload (perhaps through an extra kwarg specifying which behavior you want)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.

Closes #2157