### PR TITLE
fix: option and BridgeOption adjustments

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -395,7 +395,7 @@ class OptionChoice:
         return as_dict
 
 
-def option(name, type=None, **kwargs):
+def option(name, input_type=None, **kwargs):
     """A decorator that can be used instead of typehinting :class:`.Option`.
 
     .. versionadded:: 2.0
@@ -409,11 +409,9 @@ def option(name, type=None, **kwargs):
 
     def decorator(func):
         nonlocal type
-        type = type or func.__annotations__.get(name, str)
-        if parameter := kwargs.get("parameter_name"):
-            func.__annotations__[parameter] = Option(type, name=name, **kwargs)
-        else:
-            func.__annotations__[name] = Option(type, **kwargs)
+        resolved_name = kwargs.pop("parameter_name") or name
+        type = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
+        func.__annotations__[resolved_name] = Option(type, name=name, **kwargs)
         return func
 
     return decorator

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -408,8 +408,8 @@ def option(name, input_type=None, **kwargs):
     """
 
     def decorator(func):
-        resolved_name = kwargs.pop("parameter_name") or name
-        itype = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
+        resolved_name = kwargs.pop("parameter_name", None) or name
+        itype = kwargs.pop("type", None) or input_type or func.__annotations__.get(resolved_name, str)
         func.__annotations__[resolved_name] = Option(itype, name=name, **kwargs)
         return func
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -408,10 +408,9 @@ def option(name, input_type=None, **kwargs):
     """
 
     def decorator(func):
-        nonlocal type
         resolved_name = kwargs.pop("parameter_name") or name
-        type = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
-        func.__annotations__[resolved_name] = Option(type, name=name, **kwargs)
+        itype = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
+        func.__annotations__[resolved_name] = Option(itype, name=name, **kwargs)
         return func
 
     return decorator

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -63,6 +63,7 @@ __all__ = (
     "BridgeCommandGroup",
     "bridge_command",
     "bridge_group",
+    "bridge_option",
     "BridgeExtCommand",
     "BridgeSlashCommand",
     "BridgeExtGroup",
@@ -641,8 +642,8 @@ def bridge_option(name, input_type=None, **kwargs):
     """
 
     def decorator(func):
-        resolved_name = kwargs.pop("parameter_name") or name
-        itype = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
+        resolved_name = kwargs.pop("parameter_name", None) or name
+        itype = kwargs.pop("type", None) or input_type or func.__annotations__.get(resolved_name, str)
         func.__annotations__[resolved_name] = BridgeOption(itype, name=name, **kwargs)
         return func
 
@@ -654,5 +655,5 @@ warn_deprecated(
     "Option",
     "BridgeOption",
     "2.5",
-    reference="https://github.com/Pycord-Development/pycord/pull/2410 After 2.7, bridge.Bot may no longer use Option.",
+    reference="https://github.com/Pycord-Development/pycord/pull/2410",
 )

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -40,7 +40,7 @@ from discord import (
     SlashCommandOptionType,
 )
 
-from ...utils import MISSING, find, get
+from ...utils import MISSING, find, get, warn_deprecated
 from ..commands import BadArgument
 from ..commands import Bot as ExtBot
 from ..commands import (
@@ -627,3 +627,33 @@ class BridgeOption(Option, Converter):
             return converted
         except ValueError as exc:
             raise BadArgument() from exc
+
+def bridge_option(name, input_type=None, **kwargs):
+    """A decorator that can be used instead of typehinting :class:`.BridgeOption`.
+
+    .. versionadded:: 2.6
+
+    Attributes
+    ----------
+    parameter_name: :class:`str`
+        The name of the target parameter this option is mapped to.
+        This allows you to have a separate UI ``name`` and parameter name.
+    """
+
+    def decorator(func):
+        nonlocal type
+        resolved_name = kwargs.pop("parameter_name") or name
+        type = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
+        func.__annotations__[resolved_name] = BridgeOption(type, name=name, **kwargs)
+        return func
+
+    return decorator
+
+discord.commands.options.Option = BridgeOption
+discord.Option = BridgeOption
+warn_deprecated(
+    "Option",
+    "BridgeOption",
+    "2.5",
+    reference="https://github.com/Pycord-Development/pycord/pull/2410 After 2.7, bridge.Bot may no longer use Option.",
+)

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -641,10 +641,9 @@ def bridge_option(name, input_type=None, **kwargs):
     """
 
     def decorator(func):
-        nonlocal type
         resolved_name = kwargs.pop("parameter_name") or name
-        type = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
-        func.__annotations__[resolved_name] = BridgeOption(type, name=name, **kwargs)
+        itype = kwargs.pop("type") or input_type or func.__annotations__.get(resolved_name, str)
+        func.__annotations__[resolved_name] = BridgeOption(itype, name=name, **kwargs)
         return func
 
     return decorator


### PR DESCRIPTION
## Summary

- Support `input_type` in `option` decorator to match `Option` class.
 To preserve backwards compat, `type` kwarg fallback still exists.
- Fix `parameter_name` not being able to inherit a typehinted option type
- Implement `bridge_option` decorator
- Reverts #2252 until 2.7 to properly allow migration instead of forcing a breaking change with no warning.
Includes a deprecation warning, but perhaps there's a better way to handle this.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
