### PR TITLE
fix: further address audit log issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2480](https://github.com/Pycord-Development/pycord/pull/2480))
 - Fixed outdated logic for filtering and sorting audit log entries.
   ([#2371](https://github.com/Pycord-Development/pycord/pull/2371))
+- Further fixed logic when fetching audit logs.
+  ([#2492](https://github.com/Pycord-Development/pycord/pull/2492))
 
 ### Changed
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1946,9 +1946,9 @@ class HTTPClient:
         action_type: AuditLogAction | None = None,
     ) -> Response[audit_log.AuditLog]:
         params: dict[str, Any] = {"limit": limit}
-        if before:
+        if before is not None:
             params["before"] = before
-        if after:
+        if after is not None:
             params["after"] = after
         if user_id:
             params["user_id"] = user_id

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -511,7 +511,6 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         )
 
         entries = data.get("audit_log_entries", [])
-        print(self.limit, self.retrieve, self.before, self.after)
         # if ONLY after is passed and NOT before, Discord reverses the sort to oldest first.
         if len(data) and entries:
             if self.limit is not None:

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -491,12 +491,14 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         self.before = before
         self.user_id = user_id
         self.action_type = action_type
-        self.after = after or OLDEST_OBJECT
+        self.after = after
         self._users = {}
         self._state = guild._state
         self.entries = asyncio.Queue()
 
     async def _retrieve_entries(self, retrieve):
+        if not self._get_retrieve():
+            return
         before = self.before.id if self.before else None
         after = self.after.id if self.after else None
         data: AuditLogPayload = await self.request(
@@ -509,12 +511,16 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         )
 
         entries = data.get("audit_log_entries", [])
+        print(self.limit, self.retrieve, self.before, self.after)
+        # if ONLY after is passed and NOT before, Discord reverses the sort to oldest first.
         if len(data) and entries:
             if self.limit is not None:
                 self.limit -= retrieve
             if self.before or not self.after:
                 self.before = Object(id=int(entries[-1]["id"]))
-            if self.after or not self.before:
+            if self.after and not self.before:
+                self.after = Object(id=int(entries[-1]["id"]))
+            elif self.after or not self.before:
                 self.after = Object(id=int(entries[0]["id"]))
         return data.get("users", []), entries
 
@@ -528,9 +534,13 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
             raise NoMoreItems()
 
     def _get_retrieve(self):
-        limit = self.limit or 100
-        self.retrieve = min(limit, 100)
-        return self.retrieve > 0
+        l = self.limit
+        if l is None or l > 100:
+            r = 100
+        else:
+            r = l
+        self.retrieve = r
+        return r > 0
 
     async def _fill(self):
         from .user import User

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -519,8 +519,6 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
                 self.before = Object(id=int(entries[-1]["id"]))
             if self.after and not self.before:
                 self.after = Object(id=int(entries[-1]["id"]))
-            elif self.after or not self.before:
-                self.after = Object(id=int(entries[0]["id"]))
         return data.get("users", []), entries
 
     async def next(self) -> AuditLogEntry:


### PR DESCRIPTION
## Summary

**Any fixes to audit logs should require heavy scrutiny, please test thoroughly before approving.**

Makes further adjustments to audit log logic:
- `after` reverses the sort to oldest first IF AND ONLY IF `before` is not passed. In this instance, it should redefine `after` as the last item instead of the first. Discord's language on this in their docs is easy to misunderstand.
- Adjusted http request to accept `0` as a valid snowflake (as officially [recommended](https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log))
- Reverted `_get_retrieve` changes as the new method was not reliable, resulting in extra requests.

While i have tested this PR, it still needs further testing for guilds with extensive audit logs and thus higher limits above 100.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
