### PR TITLE
feat: add Attachment.title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,12 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2408](https://github.com/Pycord-Development/pycord/pull/2408))
 - Added `stacklevel` param to `utils.warn_deprecated` and `utils.deprecated`.
   ([#2450](https://github.com/Pycord-Development/pycord/pull/2450))
-- Added `Attachment.title`.
-  ([#2486](https://github.com/Pycord-Development/pycord/pull/2486))
 - Added support for user-installable applications.
   ([#2409](https://github.com/Pycord-Development/pycord/pull/2409)
 - Added support for one-time purchases for Discord monetization.
   ([#2438](https://github.com/Pycord-Development/pycord/pull/2438))
+- Added `Attachment.title`.
+  ([#2486](https://github.com/Pycord-Development/pycord/pull/2486))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2412](https://github.com/Pycord-Development/pycord/pull/2412))
 - Added `stacklevel` param to `utils.warn_deprecated` and `utils.deprecated`.
   ([#2450](https://github.com/Pycord-Development/pycord/pull/2450))
+- Added `Attachment.title`.
+  ([#2486](https://github.com/Pycord-Development/pycord/pull/2486))
 
 ### Fixed
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -190,6 +190,11 @@ class Attachment(Hashable):
         The unique signature of this attachment's instance.
 
         .. versionadded:: 2.5
+
+    title: Optional[:class:`str`]
+        The attachment's title. This is equal to the original :attr:`filename` if special characters were filtered from it.
+
+        .. versionadded:: 2.6
     """
 
     __slots__ = (
@@ -210,6 +215,7 @@ class Attachment(Hashable):
         "_ex",
         "_is",
         "hm",
+        "title",
     )
 
     def __init__(self, *, data: AttachmentPayload, state: ConnectionState):
@@ -218,6 +224,7 @@ class Attachment(Hashable):
         self.height: int | None = data.get("height")
         self.width: int | None = data.get("width")
         self.filename: str = data["filename"]
+        self.title: str | None = data.get("title")
         self.url: str = data.get("url")
         self.proxy_url: str = data.get("proxy_url")
         self._http = state.http

--- a/discord/message.py
+++ b/discord/message.py
@@ -192,7 +192,7 @@ class Attachment(Hashable):
         .. versionadded:: 2.5
 
     title: Optional[:class:`str`]
-        The attachment's title. This is equal to the original :attr:`filename` if special characters were filtered from it.
+        The attachment's title. This is equal to the original :attr:`filename` (without its extension) if special characters were filtered from it.
 
         .. versionadded:: 2.6
     """

--- a/discord/message.py
+++ b/discord/message.py
@@ -155,6 +155,11 @@ class Attachment(Hashable):
         The attachment's width, in pixels. Only applicable to images and videos.
     filename: :class:`str`
         The attachment's filename.
+    title: Optional[:class:`str`]
+        The attachment's title. This is equal to the original :attr:`filename` (without an extension)
+        if special characters were filtered from it.
+
+        .. versionadded:: 2.6
     url: :class:`str`
         The attachment URL. If the message this attachment was attached
         to is deleted, then this will 404.
@@ -193,12 +198,6 @@ class Attachment(Hashable):
         The unique signature of this attachment's instance.
 
         .. versionadded:: 2.5
-
-    title: Optional[:class:`str`]
-        The attachment's title. This is equal to the original :attr:`filename` (without an extension)
-        if special characters were filtered from it.
-
-        .. versionadded:: 2.6
     """
 
     __slots__ = (

--- a/discord/message.py
+++ b/discord/message.py
@@ -195,7 +195,8 @@ class Attachment(Hashable):
         .. versionadded:: 2.5
 
     title: Optional[:class:`str`]
-        The attachment's title. This is equal to the original :attr:`filename` (without its extension) if special characters were filtered from it.
+        The attachment's title. This is equal to the original :attr:`filename` (without an extension)
+        if special characters were filtered from it.
 
         .. versionadded:: 2.6
     """

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -75,6 +75,7 @@ class Attachment(TypedDict):
     duration_secs: NotRequired[float]
     waveform: NotRequired[str]
     flags: NotRequired[int]
+    title: NotRequired[str]
 
 
 MessageActivityType = Literal[1, 2, 3, 5]


### PR DESCRIPTION
## Summary

Adds attachment titles as per discord/discord-api-docs#6945. Only exists if a filename had special characters which were filtered out of the upload.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
