### PR TITLE
fix: options initializing with null input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
 - Fixed missing `application_id` in `Entitlement.delete`.
   ([#2458](https://github.com/Pycord-Development/pycord/pull/2458))
-- Fixed `AttributeError` in `register_commands` when a `discord.Option` was constructed
-  with its `input_type` set to `None`
+- Fixed `AttributeError` due to `discord.Option` being initialised
+  with `input_type` set to `None`.
   ([#2464](https://github.com/Pycord-Development/pycord/pull/2464))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
 - Fixed missing `application_id` in `Entitlement.delete`.
   ([#2458](https://github.com/Pycord-Development/pycord/pull/2458))
-- Fixed `AttributeError` in `register_commands` when a `discord.Option` was
-  constructed with its `input_type` set to `None`
+- Fixed `AttributeError` in `register_commands` when a `discord.Option` was constructed
+  with its `input_type` set to `None`
   ([#2464](https://github.com/Pycord-Development/pycord/pull/2464))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
 - Fixed missing `application_id` in `Entitlement.delete`.
   ([#2458](https://github.com/Pycord-Development/pycord/pull/2458))
-- Fixed `AttributeError` due to `discord.Option` being initialised
-  with `input_type` set to `None`.
-  ([#2464](https://github.com/Pycord-Development/pycord/pull/2464))
+- Fixed `AttributeError` due to `discord.Option` being initialised with `input_type` set
+  to `None`. ([#2464](https://github.com/Pycord-Development/pycord/pull/2464))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2448](https://github.com/Pycord-Development/pycord/pull/2448))
 - Fixed missing `application_id` in `Entitlement.delete`.
   ([#2458](https://github.com/Pycord-Development/pycord/pull/2458))
+- Fixed `AttributeError` in `register_commands` when a `discord.Option` was
+  constructed with its `input_type` set to `None`
+  ([#2464](https://github.com/Pycord-Development/pycord/pull/2464))
 
 ### Changed
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -330,6 +330,9 @@ class Option:
             "description_localizations", MISSING
         )
 
+        if input_type is None:
+            raise TypeError("input_type cannot be NoneType.")
+
     def to_dict(self) -> dict:
         as_dict = {
             "name": self.name,


### PR DESCRIPTION
## Summary

Previously, if for some reason an Option was created with a None `input_type` value, an error would not be raised until `on_connect` called `sync_commands()`. You can see the trouble I had to go through troubleshooting the vague error message [here](https://discord.com/channels/881207955029110855/1132206148309749830/1244683495217954876).

This two-line modification will simply raise an error if input_type is None after Option() has finished initialising.
If this is not a suitable fix, I am open to suggestions to make further modifications.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] I have searched the open pull requests for duplicates.
- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [X] I have updated the changelog to include these changes.
