### PR TITLE
fix: premium buttons and entitlement iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `stacklevel` param to `utils.warn_deprecated` and `utils.deprecated`.
   ([#2450](https://github.com/Pycord-Development/pycord/pull/2450))
 - Added support for user-installable applications.
-  ([#2409](https://github.com/Pycord-Development/pycord/pull/2409)
+  ([#2409](https://github.com/Pycord-Development/pycord/pull/2409))
 - Added support for one-time purchases for Discord monetization.
   ([#2438](https://github.com/Pycord-Development/pycord/pull/2438))
 - Added `Attachment.title`.
@@ -93,7 +93,10 @@ These changes are available on the `master` branch, but have not yet been releas
   `ApplicationCommand.contexts`.
   ([#2409](https://github.com/Pycord-Development/pycord/pull/2409))
 - `Message.interaction` is now deprecated in favor of `Message.interaction_metadata`.
-  ([#2409](https://github.com/Pycord-Development/pycord/pull/2409)
+  ([#2409](https://github.com/Pycord-Development/pycord/pull/2409))
+- Replaced `client.fetch_entitlements` with `client.entitlements`, which returns an
+  `EntitlementIterator`.
+  ([#2490](https://github.com/Pycord-Development/pycord/pull/2490))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2409](https://github.com/Pycord-Development/pycord/pull/2409))
 - `Message.interaction` is now deprecated in favor of `Message.interaction_metadata`.
   ([#2409](https://github.com/Pycord-Development/pycord/pull/2409))
-- Replaced `client.fetch_entitlements` with `client.entitlements`, which returns an
+- Replaced `Client.fetch_entitlements` with `Client.entitlements`, which returns an
   `EntitlementIterator`.
   ([#2490](https://github.com/Pycord-Development/pycord/pull/2490))
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -2043,7 +2043,7 @@ class Client:
         data = await self._connection.http.list_skus(self.application_id)
         return [SKU(data=s) for s in data]
 
-    async def fetch_entitlements(
+    def entitlements(
         self,
         user: Snowflake | None = None,
         skus: list[Snowflake] | None = None,
@@ -2053,9 +2053,7 @@ class Client:
         guild: Snowflake | None = None,
         exclude_ended: bool = False,
     ) -> EntitlementIterator:
-        """|coro|
-
-        Fetches the bot's entitlements.
+        """Returns an :class:`.AsyncIterator` that enables fetching the application's entitlements.
 
         .. versionadded:: 2.5
 
@@ -2083,15 +2081,29 @@ class Client:
             Whether to limit the fetched entitlements to those that have not ended.
             Defaults to ``False``.
 
-        Returns
-        -------
-        :class:`.EntitlementIterator`
+        Yields
+        ------
+        :class:`.Entitlement`
             The application's entitlements.
 
         Raises
         ------
         :exc:`HTTPException`
             Retrieving the entitlements failed.
+
+        Examples
+        --------
+
+        Usage ::
+
+            async for entitlement in client.entitlements():
+                print(entitlement.user_id)
+
+        Flattening into a list ::
+
+            entitlements = await user.entitlements().flatten()
+
+        All parameters are optional.
         """
         return EntitlementIterator(
             self._connection,

--- a/discord/client.py
+++ b/discord/client.py
@@ -2051,7 +2051,7 @@ class Client:
         after: SnowflakeTime | None = None,
         limit: int | None = 100,
         guild: Snowflake | None = None,
-        exclude_ended: bool | None = None,
+        exclude_ended: bool | None = None,  # TODO this is only a temporary workarount, as yarl does not support bool
     ) -> EntitlementIterator:
         """|coro|
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -2051,9 +2051,7 @@ class Client:
         after: SnowflakeTime | None = None,
         limit: int | None = 100,
         guild: Snowflake | None = None,
-        exclude_ended: (
-            bool | None
-        ) = None,  # TODO this is only a temporary workarount, as yarl does not support bool
+        exclude_ended: bool = False,
     ) -> EntitlementIterator:
         """|coro|
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -2085,7 +2085,7 @@ class Client:
 
         Returns
         -------
-        List[:class:`.Entitlement`]
+        :class:`.EntitlementIterator`
             The application's entitlements.
 
         Raises
@@ -2095,12 +2095,12 @@ class Client:
         """
         return EntitlementIterator(
             self._connection,
-            user_id=user.id,
-            sku_ids=[sku.id for sku in skus],
+            user_id=user.id if user else None,
+            sku_ids=[sku.id for sku in skus] if skus else None,
             before=before,
             after=after,
             limit=limit,
-            guild_id=guild.id,
+            guild_id=guild.id if guild else None,
             exclude_ended=exclude_ended,
         )
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -2051,7 +2051,7 @@ class Client:
         after: SnowflakeTime | None = None,
         limit: int | None = 100,
         guild: Snowflake | None = None,
-        exclude_ended: bool = False,
+        exclude_ended: bool | None = None,
     ) -> EntitlementIterator:
         """|coro|
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -2055,7 +2055,7 @@ class Client:
     ) -> EntitlementIterator:
         """Returns an :class:`.AsyncIterator` that enables fetching the application's entitlements.
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
 
         Parameters
         ----------

--- a/discord/client.py
+++ b/discord/client.py
@@ -2051,7 +2051,9 @@ class Client:
         after: SnowflakeTime | None = None,
         limit: int | None = 100,
         guild: Snowflake | None = None,
-        exclude_ended: bool | None = None,  # TODO this is only a temporary workarount, as yarl does not support bool
+        exclude_ended: (
+            bool | None
+        ) = None,  # TODO this is only a temporary workarount, as yarl does not support bool
     ) -> EntitlementIterator:
         """|coro|
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -68,7 +68,12 @@ from .file import File
 from .flags import SystemChannelFlags
 from .integrations import Integration, _integration_factory
 from .invite import Invite
-from .iterators import AuditLogIterator, BanIterator, MemberIterator
+from .iterators import (
+    AuditLogIterator,
+    BanIterator,
+    EntitlementIterator,
+    MemberIterator,
+)
 from .member import Member, VoiceState
 from .mixins import Hashable
 from .monetization import Entitlement
@@ -4071,7 +4076,7 @@ class Guild(Hashable):
         data = await self._state.http.create_test_entitlement(self.id, payload)
         return Entitlement(data=data, state=self._state)
 
-    async def fetch_entitlements(
+    def entitlements(
         self,
         skus: list[Snowflake] | None = None,
         before: SnowflakeTime | None = None,
@@ -4079,11 +4084,9 @@ class Guild(Hashable):
         limit: int | None = 100,
         exclude_ended: bool = False,
     ) -> EntitlementIterator:
-        """|coro|
+        """Returns an :class:`.AsyncIterator` that enables fetching the guild's entitlements.
 
-        Fetches this guild's entitlements.
-
-        This is identical to :meth:`Client.fetch_entitlements` with the ``guild`` parameter.
+        This is identical to :meth:`Client.entitlements` with the ``guild`` parameter.
 
         .. versionadded:: 2.6
 
@@ -4107,9 +4110,9 @@ class Guild(Hashable):
             Whether to limit the fetched entitlements to those that have not ended.
             Defaults to ``False``.
 
-        Returns
-        -------
-        List[:class:`.Entitlement`]
+        Yields
+        ------
+        :class:`.Entitlement`
             The application's entitlements.
 
         Raises
@@ -4119,7 +4122,7 @@ class Guild(Hashable):
         """
         return EntitlementIterator(
             self._state,
-            sku_ids=[sku.id for sku in skus],
+            sku_ids=[sku.id for sku in skus] if skus else None,
             before=before,
             after=after,
             limit=limit,

--- a/discord/http.py
+++ b/discord/http.py
@@ -2980,7 +2980,7 @@ class HTTPClient:
         if guild_id is not None:
             params["guild_id"] = guild_id
         if exclude_ended is not None:
-            params["exclude_ended"] = exclude_ended
+            params["exclude_ended"] = int(exclude_ended)
 
         r = Route(
             "GET",

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -1055,7 +1055,7 @@ class EntitlementIterator(_AsyncIterator["Entitlement"]):
             user_id=self.user_id,
             guild_id=self.guild_id,
             sku_ids=self.sku_ids,
-            exclude_ended=self.exclude_ended,
+            exclude_ended=int(self.exclude_ended),
         )
 
         if not data:

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -1055,7 +1055,7 @@ class EntitlementIterator(_AsyncIterator["Entitlement"]):
             user_id=self.user_id,
             guild_id=self.guild_id,
             sku_ids=self.sku_ids,
-            exclude_ended=int(self.exclude_ended),
+            exclude_ended=self.exclude_ended,
         )
 
         if not data:

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -117,7 +117,7 @@ class Button(Item[V]):
             )
 
         self._provided_custom_id = custom_id is not None
-        if url is None and custom_id is None:
+        if url is None and custom_id is None and sku_id is None:
             custom_id = os.urandom(16).hex()
 
         if url is not None:

--- a/discord/user.py
+++ b/discord/user.py
@@ -639,7 +639,7 @@ class User(BaseUser, discord.abc.Messageable):
         data = await self._state.http.create_test_entitlement(self.id, payload)
         return Entitlement(data=data, state=self._state)
 
-    async def fetch_entitlements(
+    def entitlements(
         self,
         skus: list[Snowflake] | None = None,
         before: SnowflakeTime | None = None,
@@ -647,11 +647,9 @@ class User(BaseUser, discord.abc.Messageable):
         limit: int | None = 100,
         exclude_ended: bool = False,
     ) -> EntitlementIterator:
-        """|coro|
+        """Returns an :class:`.AsyncIterator` that enables fetching the user's entitlements.
 
-        Fetches this user's entitlements.
-
-        This is identical to :meth:`Client.fetch_entitlements` with the ``user`` parameter.
+        This is identical to :meth:`Client.entitlements` with the ``user`` parameter.
 
         .. versionadded:: 2.6
 
@@ -675,9 +673,9 @@ class User(BaseUser, discord.abc.Messageable):
             Whether to limit the fetched entitlements to those that have not ended.
             Defaults to ``False``.
 
-        Returns
-        -------
-        List[:class:`.Entitlement`]
+        Yields
+        ------
+        :class:`.Entitlement`
             The application's entitlements.
 
         Raises
@@ -687,7 +685,7 @@ class User(BaseUser, discord.abc.Messageable):
         """
         return EntitlementIterator(
             self._state,
-            sku_ids=[sku.id for sku in skus],
+            sku_ids=[sku.id for sku in skus] if skus else None,
             before=before,
             after=after,
             limit=limit,


### PR DESCRIPTION
## Summary
This PR fixes some issues with monetization.

1) Premium buttons do not work with a custom ID, I disabled the auto-generated custom_id for premium buttons
2) `bot.fetch_entitlements()` did not work when certain parameters were not set
3) The `exclude_ended` attribute threw an error, because yarl does not support boolean params. I don't know how to fix that, so I just set it to `None` for now. Perhaps @plun1331 can help

I have tested the changes with a monetized Discord bot.

Edit: This PR now renames `client.fetch_entitlements` to `client.entitlements`.

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
