### PR TITLE
fix: Raise WebSocketClosure on protocol level errors

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -603,13 +603,11 @@ class DiscordWebSocket:
                 await self.received_message(msg.data)
             elif msg.type is aiohttp.WSMsgType.BINARY:
                 await self.received_message(msg.data)
-            elif msg.type is aiohttp.WSMsgType.ERROR:
-                _log.debug("Received %s", msg)
-                raise msg.data
             elif msg.type in (
                 aiohttp.WSMsgType.CLOSED,
                 aiohttp.WSMsgType.CLOSING,
                 aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.ERROR,
             ):
                 _log.debug("Received %s", msg)
                 raise WebSocketClosure


### PR DESCRIPTION
## Summary

My bot crashed from the exception aiohttp.http_websocket.WebSocketError: Received fragmented control frame. Did some research and the exact same crash was reported in https://github.com/Rapptz/discord.py/discussions/9561. This pull request applies the same patch made for this issue in this [discord.py commit](https://github.com/Rapptz/discord.py/commit/163a86c4a031f7ecd856f45a74da47e63b17bb16).

This is a duplicate PR, but this PR includes some requested changes from the original PR.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
  - There is a duplicate, but it had some requested changes which I have applied to this PR.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
