### PR TITLE
docs: limits on integer and number option types

### DIFF
--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -30,6 +30,13 @@ of :class:`enum.Enum`.
     .. attribute:: integer
 
         An integer.
+
+        .. note::
+
+            Any integer between -2⁵³ and 2⁵³. 
+            
+            IDs, such as 881224361015672863, are often too for this input type.
+
     .. attribute:: boolean
 
         A boolean.
@@ -47,7 +54,13 @@ of :class:`enum.Enum`.
         A mentionable (user or role).
     .. attribute:: number
 
-        A floating number.
+        A floating-point number.
+
+        .. note::
+
+            Any floating-point number between -2⁵³ and 2⁵³. 
+            
+            IDs, such as 881224361015672863, are often too for this input type.
 
     .. attribute:: attachment
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -29,11 +29,9 @@ of :class:`enum.Enum`.
         A string.
     .. attribute:: integer
 
-        An integer.
+        An integer between -2⁵³ and 2⁵³.
 
         .. note::
-
-            Any integer between -2⁵³ and 2⁵³.
 
             IDs, such as 881224361015672863, are often too for this input type.
 
@@ -54,11 +52,9 @@ of :class:`enum.Enum`.
         A mentionable (user or role).
     .. attribute:: number
 
-        A floating-point number.
+        A floating-point number between -2⁵³ and 2⁵³.
 
         .. note::
-
-            Any floating-point number between -2⁵³ and 2⁵³.
 
             IDs, such as 881224361015672863, are often too for this input type.
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -33,7 +33,7 @@ of :class:`enum.Enum`.
 
         .. note::
 
-            IDs, such as 881224361015672863, are often too for this input type.
+            IDs, such as 881224361015672863, are often too big for this input type.
 
     .. attribute:: boolean
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -33,8 +33,8 @@ of :class:`enum.Enum`.
 
         .. note::
 
-            Any integer between -2⁵³ and 2⁵³. 
-            
+            Any integer between -2⁵³ and 2⁵³.
+
             IDs, such as 881224361015672863, are often too for this input type.
 
     .. attribute:: boolean
@@ -58,8 +58,8 @@ of :class:`enum.Enum`.
 
         .. note::
 
-            Any floating-point number between -2⁵³ and 2⁵³. 
-            
+            Any floating-point number between -2⁵³ and 2⁵³.
+
             IDs, such as 881224361015672863, are often too for this input type.
 
     .. attribute:: attachment

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -56,7 +56,7 @@ of :class:`enum.Enum`.
 
         .. note::
 
-            IDs, such as 881224361015672863, are often too for this input type.
+            IDs, such as 881224361015672863, are often too big for this input type.
 
     .. attribute:: attachment
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Many people seem to use `SlashCommandOptionType.integer` or similar for IDs. This change serves to clarify its limitations.

The superscripts seem to have extra spacing because of monospaces, but this looks fine-ish on the documentation.

Looking for feedback about whether the ID notes for `SlashCommandOptionType.number` are necessary or can be removed.

I'm not sure how to remove ambiguity with this change and with `Option.max_value` and `Option.min_value` since those can be used to change the range of accepted values.

<img width="523" alt="image" src="https://github.com/Pycord-Development/pycord/assets/89910983/4227c4b2-e791-4b21-8502-8b341fc6fdd3">


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
