### PR TITLE
fix: enum option issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
 - Fixed missing `application_id` in `Entitlement.delete`.
   ([#2458](https://github.com/Pycord-Development/pycord/pull/2458))
+- Fixed issues with enums as `Option` types with long descriptions or too many values
+  ([#2463](https://github.com/Pycord-Development/pycord/pull/2463))
 
 ### Changed
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -115,6 +115,7 @@ class Option:
     input_type: Union[Type[:class:`str`], Type[:class:`bool`], Type[:class:`int`], Type[:class:`float`], Type[:class:`.abc.GuildChannel`], Type[:class:`Thread`], Type[:class:`Member`], Type[:class:`User`], Type[:class:`Attachment`], Type[:class:`Role`], Type[:class:`.abc.Mentionable`], :class:`SlashCommandOptionType`, Type[:class:`.ext.commands.Converter`], Type[:class:`enums.Enum`], Type[:class:`Enum`]]
         The type of input that is expected for this option. This can be a :class:`SlashCommandOptionType`,
         an associated class, a channel type, a :class:`Converter`, a converter class or an :class:`enum.Enum`.
+        If a :class:`enum.Enum` is used and it has up to 25 values, :attr:`choices` will be automatically filled. If the :class:`enum.Enum` has more than 25 values, :attr:`autocomplete` will be implemented with :func:`discord.utils.basic_autocomplete` instead.
     name: :class:`str`
         The name of this option visible in the UI.
         Inherits from the variable name if not provided as a parameter.

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -88,6 +88,7 @@ CHANNEL_TYPE_MAP = {
 
 _log = logging.getLogger(__name__)
 
+
 class ThreadOption:
     """Represents a class that can be passed as the ``input_type`` for an :class:`Option` class.
 
@@ -203,7 +204,7 @@ class Option:
                     _log.warning(
                         "Option %s's description was truncated due to Enum %s's docstring exceeding 100 characters.",
                         self.name,
-                        input_type
+                        input_type,
                     )
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -196,7 +196,7 @@ class Option:
         input_type_is_class = isinstance(input_type, type)
         if input_type_is_class and issubclass(input_type, (Enum, DiscordEnum)):
             if description is None:
-                description = inspect.getdoc(input_type)
+                description = inspect.cleandoc(input_type.__doc__)
                 if description and len(description) > 100:
                     description = description[:97] + "..."
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import inspect
+import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Optional, Type, Union
 
@@ -87,7 +88,6 @@ CHANNEL_TYPE_MAP = {
 }
 
 _log = logging.getLogger(__name__)
-
 
 class ThreadOption:
     """Represents a class that can be passed as the ``input_type`` for an :class:`Option` class.
@@ -204,7 +204,7 @@ class Option:
                     _log.warning(
                         "Option %s's description was truncated due to Enum %s's docstring exceeding 100 characters.",
                         self.name,
-                        input_type,
+                        input_type
                     )
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -86,6 +86,7 @@ CHANNEL_TYPE_MAP = {
     DMChannel: ChannelType.private,
 }
 
+_log = logging.getLogger(__name__)
 
 class ThreadOption:
     """Represents a class that can be passed as the ``input_type`` for an :class:`Option` class.
@@ -121,7 +122,7 @@ class Option:
         Inherits from the variable name if not provided as a parameter.
     description: Optional[:class:`str`]
         The description of this option.
-        Must be 100 characters or fewer.
+        Must be 100 characters or fewer. If :attr:`input_type` is a :class:`enum.Enum` and :attr:`description` is not specified, :attr:`input_type`'s docstring will be used.
     choices: Optional[List[Union[:class:`Any`, :class:`OptionChoice`]]]
         The list of available choices for this option.
         Can be a list of values or :class:`OptionChoice` objects (which represent a name:value pair).
@@ -199,6 +200,11 @@ class Option:
                 description = inspect.cleandoc(input_type.__doc__)
                 if description and len(description) > 100:
                     description = description[:97] + "..."
+                    _log.warning(
+                        "Option %s's description was truncated due to Enum %s's docstring exceeding 100 characters.",
+                        self.name,
+                        input_type
+                    )
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__
             if all(isinstance(elem.value, value_class) for elem in enum_choices):

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -89,6 +89,7 @@ CHANNEL_TYPE_MAP = {
 
 _log = logging.getLogger(__name__)
 
+
 class ThreadOption:
     """Represents a class that can be passed as the ``input_type`` for an :class:`Option` class.
 
@@ -204,7 +205,7 @@ class Option:
                     _log.warning(
                         "Option %s's description was truncated due to Enum %s's docstring exceeding 100 characters.",
                         self.name,
-                        input_type
+                        input_type,
                     )
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__


### PR DESCRIPTION
## Summary

Makes two changes for better enum support in options:
- If an enum's docstring is greater than 100 characters, truncate it (fixes issues on Python 3.11)
- If an enum has more than 25 values, use `basic_autocomplete` instead of `choices` and forces the type back to string.

Related thread: https://discord.com/channels/881207955029110855/1238137800440942684/1238624044396314714

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
