### PR TITLE
docs: Add missing attributes to UserCommand and MessageCommand

### DIFF
--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1730,7 +1730,17 @@ class UserCommand(ContextMenuCommand):
         The coroutine that is executed when the command is called.
     guild_ids: Optional[List[:class:`int`]]
         The ids of the guilds where this command will be registered.
-    cog: Optional[:class:`.Cog`]
+    guild_only: :class:`bool`
+        Whether the command should only be usable inside a guild.
+
+        .. deprecated:: 2.6
+            Use the ``contexts`` parameter instead.
+    nsfw: :class:`bool`
+        Whether the command should be restricted to 18+ channels and users.
+        Apps intending to be listed in the App Directory cannot have NSFW commands.
+    default_member_permissions: :class:`~discord.Permissions`
+        The default permissions a member needs to be able to run the command.
+    cog: Optional[:class:`Cog`]
         The cog that this command belongs to. ``None`` if there isn't one.
     checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]
         A list of predicates that verifies if the command could be executed
@@ -1739,6 +1749,16 @@ class UserCommand(ContextMenuCommand):
         :exc:`.ApplicationCommandError` should be used. Note that if the checks fail then
         :exc:`.CheckFailure` exception is raised to the :func:`.on_application_command_error`
         event.
+    cooldown: Optional[:class:`~discord.ext.commands.Cooldown`]
+        The cooldown applied when the command is invoked. ``None`` if the command
+        doesn't have a cooldown.
+    name_localizations: Dict[:class:`str`, :class:`str`]
+        The name localizations for this command. The values of this should be ``"locale": "name"``. See
+        `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
+    integration_types: Set[:class:`IntegrationType`]
+        The installation contexts where this command is available. Unapplicable for guild commands.
+    contexts: Set[:class:`InteractionContextType`]
+        The interaction contexts where this command is available. Unapplicable for guild commands.
     """
 
     type = 2
@@ -1829,7 +1849,17 @@ class MessageCommand(ContextMenuCommand):
         The coroutine that is executed when the command is called.
     guild_ids: Optional[List[:class:`int`]]
         The ids of the guilds where this command will be registered.
-    cog: Optional[:class:`.Cog`]
+    guild_only: :class:`bool`
+        Whether the command should only be usable inside a guild.
+
+        .. deprecated:: 2.6
+            Use the ``contexts`` parameter instead.
+    nsfw: :class:`bool`
+        Whether the command should be restricted to 18+ channels and users.
+        Apps intending to be listed in the App Directory cannot have NSFW commands.
+    default_member_permissions: :class:`~discord.Permissions`
+        The default permissions a member needs to be able to run the command.
+    cog: Optional[:class:`Cog`]
         The cog that this command belongs to. ``None`` if there isn't one.
     checks: List[Callable[[:class:`.ApplicationContext`], :class:`bool`]]
         A list of predicates that verifies if the command could be executed
@@ -1838,6 +1868,16 @@ class MessageCommand(ContextMenuCommand):
         :exc:`.ApplicationCommandError` should be used. Note that if the checks fail then
         :exc:`.CheckFailure` exception is raised to the :func:`.on_application_command_error`
         event.
+    cooldown: Optional[:class:`~discord.ext.commands.Cooldown`]
+        The cooldown applied when the command is invoked. ``None`` if the command
+        doesn't have a cooldown.
+    name_localizations: Dict[:class:`str`, :class:`str`]
+        The name localizations for this command. The values of this should be ``"locale": "name"``. See
+        `here <https://discord.com/developers/docs/reference#locales>`_ for a list of valid locales.
+    integration_types: Set[:class:`IntegrationType`]
+        The installation contexts where this command is available. Unapplicable for guild commands.
+    contexts: Set[:class:`InteractionContextType`]
+        The interaction contexts where this command is available. Unapplicable for guild commands.
     """
 
     type = 3


### PR DESCRIPTION
## Summary
Adds attributes to UserCommand and MessageCommand that were previously missing. They are documented in the superclass `ContextMenuCommand` however this inheritance is not converted by the `autoclass`.

I tried looking for a better way to do this other than just copy/paste but I could not find a viable method. I tried adding `:inherited-members:`, but this did not inherit attributes, only properties and methods. I am willing to look into a better solution if needed.
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
