### PR TITLE
fix: Added member data to the raw_reaction_remove event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Added
 
+- Added `member` to the `raw_reaction_remove` event.
+  ([#2412](https://github.com/Pycord-Development/pycord/pull/2412))
 - Added `banner` parameter to `ClientUser.edit`.
   ([#2396](https://github.com/Pycord-Development/pycord/pull/2396))
 - Added `user` argument to `Paginator.edit`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Added
 
-- Added `member` to the `raw_reaction_remove` event.
-  ([#2412](https://github.com/Pycord-Development/pycord/pull/2412))
 - Added `banner` parameter to `ClientUser.edit`.
   ([#2396](https://github.com/Pycord-Development/pycord/pull/2396))
 - Added `user` argument to `Paginator.edit`.
@@ -22,6 +20,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
 - Added `Guild.search_members`.
   ([#2418](https://github.com/Pycord-Development/pycord/pull/2418))
+- Added `member` data to the `raw_reaction_remove` event.
+  ([#2412](https://github.com/Pycord-Development/pycord/pull/2412))
 
 ### Fixed
 

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -205,8 +205,7 @@ class RawReactionActionEvent(_RawReprMixin):
     emoji: :class:`PartialEmoji`
         The custom or unicode emoji being used.
     member: Optional[:class:`Member`]
-        The member who added the reaction. Only available if `event_type` is `REACTION_ADD`
-        and the reaction is inside a guild.
+        The member who added the reaction. Only available if the reaction occurs within a guild.
 
         .. versionadded:: 1.3
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -792,7 +792,7 @@ class ConnectionState:
             else:
                 raw.member = None
         else:
-                raw.member = None
+            raw.member = None
 
         self.dispatch("raw_reaction_remove", raw)
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -783,6 +783,17 @@ class ConnectionState:
         emoji_id = utils._get_as_snowflake(emoji, "id")
         emoji = PartialEmoji.with_state(self, id=emoji_id, name=emoji["name"])
         raw = RawReactionActionEvent(data, emoji, "REACTION_REMOVE")
+
+        member_data = data.get("member")
+        if member_data:
+            guild = self._get_guild(raw.guild_id)
+            if guild is not None:
+                raw.member = Member(data=member_data, guild=guild, state=self)
+            else:
+                raw.member = None
+        else:
+                raw.member = None
+
         self.dispatch("raw_reaction_remove", raw)
 
         message = self._get_message(raw.message_id)


### PR DESCRIPTION
## Summary

This Pull Request adds the member data to the raw_reaction_remove event
This ensures user consistency between the add/remove reaction events.

## Information


- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [N/A] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
