### PR TITLE
fix: TypeError when `ScheduledEvent.subscribers` limit is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2402](https://github.com/Pycord-Development/pycord/pull/2402))
 - Fixed the type-hinting of `ScheduledEvent.subscribers` to reflect actual behavior.
   ([#2400](https://github.com/Pycord-Development/pycord/pull/2400))
+- Fixed `ScheduledEvent.subscribers` behaviour with `limit=None`.
+  ([#2407](https://github.com/Pycord-Development/pycord/pull/2407))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2402](https://github.com/Pycord-Development/pycord/pull/2402))
 - Fixed the type-hinting of `ScheduledEvent.subscribers` to reflect actual behavior.
   ([#2400](https://github.com/Pycord-Development/pycord/pull/2400))
-- Fixed `ScheduledEvent.subscribers` behaviour with `limit=None`.
+- Fixed `ScheduledEvent.subscribers` behavior with `limit=None`.
   ([#2407](https://github.com/Pycord-Development/pycord/pull/2407))
 
 ### Changed

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -919,7 +919,7 @@ class ScheduledEventSubscribersIterator(_AsyncIterator[Union["User", "Member"]])
             before=before,
             after=after,
         )
-        if data:
+        if data and self.limit:
             self.limit -= self.retrieve
 
         for element in reversed(data):

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -919,8 +919,14 @@ class ScheduledEventSubscribersIterator(_AsyncIterator[Union["User", "Member"]])
             before=before,
             after=after,
         )
-        if data and self.limit:
-            self.limit -= self.retrieve
+
+        data_length = len(data)
+        if data_length < self.retrieve:
+            self.limit = 0
+        elif data_length > 0:
+            if self.limit:
+                self.limit -= self.retrieve
+            self.after = Object(id=int(data[-1]["user_id"]))
 
         for element in reversed(data):
             if "member" in element:

--- a/discord/types/scheduled_events.py
+++ b/discord/types/scheduled_events.py
@@ -60,5 +60,6 @@ class ScheduledEventEntityMetadata(TypedDict):
 
 class ScheduledEventSubscriber(TypedDict):
     guild_scheduled_event_id: Snowflake
+    user_id: Snowflake
     user: User
     member: Member | None


### PR DESCRIPTION
## Summary

Fixed a bug for the case where `ScheduledEvent.subscribers` was executed with the parameter `limit=None`.
Updated `ScheduledEventSubscriber` to include `user_id` parameter.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
