### PR TITLE
fix: inverted type hints in `CheckAnyFailure`

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -212,10 +212,10 @@ class CheckAnyFailure(CheckFailure):
     """
 
     def __init__(
-        self, checks: list[CheckFailure], errors: list[Callable[[Context], bool]]
+        self, checks: list[Callable[[Context], bool]], errors: list[CheckFailure]
     ) -> None:
-        self.checks: list[CheckFailure] = checks
-        self.errors: list[Callable[[Context], bool]] = errors
+        self.checks: list[Callable[[Context], bool]] = checks
+        self.errors: list[CheckFailure] = errors
         super().__init__("You do not have permission to run this command.")
 
 


### PR DESCRIPTION
## Summary

In `CheckAnyFailure` the type hints on the attributes were inverted. See https://github.com/Pycord-Development/pycord/blob/7b617da331b7f945a578baeb7febac289f2558ce/discord/ext/commands/core.py#L1926
for how the error is raised. The docstring was correct on the other hand so I did not change it.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
