### PR TITLE
fix: pass proper state to interaction._guild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2400](https://github.com/Pycord-Development/pycord/pull/2400))
 - Fixed `ScheduledEvent.subscribers` behavior with `limit=None`.
   ([#2407](https://github.com/Pycord-Development/pycord/pull/2407))
+- Fixed invalid data being passed to `Interaction._guild` in certain cases.
+  ([#2411](https://github.com/Pycord-Development/pycord/pull/2411))
 
 ### Changed
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -198,7 +198,7 @@ class Interaction:
         self._guild: Guild | None = None
         self._guild_data = data.get("guild")
         if self.guild is None and self._guild_data:
-            self._guild = Guild(data=self._guild_data, state=self)
+            self._guild = Guild(data=self._guild_data, state=self._state)
 
         # TODO: there's a potential data loss here
         if self.guild_id:


### PR DESCRIPTION
## Summary

Followup PR to #2402 since state was also not set correctly

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
