### PR TITLE
fix: Avoid premature garbage collection of Client tasks

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -31,15 +31,7 @@ import signal
 import sys
 import traceback
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Coroutine,
-    Generator,
-    Sequence,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator, Sequence, TypeVar
 
 import aiohttp
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -31,7 +31,7 @@ import signal
 import sys
 import traceback
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator, Sequence, Set, TypeVar
 
 import aiohttp
 
@@ -256,6 +256,9 @@ class Client:
             VoiceClient.warn_nacl = False
             _log.warning("PyNaCl is not installed, voice will NOT be supported")
 
+        # Used to hard-reference tasks so they don't get garbage collected (discarded with done_callbacks)
+        self._tasks: Set[asyncio.Task] = set()
+
     async def __aenter__(self) -> Client:
         loop = asyncio.get_running_loop()
         self.loop = loop
@@ -423,8 +426,12 @@ class Client:
         **kwargs: Any,
     ) -> asyncio.Task:
         wrapped = self._run_event(coro, event_name, *args, **kwargs)
-        # Schedules the task
-        return asyncio.create_task(wrapped, name=f"pycord: {event_name}")
+
+        # Schedule task and store in set to avoid task garbage collection
+        task = asyncio.create_task(wrapped, name=f"pycord: {event_name}")
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
 
     def dispatch(self, event: str, *args: Any, **kwargs: Any) -> None:
         _log.debug("Dispatching event %s", event)

--- a/discord/client.py
+++ b/discord/client.py
@@ -38,7 +38,6 @@ from typing import (
     Coroutine,
     Generator,
     Sequence,
-    Set,
     TypeVar,
 )
 
@@ -266,7 +265,7 @@ class Client:
             _log.warning("PyNaCl is not installed, voice will NOT be supported")
 
         # Used to hard-reference tasks so they don't get garbage collected (discarded with done_callbacks)
-        self._tasks: set[asyncio.Task] = set()
+        self._tasks = set()
 
     async def __aenter__(self) -> Client:
         loop = asyncio.get_running_loop()

--- a/discord/client.py
+++ b/discord/client.py
@@ -31,7 +31,16 @@ import signal
 import sys
 import traceback
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator, Sequence, Set, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Generator,
+    Sequence,
+    Set,
+    TypeVar,
+)
 
 import aiohttp
 
@@ -257,7 +266,7 @@ class Client:
             _log.warning("PyNaCl is not installed, voice will NOT be supported")
 
         # Used to hard-reference tasks so they don't get garbage collected (discarded with done_callbacks)
-        self._tasks: Set[asyncio.Task] = set()
+        self._tasks: set[asyncio.Task] = set()
 
     async def __aenter__(self) -> Client:
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary

Addresses #2179: Avoids client tasks being garbage collected prematurely, particularly on long-running tasks.

## Information
- [ x] This PR fixes an issue.

## Checklist
- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
