### PR TITLE
fix: incorrect type-hint for RawMemberRemoveEvent.user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2446](https://github.com/Pycord-Development/pycord/pull/2446))
 - Fixed paginator to revert state if a page update callback fails.
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
-- Fixed the type-hinting of `RawMemberRemoveEvent.user` to reflect actual
-  behavior. ([#2456](https://github.com/Pycord-Development/pycord/pull/2456))
+- Fixed the type-hinting of `RawMemberRemoveEvent.user` to reflect actual behavior.
+  ([#2456](https://github.com/Pycord-Development/pycord/pull/2456))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2446](https://github.com/Pycord-Development/pycord/pull/2446))
 - Fixed paginator to revert state if a page update callback fails.
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
+- Fixed the type-hinting of `RawMemberRemoveEvent.user` to reflect actual
+  behavior. ([]())
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2446](https://github.com/Pycord-Development/pycord/pull/2446))
 - Fixed paginator to revert state if a page update callback fails.
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
-- Fixed the type-hinting of `RawMemberRemoveEvent.user` to reflect actual behavior.
+- Fixed the incorrect type of `RawMemberRemoveEvent.user`.
   ([#2456](https://github.com/Pycord-Development/pycord/pull/2456))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed paginator to revert state if a page update callback fails.
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
 - Fixed the type-hinting of `RawMemberRemoveEvent.user` to reflect actual
-  behavior. ([]())
+  behavior. ([#2456](https://github.com/Pycord-Development/pycord/pull/2456))
 
 ### Changed
 

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING
 
 from .automod import AutoModAction, AutoModTriggerType
 from .enums import AuditLogAction, ChannelType, ReactionType, try_enum
-from .types.user import User
 
 if TYPE_CHECKING:
     from .abc import MessageableChannel
@@ -58,6 +57,7 @@ if TYPE_CHECKING:
         TypingEvent,
         VoiceChannelStatusUpdateEvent,
     )
+    from .user import User
 
 
 __all__ = (


### PR DESCRIPTION
## Summary

Fixed the type-hinting of `RawMemberRemoveEvent.user` to reflect actual behavior.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
