### PR TITLE
fix: remove_application_command missing case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2457](https://github.com/Pycord-Development/pycord/pull/2457))
 - Fixed `AttributeError` due to `discord.Option` being initialised with `input_type` set
   to `None`. ([#2464](https://github.com/Pycord-Development/pycord/pull/2464))
+- Fixed `remove_application_command` causing issues while reloading extensions.
+  ([#2480](https://github.com/Pycord-Development/pycord/pull/2480))
 
 ### Changed
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -108,7 +108,7 @@ class ApplicationCommandMixin(ABC):
         return list(self._application_commands.values())
 
     def add_application_command(self, command: ApplicationCommand) -> None:
-        """Adds a :class:`.ApplicationCommand` into the internal list of commands.
+        """Adds an :class:`.ApplicationCommand` into the internal list of commands.
 
         This is usually not called, instead the :meth:`command` or
         other shortcut decorators are used instead.
@@ -136,7 +136,7 @@ class ApplicationCommandMixin(ABC):
     def remove_application_command(
         self, command: ApplicationCommand
     ) -> ApplicationCommand | None:
-        """Remove a :class:`.ApplicationCommand` from the internal list
+        """Remove an :class:`.ApplicationCommand` from the internal list
         of commands.
 
         .. versionadded:: 2.0
@@ -149,16 +149,15 @@ class ApplicationCommandMixin(ABC):
         Returns
         -------
         Optional[:class:`.ApplicationCommand`]
-            The command that was removed. If the name is not valid then
+            The command that was removed. If the command has not been added,
             ``None`` is returned instead.
         """
-        if command.id is None:
-            try:
-                index = self._pending_application_commands.index(command)
-            except ValueError:
-                return None
-            return self._pending_application_commands.pop(index)
-        return self._application_commands.pop(command.id, None)
+        if command.id:
+            self._application_commands.pop(command.id, None)
+
+        if command in self._pending_application_commands:
+            self._pending_application_commands.remove(command)
+            return command
 
     @property
     def get_command(self):
@@ -178,7 +177,7 @@ class ApplicationCommandMixin(ABC):
         guild_ids: list[int] | None = None,
         type: type[ApplicationCommand] = ApplicationCommand,
     ) -> ApplicationCommand | None:
-        """Get a :class:`.ApplicationCommand` from the internal list
+        """Get an :class:`.ApplicationCommand` from the internal list
         of commands.
 
         .. versionadded:: 2.0

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -460,7 +460,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         called. This makes it a useful function to set up database
         connections or any type of set up required.
 
-        This pre-invoke hook takes a sole parameter, a :class:`.ApplicationContext`.
+        This pre-invoke hook takes a sole parameter, an :class:`.ApplicationContext`.
         See :meth:`.Bot.before_invoke` for more info.
 
         Parameters
@@ -485,7 +485,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
         called. This makes it a useful function to clean-up database
         connections or any type of clean up required.
 
-        This post-invoke hook takes a sole parameter, a :class:`.ApplicationContext`.
+        This post-invoke hook takes a sole parameter, an :class:`.ApplicationContext`.
         See :meth:`.Bot.after_invoke` for more info.
 
         Parameters


### PR DESCRIPTION
## Summary
The current implementation of `CogMixin.remove_application_command` ignores the fact that commands with IDs (synchronised commands) stay in the list of pending commands. The new implementation takes this into account.

This intends to fix #1383, requires testing.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
