### PR TITLE
fix: missing `application_id` in `Entitlement.delete`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2446](https://github.com/Pycord-Development/pycord/pull/2446))
 - Fixed paginator to revert state if a page update callback fails.
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
+- Fixed missing `application_id` in `Entitlement.delete`.
+  ([#2458](https://github.com/Pycord-Development/pycord/pull/2458))
 
 ### Changed
 

--- a/discord/monetization.py
+++ b/discord/monetization.py
@@ -173,4 +173,4 @@ class Entitlement(Hashable):
         HTTPException
             Deleting the entitlement failed.
         """
-        await self._state.http.delete_test_entitlement(self.id)
+        await self._state.http.delete_test_entitlement(self.application_id, self.id)


### PR DESCRIPTION
## Summary

Fixed issue with missing `application_id` in `Entitlement.delete`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
