### PR TITLE
feat: Support bulk banning in guilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
 - Added `Guild.search_members`.
   ([#2418](https://github.com/Pycord-Development/pycord/pull/2418))
-- Added bulk banning up to 200 users through `Guild.ban`
+- Added bulk banning up to 200 users through `Guild.ban`.
   ([#2421](https://github.com/Pycord-Development/pycord/pull/2421))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
 - Added `Guild.search_members`.
   ([#2418](https://github.com/Pycord-Development/pycord/pull/2418))
+- Added bulk banning up to 200 users through `Guild.ban`
+  ([#2421](https://github.com/Pycord-Development/pycord/pull/2421))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ These changes are available on the `master` branch, but have not yet been releas
 - `Guild.query_members` now accepts `limit=None` to retrieve all members.
   ([#2419](https://github.com/Pycord-Development/pycord/pull/2419))
 
+### Removed
+
+- Removed the `delete_message_days` parameter from ban methods. Please use
+  `delete_message_seconds` instead.
+  ([#2421](https://github.com/Pycord-Development/pycord/pull/2421))
+
 ## [2.5.0] - 2024-03-02
 
 ### Added

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3116,7 +3116,7 @@ class Guild(Hashable):
             user.id, self.id, delete_message_seconds, reason=reason
         )
 
-    async def ban(
+    async def bulk_ban(
         self,
         *users: Snowflake,
         delete_message_seconds: int | None = None,

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3140,18 +3140,25 @@ class Guild(Hashable):
 
         if len(users) == 1:
             await self._state.http.ban(
-                users[0].id, self.id, delete_message_seconds, delete_message_days, reason=reason
+                users[0].id,
+                self.id,
+                delete_message_seconds,
+                delete_message_days,
+                reason=reason,
             )
         elif len(users) > 200:
             raise ValueError("You may only bulk ban up to 200 members.")
         else:
             data = await self._state.http.bulk_ban(
-                [u.id for u in users], self.id, delete_message_seconds, delete_message_days, reason=reason
+                [u.id for u in users],
+                self.id,
+                delete_message_seconds,
+                delete_message_days,
+                reason=reason,
             )
             banned = [u for u in users if u.id in data["banned_users"]]
             failed = [u for u in users if u.id in data["failed_users"]]
             return banned, failed
-
 
     async def unban(self, user: Snowflake, *, reason: str | None = None) -> None:
         """|coro|

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3156,8 +3156,8 @@ class Guild(Hashable):
                 delete_message_days,
                 reason=reason,
             )
-            banned = [u for u in users if u.id in data["banned_users"]]
-            failed = [u for u in users if u.id in data["failed_users"]]
+            banned = [u for u in users if str(u.id) in data["banned_users"]]
+            failed = [u for u in users if str(u.id) in data["failed_users"]]
             return banned, failed
 
     async def unban(self, user: Snowflake, *, reason: str | None = None) -> None:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3073,24 +3073,66 @@ class Guild(Hashable):
 
     async def ban(
         self,
+        user: Snowflake,
+        *,
+        delete_message_seconds: int | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """|coro|
+
+        Bans a user from the guild.
+
+        The user must meet the :class:`abc.Snowflake` abc.
+
+        You must have the :attr:`~Permissions.ban_members` permission to
+        do this.
+
+        Parameters
+        ----------
+        user: :class:`abc.Snowflake`
+            The user to ban from their guild.
+        delete_message_seconds: Optional[:class:`int`]
+            The number of seconds worth of messages to delete from
+            the user in the guild. The minimum is 0 and the maximum
+            is 604800 (i.e. 7 days). The default is 0.
+        reason: Optional[:class:`str`]
+            The reason the user got banned.
+
+        Raises
+        ------
+        Forbidden
+            You do not have the proper permissions to ban.
+        HTTPException
+            Banning failed.
+        """
+
+        if delete_message_seconds is not None and not (
+            0 <= delete_message_seconds <= 604800
+        ):
+            raise TypeError(
+                "delete_message_seconds must be between 0 and 604800 seconds."
+            )
+
+        await self._state.http.ban(
+            user.id, self.id, delete_message_seconds, reason=reason
+        )
+
+    async def ban(
+        self,
         *users: Snowflake,
         delete_message_seconds: int | None = None,
-        delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] | None = None,
         reason: str | None = None,
     ) -> list[list[Snowflake], list[Snowflake]] | None:
         r"""|coro|
 
-        Bans user(s) from the guild.
+        Bulk ban users from the guild.
 
-        The user(s) must meet the :class:`abc.Snowflake` abc.
+        The users must meet the :class:`abc.Snowflake` abc.
 
         You must have the :attr:`~Permissions.ban_members` permission to
         do this.
 
         Example Usage: ::
-
-            # Ban a single user
-            await guild.ban(user, reason="Spam")
 
             # Ban multiple users
             successes, failures = await guild.ban(user1, user2, user3, ..., reason="Raid")
@@ -3106,16 +3148,13 @@ class Guild(Hashable):
             The number of seconds worth of messages to delete from
             the user in the guild. The minimum is 0 and the maximum
             is 604800 (i.e. 7 days). The default is 0.
-        delete_message_days: Optional[:class:`int`]
-            ***Deprecated parameter***, same as ``delete_message_seconds`` but
-            is used for days instead.
         reason: Optional[:class:`str`]
-            The reason the users got banned.
+            The reason the users were banned.
 
         Returns
         -------
-        Optional[List[List[:class:`abc.Snowflake`], List[:class:`abc.Snowflake`]]]
-            If banning a single member, returns nothing. Otherwise, returns two lists: the first contains members that were successfully banned, while the second is members that could not be banned.
+        List[List[:class:`abc.Snowflake`], List[:class:`abc.Snowflake`]]
+            Returns two lists: the first contains members that were successfully banned, while the second is members that could not be banned.
 
         Raises
         ------
@@ -3126,10 +3165,6 @@ class Guild(Hashable):
         HTTPException
             No users were banned.
         """
-        if delete_message_seconds and delete_message_days:
-            raise TypeError(
-                "delete_message_seconds and delete_message_days are mutually exclusive."
-            )
 
         if delete_message_seconds is not None and not (
             0 <= delete_message_seconds <= 604800
@@ -3137,30 +3172,21 @@ class Guild(Hashable):
             raise TypeError(
                 "delete_message_seconds must be between 0 and 604800 seconds."
             )
-
-        if len(users) == 1:
-            await self._state.http.ban(
-                users[0].id,
-                self.id,
-                delete_message_seconds,
-                delete_message_days,
-                reason=reason,
-            )
-        elif len(users) > 200:
+            
+        if len(users) > 200 or len(users) < 1:
             raise ValueError(
                 "The number of users to be banned must be between 1 and 200."
             )
-        else:
-            data = await self._state.http.bulk_ban(
-                [u.id for u in users],
-                self.id,
-                delete_message_seconds,
-                delete_message_days,
-                reason=reason,
-            )
-            banned = [u for u in users if str(u.id) in data["banned_users"]]
-            failed = [u for u in users if str(u.id) in data["failed_users"]]
-            return banned, failed
+
+        data = await self._state.http.bulk_ban(
+            [u.id for u in users],
+            self.id,
+            delete_message_seconds,
+            reason=reason,
+        )
+        banned = [u for u in users if str(u.id) in data["banned_users"]]
+        failed = [u for u in users if str(u.id) in data["failed_users"]]
+        return banned, failed
 
     async def unban(self, user: Snowflake, *, reason: str | None = None) -> None:
         """|coro|
@@ -3398,7 +3424,7 @@ class Guild(Hashable):
         self,
         query: str | None = None,
         *,
-        limit: int | None = 5,
+        limit: int = 5,
         user_ids: list[int] | None = None,
         presences: bool = False,
         cache: bool = True,
@@ -3416,14 +3442,10 @@ class Guild(Hashable):
         ----------
         query: Optional[:class:`str`]
             The string that the username's start with.
-        user_ids: Optional[List[:class:`int`]]
-            List of user IDs to search for. If the user ID is not in the guild then it won't be returned.
-
-            .. versionadded:: 1.4
-        limit: Optional[:class:`int`]
-            The maximum number of members to send back. If no query is passed, passing ``None`` returns all members.
-            If a ``query`` or ``user_ids`` is passed, must be between 1 and 100. Defaults to 5.
-        presences: Optional[:class:`bool`]
+        limit: :class:`int`
+            The maximum number of members to send back. This must be
+            a number between 5 and 100.
+        presences: :class:`bool`
             Whether to request for presences to be provided. This defaults
             to ``False``.
 
@@ -3431,7 +3453,11 @@ class Guild(Hashable):
 
         cache: :class:`bool`
             Whether to cache the members internally. This makes operations
-            such as :meth:`get_member` work for those that matched. Defaults to ``True``.
+            such as :meth:`get_member` work for those that matched.
+        user_ids: Optional[List[:class:`int`]]
+            List of user IDs to search for. If the user ID is not in the guild then it won't be returned.
+
+            .. versionadded:: 1.4
 
         Returns
         -------
@@ -3451,18 +3477,12 @@ class Guild(Hashable):
         if presences and not self._state._intents.presences:
             raise ClientException("Intents.presences must be enabled to use this.")
 
-        if not limit or limit > 100 or limit < 1:
-            if query or user_ids:
-                raise ValueError(
-                    "limit must be between 1 and 100 when using query or user_ids"
-                )
-            if not limit:
-                query = ""
-                limit = 0
-
         if query is None:
+            if query == "":
+                raise ValueError("Cannot pass empty query string.")
+
             if user_ids is None:
-                raise ValueError("Must pass query or user_ids, or set limit to None")
+                raise ValueError("Must pass either query or user_ids")
 
         if user_ids is not None and query is not None:
             raise ValueError("Cannot pass both query and user_ids")
@@ -3470,6 +3490,7 @@ class Guild(Hashable):
         if user_ids is not None and not user_ids:
             raise ValueError("user_ids must contain at least 1 value")
 
+        limit = min(100, limit or 5)
         return await self._state.query_members(
             self,
             query=query,

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -32,7 +32,6 @@ from typing import (
     Any,
     ClassVar,
     List,
-    Literal,
     NamedTuple,
     Optional,
     Sequence,
@@ -3172,7 +3171,7 @@ class Guild(Hashable):
             raise TypeError(
                 "delete_message_seconds must be between 0 and 604800 seconds."
             )
-            
+
         if len(users) > 200 or len(users) < 1:
             raise ValueError(
                 "The number of users to be banned must be between 1 and 200."

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3121,7 +3121,7 @@ class Guild(Hashable):
         *users: Snowflake,
         delete_message_seconds: int | None = None,
         reason: str | None = None,
-    ) -> list[list[Snowflake], list[Snowflake]] | None:
+    ) -> list[list[Snowflake], list[Snowflake]]:
         r"""|coro|
 
         Bulk ban users from the guild.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3423,7 +3423,7 @@ class Guild(Hashable):
         self,
         query: str | None = None,
         *,
-        limit: int = 5,
+        limit: int | None = 5,
         user_ids: list[int] | None = None,
         presences: bool = False,
         cache: bool = True,
@@ -3441,10 +3441,14 @@ class Guild(Hashable):
         ----------
         query: Optional[:class:`str`]
             The string that the username's start with.
-        limit: :class:`int`
-            The maximum number of members to send back. This must be
-            a number between 5 and 100.
-        presences: :class:`bool`
+        user_ids: Optional[List[:class:`int`]]
+            List of user IDs to search for. If the user ID is not in the guild then it won't be returned.
+
+            .. versionadded:: 1.4
+        limit: Optional[:class:`int`]
+            The maximum number of members to send back. If no query is passed, passing ``None`` returns all members.
+            If a ``query`` or ``user_ids`` is passed, must be between 1 and 100. Defaults to 5.
+        presences: Optional[:class:`bool`]
             Whether to request for presences to be provided. This defaults
             to ``False``.
 
@@ -3452,11 +3456,7 @@ class Guild(Hashable):
 
         cache: :class:`bool`
             Whether to cache the members internally. This makes operations
-            such as :meth:`get_member` work for those that matched.
-        user_ids: Optional[List[:class:`int`]]
-            List of user IDs to search for. If the user ID is not in the guild then it won't be returned.
-
-            .. versionadded:: 1.4
+            such as :meth:`get_member` work for those that matched. Defaults to ``True``.
 
         Returns
         -------
@@ -3476,12 +3476,18 @@ class Guild(Hashable):
         if presences and not self._state._intents.presences:
             raise ClientException("Intents.presences must be enabled to use this.")
 
-        if query is None:
-            if query == "":
-                raise ValueError("Cannot pass empty query string.")
+        if not limit or limit > 100 or limit < 1:
+            if query or user_ids:
+                raise ValueError(
+                    "limit must be between 1 and 100 when using query or user_ids"
+                )
+            if not limit:
+                query = ""
+                limit = 0
 
+        if query is None:
             if user_ids is None:
-                raise ValueError("Must pass either query or user_ids")
+                raise ValueError("Must pass query or user_ids, or set limit to None")
 
         if user_ids is not None and query is not None:
             raise ValueError("Cannot pass both query and user_ids")
@@ -3489,7 +3495,6 @@ class Guild(Hashable):
         if user_ids is not None and not user_ids:
             raise ValueError("user_ids must contain at least 1 value")
 
-        limit = min(100, limit or 5)
         return await self._state.query_members(
             self,
             query=query,

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3079,7 +3079,7 @@ class Guild(Hashable):
         delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] | None = None,
         reason: str | None = None,
     ) -> None:
-        """|coro|
+        r"""|coro|
 
         Bans users from the guild.
 
@@ -3105,7 +3105,7 @@ class Guild(Hashable):
         Returns
         -------
         Optional[List[List[:class:`Snowflake`], List[:class:`Snowflake`]]]
-            If banning a single member, returns nothing. Otherwise, returns two lists; 
+            If banning a single member, returns nothing. Otherwise, returns two lists;
 
         Raises
         ------
@@ -3138,7 +3138,7 @@ class Guild(Hashable):
             raise TypeError(
                 "delete_message_seconds must be between 0 and 604800 seconds."
             )
-        
+
         if len(users) == 1:
             await self._state.http.ban(
                 users[0].id, self.id, delete_message_seconds, delete_message_days, reason=reason

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3114,8 +3114,8 @@ class Guild(Hashable):
 
         Returns
         -------
-        Optional[List[List[:class:`Snowflake`], List[:class:`Snowflake`]]]
-            If banning a single member, returns nothing. Otherwise, returns two lists;
+        Optional[List[List[:class:`abc.Snowflake`], List[:class:`abc.Snowflake`]]]
+            If banning a single member, returns nothing. Otherwise, returns two lists: the first contains members that were successfully banned, while the second is members that could not be banned.
 
         Raises
         ------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3074,7 +3074,6 @@ class Guild(Hashable):
     async def ban(
         self,
         *users: Snowflake,
-        *,
         delete_message_seconds: int | None = None,
         delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] | None = None,
         reason: str | None = None,

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3147,7 +3147,9 @@ class Guild(Hashable):
                 reason=reason,
             )
         elif len(users) > 200:
-            raise ValueError("The number of users to be banned must be between 1 and 200.")
+            raise ValueError(
+                "The number of users to be banned must be between 1 and 200."
+            )
         else:
             data = await self._state.http.bulk_ban(
                 [u.id for u in users],

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3077,15 +3077,26 @@ class Guild(Hashable):
         delete_message_seconds: int | None = None,
         delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] | None = None,
         reason: str | None = None,
-    ) -> None:
+    ) -> list[list[Snowflake], list[Snowflake]] | None:
         r"""|coro|
 
-        Bans users from the guild.
+        Bans user(s) from the guild.
 
-        The users must meet the :class:`abc.Snowflake` abc.
+        The user(s) must meet the :class:`abc.Snowflake` abc.
 
         You must have the :attr:`~Permissions.ban_members` permission to
         do this.
+
+        Example Usage: ::
+
+            # Ban a single user
+            await guild.ban(user, reason="Spam")
+
+            # Ban multiple users
+            successes, failures = await guild.ban(user1, user2, user3, ..., reason="Raid")
+
+            # Ban a list of users
+            successes, failures = await guild.ban(*users)
 
         Parameters
         ----------
@@ -3114,17 +3125,6 @@ class Guild(Hashable):
             You do not have the proper permissions to ban.
         HTTPException
             No users were banned.
-
-        Example Usage: ::
-
-            # Ban a single member
-            await guild.ban(member, reason="Spam")
-
-            # Ban multiple members
-            successes, failures = await guild.ban(member1, member2, member3, ..., reason="Raid")
-
-            # Ban a list of members
-            successes, failures = await guild.ban(*members, reason="Hacked")
         """
         if delete_message_seconds and delete_message_days:
             raise TypeError(
@@ -3147,7 +3147,7 @@ class Guild(Hashable):
                 reason=reason,
             )
         elif len(users) > 200:
-            raise ValueError("You may only bulk ban up to 200 members.")
+            raise ValueError("The number of users to be banned must be between 1 and 200.")
         else:
             data = await self._state.http.bulk_ban(
                 [u.id for u in users],

--- a/discord/http.py
+++ b/discord/http.py
@@ -940,7 +940,7 @@ class HTTPClient:
         reason: str | None = None,
     ) -> Response[guild.GuildBulkBan]:
         r = Route(
-            "PUT",
+            "POST",
             "/guilds/{guild_id}/bulk-ban",
             guild_id=guild_id,
         )

--- a/discord/http.py
+++ b/discord/http.py
@@ -944,11 +944,11 @@ class HTTPClient:
             "/guilds/{guild_id}/bulk-ban",
             guild_id=guild_id,
         )
-        params = {
+        payload = {
             "user_ids": user_ids,
         }
         if delete_message_seconds:
-            params["delete_message_seconds"] = delete_message_seconds
+            payload["delete_message_seconds"] = delete_message_seconds
         elif delete_message_days:
             warn_deprecated(
                 "delete_message_days",
@@ -956,9 +956,9 @@ class HTTPClient:
                 "2.2",
                 reference="https://github.com/discord/discord-api-docs/pull/5219",
             )
-            params["delete_message_days"] = delete_message_days
+            payload["delete_message_days"] = delete_message_days
 
-        return self.request(r, params=params, reason=reason)
+        return self.request(r, json=payload, reason=reason)
 
     def unban(
         self, user_id: Snowflake, guild_id: Snowflake, *, reason: str | None = None

--- a/discord/http.py
+++ b/discord/http.py
@@ -907,7 +907,6 @@ class HTTPClient:
         user_id: Snowflake,
         guild_id: Snowflake,
         delete_message_seconds: int = None,
-        delete_message_days: int = None,
         reason: str | None = None,
     ) -> Response[None]:
         r = Route(
@@ -920,14 +919,6 @@ class HTTPClient:
 
         if delete_message_seconds:
             params["delete_message_seconds"] = delete_message_seconds
-        elif delete_message_days:
-            warn_deprecated(
-                "delete_message_days",
-                "delete_message_seconds",
-                "2.2",
-                reference="https://github.com/discord/discord-api-docs/pull/5219",
-            )
-            params["delete_message_days"] = delete_message_days
 
         return self.request(r, params=params, reason=reason)
 
@@ -936,7 +927,6 @@ class HTTPClient:
         user_ids: list[Snowflake],
         guild_id: Snowflake,
         delete_message_seconds: int = None,
-        delete_message_days: int = None,
         reason: str | None = None,
     ) -> Response[guild.GuildBulkBan]:
         r = Route(
@@ -949,14 +939,6 @@ class HTTPClient:
         }
         if delete_message_seconds:
             payload["delete_message_seconds"] = delete_message_seconds
-        elif delete_message_days:
-            warn_deprecated(
-                "delete_message_days",
-                "delete_message_seconds",
-                "2.2",
-                reference="https://github.com/discord/discord-api-docs/pull/5219",
-            )
-            payload["delete_message_days"] = delete_message_days
 
         return self.request(r, json=payload, reason=reason)
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -936,6 +936,7 @@ class HTTPClient:
         user_ids: list[Snowflake],
         guild_id: Snowflake,
         delete_message_seconds: int = None,
+        delete_message_days: int = None,
         reason: str | None = None,
     ) -> Response[guild.GuildBulkBan]:
         r = Route(

--- a/discord/http.py
+++ b/discord/http.py
@@ -931,6 +931,34 @@ class HTTPClient:
 
         return self.request(r, params=params, reason=reason)
 
+    def bulk_ban(
+        self,
+        user_ids: list[Snowflake],
+        guild_id: Snowflake,
+        delete_message_seconds: int = None,
+        reason: str | None = None,
+    ) -> Response[guild.GuildBulkBan]:
+        r = Route(
+            "PUT",
+            "/guilds/{guild_id}/bulk-ban",
+            guild_id=guild_id,
+        )
+        params = {
+            "user_ids": user_ids,
+        }
+        if delete_message_seconds:
+            params["delete_message_seconds"] = delete_message_seconds
+        elif delete_message_days:
+            warn_deprecated(
+                "delete_message_days",
+                "delete_message_seconds",
+                "2.2",
+                reference="https://github.com/discord/discord-api-docs/pull/5219",
+            )
+            params["delete_message_days"] = delete_message_days
+
+        return self.request(r, params=params, reason=reason)
+
     def unban(
         self, user_id: Snowflake, guild_id: Snowflake, *, reason: str | None = None
     ) -> Response[None]:

--- a/discord/member.py
+++ b/discord/member.py
@@ -30,7 +30,7 @@ import inspect
 import itertools
 import sys
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 import discord.abc
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -684,7 +684,6 @@ class Member(discord.abc.Messageable, _UserTag):
         self,
         *,
         delete_message_seconds: int | None = None,
-        delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] | None = None,
         reason: str | None = None,
     ) -> None:
         """|coro|
@@ -695,7 +694,6 @@ class Member(discord.abc.Messageable, _UserTag):
             self,
             reason=reason,
             delete_message_seconds=delete_message_seconds,
-            delete_message_days=delete_message_days,
         )
 
     async def unban(self, *, reason: str | None = None) -> None:

--- a/discord/types/guild.py
+++ b/discord/types/guild.py
@@ -186,6 +186,7 @@ class RolePositionUpdate(TypedDict, total=False):
 class GuildMFAModify(TypedDict):
     level: Literal[0, 1]
 
+
 class GuildBulkBan(TypedDict):
     banned_users: list[Snowflake]
     failed_users: list[Snowflake]

--- a/discord/types/guild.py
+++ b/discord/types/guild.py
@@ -185,3 +185,7 @@ class RolePositionUpdate(TypedDict, total=False):
 
 class GuildMFAModify(TypedDict):
     level: Literal[0, 1]
+
+class GuildBulkBan(TypedDict):
+    banned_users: list[Snowflake]
+    failed_users: list[Snowflake]

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -573,11 +573,10 @@ When mixed with the :data:`typing.Optional` converter you can provide simple and
 
     @bot.command()
     async def ban(ctx, members: commands.Greedy[discord.Member],
-                       delete_days: typing.Optional[int] = 0, *,
+                       delete_seconds: typing.Optional[int] = 0, *,
                        reason: str):
-        """Mass bans members with an optional delete_days parameter"""
-        for member in members:
-            await member.ban(delete_message_days=delete_days, reason=reason)
+        """Bulk bans members with an optional delete_seconds parameter"""
+        await ctx.guild.bulk_ban(*members, delete_message_seconds=delete_seconds, reason=reason)
 
 
 This command can be invoked any of the following ways:
@@ -707,7 +706,7 @@ For example, augmenting the example above:
     @commands.command()
     async def ban(ctx, *, flags: BanFlags):
         for member in flags.members:
-            await member.ban(reason=flags.reason, delete_message_days=flags.days)
+            await member.ban(reason=flags.reason, delete_message_seconds=flags.days * 60 * 24)
 
         members = ', '.join(str(member) for member in flags.members)
         plural = f'{flags.days} days' if flags.days != 1 else f'{flags.days} day'


### PR DESCRIPTION
## Summary

`Guild.ban` now accepts up to 200 members
Currently, this returns two lists:
```py
successes, failures = await guild.ban(*members, reason="Hacked")
```
Alternatively, we could have a new `GuildBulkBan` object with attributes `banned` and `failed`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
