### PR TITLE
fix: AttributeError using PartialMessage.edit(embed=None)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2411](https://github.com/Pycord-Development/pycord/pull/2411))
 - Fixed option typehints being ignored when using `parameter_name`.
   ([#2417](https://github.com/Pycord-Development/pycord/pull/2417))
+- Fixed parameter `embed=None` causing `AttributeError` on `PartialMessage.edit`.
+  ([#2446](https://github.com/Pycord-Development/pycord/pull/2446))
 
 ### Changed
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -2039,7 +2039,7 @@ class PartialMessage(Hashable):
             raise InvalidArgument("Cannot pass both embed and embeds parameters.")
 
         if embed is not MISSING:
-            fields["embeds"] = [embed.to_dict()]
+            fields["embeds"] = [] if embed is None else [embed.to_dict()]
 
         if embeds is not MISSING:
             fields["embeds"] = [embed.to_dict() for embed in embeds]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The documentation of method `PartialMessage.edit` says that you can pass parameter `embed` as None to remove the embed, but on the implementation there was an `AttributeError`: 'NoneType' object has no attribute 'to_dict'.
So I quickly fixed it adding a check ```if embed is None```, same way as it is in the method `Message.edit`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
