### PR TITLE
fix: always cast PartialMessage(able) IDs to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
 - Fixed `NameError` in some instances of `Interaction`.
   ([#2402](https://github.com/Pycord-Development/pycord/pull/2402))
-- Fixed `PartialMessage/able` IDs sometimes being `str` rather than `int`.
-  ([#2406](https://github.com/Pycord-Development/pycord/pull/2406))
-- Fixed Views sent in `ForumChannel.create_thread` not recieving interactions.
+- Fixed interactions being ignored due to `PartialMessage(able).id` being of type `str`.
   ([#2406](https://github.com/Pycord-Development/pycord/pull/2406))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
 - Fixed `NameError` in some instances of `Interaction`.
   ([#2402](https://github.com/Pycord-Development/pycord/pull/2402))
-- Fixed interactions being ignored due to `PartialMessage(able).id` being of type `str`.
+- Fixed interactions being ignored due to `PartialMessage.id` being of type `str`.
   ([#2406](https://github.com/Pycord-Development/pycord/pull/2406))
 - Fixed the type-hinting of `ScheduledEvent.subscribers` to reflect actual behavior.
   ([#2400](https://github.com/Pycord-Development/pycord/pull/2400))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2390](https://github.com/Pycord-Development/pycord/pull/2390))
 - Fixed `NameError` in some instances of `Interaction`.
   ([#2402](https://github.com/Pycord-Development/pycord/pull/2402))
+- Fixed `PartialMessage/able` IDs sometimes being `str` rather than `int`.
+  ([#2406](https://github.com/Pycord-Development/pycord/pull/2406))
+- Fixed Views sent in `ForumChannel.create_thread` not recieving interactions.
+  ([#2406](https://github.com/Pycord-Development/pycord/pull/2406))
 
 ### Changed
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1339,7 +1339,7 @@ class ForumChannel(_TextChannel):
                     f.close()
 
         ret = Thread(guild=self.guild, state=self._state, data=data)
-        msg = ret.get_partial_message(data["last_message_id"])
+        msg = ret.get_partial_message(int(data["last_message_id"]))
         if view:
             state.store_view(view, msg.id)
 
@@ -3189,7 +3189,7 @@ class PartialMessageable(discord.abc.Messageable, Hashable):
     ):
         self._state: ConnectionState = state
         self._channel: Object = Object(id=id)
-        self.id: int = int(id)
+        self.id: int = id
         self.type: ChannelType | None = type
 
     async def _get_channel(self) -> Object:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -3189,7 +3189,7 @@ class PartialMessageable(discord.abc.Messageable, Hashable):
     ):
         self._state: ConnectionState = state
         self._channel: Object = Object(id=id)
-        self.id: int = id
+        self.id: int = int(id)
         self.type: ChannelType | None = type
 
     async def _get_channel(self) -> Object:

--- a/discord/message.py
+++ b/discord/message.py
@@ -1923,7 +1923,7 @@ class PartialMessage(Hashable):
 
         self.channel: PartialMessageableChannel = channel
         self._state: ConnectionState = channel._state
-        self.id: int = int(id)
+        self.id: int = id
 
     def _update(self, data) -> None:
         # This is used for duck typing purposes.

--- a/discord/message.py
+++ b/discord/message.py
@@ -1923,7 +1923,7 @@ class PartialMessage(Hashable):
 
         self.channel: PartialMessageableChannel = channel
         self._state: ConnectionState = channel._state
-        self.id: int = id
+        self.id: int = int(id)
 
     def _update(self, data) -> None:
         # This is used for duck typing purposes.


### PR DESCRIPTION
## Summary

This was initially a PR to fix broken views sent in create_thread, but it turned out to be an underlying issue... once again with string IDs still being present in some areas of the library. `ForumChannel.create_thread` used the raw string ID for the ViewStore key, resulting in it always failing to resolve. Instead of casting `int` here, I opted to force `PartialMessage` and `PartialMessageable` to always convert to `int`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
