### PR TITLE
fix: type-hinting in Guild.bulk_ban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2411](https://github.com/Pycord-Development/pycord/pull/2411))
 - Fixed option typehints being ignored when using `parameter_name`.
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
-- Fixed the type-hinting of `Guild.bulk_ban` to provide relevant examples. ([#2440](https://github.com/Pycord-Development/pycord/pull/2440))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2411](https://github.com/Pycord-Development/pycord/pull/2411))
 - Fixed option typehints being ignored when using `parameter_name`.
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
+- Fixed the type-hinting of `Guild.bulk_ban` to provide relevant examples. ([#2440](https://github.com/Pycord-Development/pycord/pull/2440))
 
 ### Changed
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3134,10 +3134,10 @@ class Guild(Hashable):
         Example Usage: ::
 
             # Ban multiple users
-            successes, failures = await guild.ban(user1, user2, user3, ..., reason="Raid")
+            successes, failures = await guild.bulk_ban(user1, user2, user3, ..., reason="Raid")
 
             # Ban a list of users
-            successes, failures = await guild.ban(*users)
+            successes, failures = await guild.bulk_ban(*users)
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary

Fixed type-hinting in `Example Usage` section of `Guild.bulk_ban`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
