### PR TITLE
fix: :memo: Improve wording in `option` decorator slightly

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -424,7 +424,7 @@ def option(name, input_type=None, **kwargs):
     Attributes
     ----------
     parameter_name: :class:`str`
-        The name of the target parameter this option is mapped to.
+        The name of the target function parameter this option is mapped to.
         This allows you to have a separate UI ``name`` and parameter name.
     """
 

--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -660,7 +660,7 @@ def bridge_option(name, input_type=None, **kwargs):
     Attributes
     ----------
     parameter_name: :class:`str`
-        The name of the target parameter this option is mapped to.
+        The name of the target function parameter this option is mapped to.
         This allows you to have a separate UI ``name`` and parameter name.
     """
 


### PR DESCRIPTION
## Summary
Improve wording slightly after https://discord.com/channels/881207955029110855/1268565153516093500 
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
