### PR TITLE
fix: Guild.query_members may accept empty query and limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
 - `Option` may be used instead of `BridgeOption` until 2.7.
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
+- `Guild.query_members` now accepts `limit=None` to retrieve all members.
+  ([#2419](https://github.com/Pycord-Development/pycord/pull/2419))
 
 ## [2.5.0] - 2024-03-02
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3331,7 +3331,7 @@ class Guild(Hashable):
         self,
         query: str | None = None,
         *,
-        limit: int = 5,
+        limit: int | None = 5,
         user_ids: list[int] | None = None,
         presences: bool = False,
         cache: bool = True,
@@ -3349,22 +3349,22 @@ class Guild(Hashable):
         ----------
         query: Optional[:class:`str`]
             The string that the username's start with.
-        limit: :class:`int`
-            The maximum number of members to send back. This must be
-            a number between 5 and 100.
-        presences: :class:`bool`
+        user_ids: Optional[List[:class:`int`]]
+            List of user IDs to search for. If the user ID is not in the guild then it won't be returned.
+
+            .. versionadded:: 1.4
+        limit: Optional[:class:`int`]
+            The maximum number of members to send back. If no query is passed, pass ``None`` to return all members. 
+            If you specify a ``query`` or ``user_ids``, this must be between 1 and 100. Defaults to 5.
+        presences: Optional[:class:`bool`]
             Whether to request for presences to be provided. This defaults
             to ``False``.
 
             .. versionadded:: 1.6
 
-        cache: :class:`bool`
+        cache: Optional[:class:`bool`]
             Whether to cache the members internally. This makes operations
-            such as :meth:`get_member` work for those that matched.
-        user_ids: Optional[List[:class:`int`]]
-            List of user IDs to search for. If the user ID is not in the guild then it won't be returned.
-
-            .. versionadded:: 1.4
+            such as :meth:`get_member` work for those that matched. Defaults to ``True``.
 
         Returns
         -------
@@ -3384,12 +3384,16 @@ class Guild(Hashable):
         if presences and not self._state._intents.presences:
             raise ClientException("Intents.presences must be enabled to use this.")
 
-        if query is None:
-            if query == "":
-                raise ValueError("Cannot pass empty query string.")
+        if not limit or limit > 100 or limit < 1:
+            if query or user_ids:
+                raise ValueError("limit must be between 1 and 100 when using query or user_ids")
+            if not limit:
+                query = ""
+                limit = 0
 
+        if query is None:
             if user_ids is None:
-                raise ValueError("Must pass either query or user_ids")
+                raise ValueError("Must pass query, user_ids, or set limit to None")
 
         if user_ids is not None and query is not None:
             raise ValueError("Cannot pass both query and user_ids")
@@ -3397,7 +3401,6 @@ class Guild(Hashable):
         if user_ids is not None and not user_ids:
             raise ValueError("user_ids must contain at least 1 value")
 
-        limit = min(100, limit or 5)
         return await self._state.query_members(
             self,
             query=query,

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3395,7 +3395,7 @@ class Guild(Hashable):
 
         if query is None:
             if user_ids is None:
-                raise ValueError("Must pass query, user_ids, or set limit to None")
+                raise ValueError("Must pass query or user_ids, or set limit to None")
 
         if user_ids is not None and query is not None:
             raise ValueError("Cannot pass both query and user_ids")

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3392,7 +3392,7 @@ class Guild(Hashable):
 
             .. versionadded:: 1.6
 
-        cache: Optional[:class:`bool`]
+        cache: :class:`bool`
             Whether to cache the members internally. This makes operations
             such as :meth:`get_member` work for those that matched. Defaults to ``True``.
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3384,8 +3384,8 @@ class Guild(Hashable):
 
             .. versionadded:: 1.4
         limit: Optional[:class:`int`]
-            The maximum number of members to send back. If no query is passed, pass ``None`` to return all members.
-            If you specify a ``query`` or ``user_ids``, this must be between 1 and 100. Defaults to 5.
+            The maximum number of members to send back. If no query is passed, passing ``None`` returns all members.
+            If a ``query`` or ``user_ids`` is passed, must be between 1 and 100. Defaults to 5.
         presences: Optional[:class:`bool`]
             Whether to request for presences to be provided. This defaults
             to ``False``.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3354,7 +3354,7 @@ class Guild(Hashable):
 
             .. versionadded:: 1.4
         limit: Optional[:class:`int`]
-            The maximum number of members to send back. If no query is passed, pass ``None`` to return all members. 
+            The maximum number of members to send back. If no query is passed, pass ``None`` to return all members.
             If you specify a ``query`` or ``user_ids``, this must be between 1 and 100. Defaults to 5.
         presences: Optional[:class:`bool`]
             Whether to request for presences to be provided. This defaults
@@ -3386,7 +3386,9 @@ class Guild(Hashable):
 
         if not limit or limit > 100 or limit < 1:
             if query or user_ids:
-                raise ValueError("limit must be between 1 and 100 when using query or user_ids")
+                raise ValueError(
+                    "limit must be between 1 and 100 when using query or user_ids"
+                )
             if not limit:
                 query = ""
                 limit = 0


### PR DESCRIPTION
## Summary

When requesting guild members [through the gateway](https://discord.com/developers/docs/topics/gateway-events#request-guild-members), you can pass an empty string `query` and `limit=0` to recieve all members. This adjusts `Guild.query_members` to accept `limit=None` (or `0`) to allow this behavior, though the default `limit` isn't changed to avoid breaking, and interprests `query=None` as an empty string.
As such, all guild members can be quickly recieved (and cached) through `await guild.query_members(limit=None)`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
