### PR TITLE
fix: Rename 'cover' to 'image' in relation to ScheduledEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Changed
 
-- Renamed `cover` property of `ScheduledEvent` and `cover` argument of `ScheduledEvent.edit` to `image`.
+- Renamed `cover` property of `ScheduledEvent` and `cover` argument of
+  `ScheduledEvent.edit` to `image`.
   ([#2496](https://github.com/Pycord-Development/pycord/pull/2496))
 
 ## [2.6.0] - 2024-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+### Changed
+
+- Renamed `cover` property of `ScheduledEvent` and `cover` attribute of `ScheduledEvent.edit` to `image`.
+  ([#2496](https://github.com/Pycord-Development/pycord/pull/2496))
+
 ## [2.6.0] - 2024-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Changed
 
-- Renamed `cover` property of `ScheduledEvent` and `cover` attribute of `ScheduledEvent.edit` to `image`.
+- Renamed `cover` property of `ScheduledEvent` and `cover` argument of `ScheduledEvent.edit` to `image`.
   ([#2496](https://github.com/Pycord-Development/pycord/pull/2496))
 
 ## [2.6.0] - 2024-07-09

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -277,7 +277,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_scheduled_event_cover(
+    def _from_scheduled_event_image(
         cls, state, event_id: int, cover_hash: str
     ) -> Asset:
         return cls(

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -153,12 +153,12 @@ def _transform_avatar(entry: AuditLogEntry, data: str | None) -> Asset | None:
     return Asset._from_avatar(entry._state, entry._target_id, data)  # type: ignore
 
 
-def _transform_scheduled_event_cover(
+def _transform_scheduled_event_image(
     entry: AuditLogEntry, data: str | None
 ) -> Asset | None:
     if data is None:
         return None
-    return Asset._from_scheduled_event_cover(entry._state, entry._target_id, data)
+    return Asset._from_scheduled_event_image(entry._state, entry._target_id, data)
 
 
 def _guild_hash_transformer(
@@ -274,7 +274,7 @@ class AuditLogChanges:
             _enum_transformer(enums.ScheduledEventLocationType),
         ),
         "command_id": ("command_id", _transform_snowflake),
-        "image_hash": ("cover", _transform_scheduled_event_cover),
+        "image_hash": ("image", _transform_scheduled_event_image),
         "trigger_type": (None, _enum_transformer(enums.AutoModTriggerType)),
         "event_type": (None, _enum_transformer(enums.AutoModEventType)),
         "actions": (None, _transform_actions),

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -35,12 +35,11 @@ from .enums import (
     ScheduledEventStatus,
     try_enum,
 )
-from .errors import ValidationError
+from .errors import InvalidArgument, ValidationError
 from .iterators import ScheduledEventSubscribersIterator
 from .mixins import Hashable
 from .object import Object
 from .utils import warn_deprecated
-from .errors import InvalidArgument
 
 __all__ = (
     "ScheduledEvent",
@@ -362,7 +361,9 @@ class ScheduledEvent(Hashable):
         if cover is not MISSING:
             warn_deprecated("cover", "image", "2.7")
             if image is not MISSING:
-                raise InvalidArgument("cannot pass both `image` and `cover` to `ScheduledEvent.edit`")
+                raise InvalidArgument(
+                    "cannot pass both `image` and `cover` to `ScheduledEvent.edit`"
+                )
             else:
                 image = cover
 

--- a/discord/scheduled_events.py
+++ b/discord/scheduled_events.py
@@ -39,6 +39,8 @@ from .errors import ValidationError
 from .iterators import ScheduledEventSubscribersIterator
 from .mixins import Hashable
 from .object import Object
+from .utils import warn_deprecated
+from .errors import InvalidArgument
 
 __all__ = (
     "ScheduledEvent",
@@ -180,7 +182,7 @@ class ScheduledEvent(Hashable):
         "location",
         "guild",
         "_state",
-        "_cover",
+        "_image",
         "subscriber_count",
     )
 
@@ -198,7 +200,7 @@ class ScheduledEvent(Hashable):
         self.guild: Guild = guild
         self.name: str = data.get("name")
         self.description: str | None = data.get("description", None)
-        self._cover: str | None = data.get("image", None)
+        self._image: str | None = data.get("image", None)
         self.start_time: datetime.datetime = datetime.datetime.fromisoformat(
             data.get("scheduled_start_time")
         )
@@ -254,13 +256,24 @@ class ScheduledEvent(Hashable):
 
     @property
     def cover(self) -> Asset | None:
+        """
+        Returns the scheduled event cover image asset, if available.
+
+        .. deprecated:: 2.7
+                Use the :attr:`image` property instead.
+        """
+        warn_deprecated("cover", "image", "2.7")
+        return self.image
+
+    @property
+    def image(self) -> Asset | None:
         """Returns the scheduled event cover image asset, if available."""
-        if self._cover is None:
+        if self._image is None:
             return None
-        return Asset._from_scheduled_event_cover(
+        return Asset._from_scheduled_event_image(
             self._state,
             self.id,
-            self._cover,
+            self._image,
         )
 
     async def edit(
@@ -276,6 +289,7 @@ class ScheduledEvent(Hashable):
         start_time: datetime.datetime = MISSING,
         end_time: datetime.datetime = MISSING,
         cover: bytes | None = MISSING,
+        image: bytes | None = MISSING,
         privacy_level: ScheduledEventPrivacyLevel = ScheduledEventPrivacyLevel.guild_only,
     ) -> ScheduledEvent | None:
         """|coro|
@@ -310,8 +324,13 @@ class ScheduledEvent(Hashable):
             so there is no need to change this parameter.
         reason: Optional[:class:`str`]
             The reason to show in the audit log.
+        image: Optional[:class:`bytes`]
+            The cover image of the scheduled event.
         cover: Optional[:class:`bytes`]
             The cover image of the scheduled event.
+
+            .. deprecated:: 2.7
+                Use the `image` argument instead.
 
         Returns
         -------
@@ -341,8 +360,17 @@ class ScheduledEvent(Hashable):
             payload["privacy_level"] = int(privacy_level)
 
         if cover is not MISSING:
-            if cover is not None:
-                payload["image"] = utils._bytes_to_base64_data(cover)
+            warn_deprecated("cover", "image", "2.7")
+            if image is not MISSING:
+                raise InvalidArgument("cannot pass both `image` and `cover` to `ScheduledEvent.edit`")
+            else:
+                image = cover
+
+        if image is not MISSING:
+            if image is None:
+                payload["image"] = None
+            else:
+                payload["image"] = utils._bytes_to_base64_data(image)
 
         if location is not MISSING:
             if not isinstance(

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -524,5 +524,11 @@ this goal, it must make use of a couple of data classes that aid in this goal.
 
         :type: :class:`str`
 
+   .. attribute:: image
+
+      The cover image of a :class:`ScheduledEvent`.
+
+      :type: :class:`str`
+
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to about porting these

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -1413,6 +1413,7 @@ of :class:`enum.Enum`.
         - :attr:`~discord.ScheduledEvent.location`
         - :attr:`~discord.ScheduledEvent.status`
         - :attr:`~discord.ScheduledEventLocation.type`
+        - :attr:`~discord.ScheduledEvent.image`
 
         .. versionadded:: 2.0
 
@@ -1433,6 +1434,7 @@ of :class:`enum.Enum`.
         - :attr:`~discord.ScheduledEvent.location`
         - :attr:`~discord.ScheduledEvent.status`
         - :attr:`~discord.ScheduledEventLocation.type`
+        - :attr:`~discord.ScheduledEvent.image`
 
         .. versionadded:: 2.0
 
@@ -1453,6 +1455,7 @@ of :class:`enum.Enum`.
         - :attr:`~discord.ScheduledEvent.location`
         - :attr:`~discord.ScheduledEvent.status`
         - :attr:`~discord.ScheduledEventLocation.type`
+        - :attr:`~discord.ScheduledEvent.image`
 
         .. versionadded:: 2.0
 


### PR DESCRIPTION
## Summary
Renames the `cover` property of `ScheduledEvent` to `image`.
Renames the `cover` argument of `ScheduledEvent.edit` to `image`.

This is to be consistent with the API as well as other ScheduledEvent related naming. 
This contains breaking changes to private and undocumented features.

I think this also fixes an issue where the image was unable to be removed (only changed) via the `ScheduledEvent.edit` method.

Closes #2010 
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
