### PR TITLE
chore(python)!: remove support for python 3.8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-min_python_version = 3.8
+min_python_version = 3.9
 
 # Incompatible with black see https://github.com/ambv/black/issues/315
 ignore =

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report broken or incorrect behaviour
-labels: unconfirmed bug
+labels: ["unconfirmed bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a feature for this library
-labels: feature request
+labels: ["feature request"]
 body:
   - type: input
     attributes:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # Python 3.8/3.9 are on macos-13 but not macos-latest (macos-14-arm64)
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        # Python 3.9 are on macos-13 but not macos-latest (macos-14-arm64)
         # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
         exclude:
-          - { python-version: "3.8", os: "macos-latest" }
           - { python-version: "3.9", os: "macos-latest" }
         include:
-          - { python-version: "3.8", os: "macos-13" }
           - { python-version: "3.9", os: "macos-13" }
-
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -58,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
           cache-dependency-path: "requirements/docs.txt"
           check-latest: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ formats: []
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
   configuration: docs/conf.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Renamed `cover` property of `ScheduledEvent` and `cover` argument of
   `ScheduledEvent.edit` to `image`.
   ([#2496](https://github.com/Pycord-Development/pycord/pull/2496))
+- ⚠️ **Removed support for Python 3.8** ⚠️
 
 ## [2.6.0] - 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ possible (see our [Version Guarantees] for more info).
 
 These changes are available on the `master` branch, but have not yet been released.
 
+⚠️ **This Version Removes Support For Python 3.8** ⚠️
+
 ### Changed
 
 - Renamed `cover` property of `ScheduledEvent` and `cover` argument of
   `ScheduledEvent.edit` to `image`.
   ([#2496](https://github.com/Pycord-Development/pycord/pull/2496))
-- ⚠️ **Removed support for Python 3.8** ⚠️
+- ⚠️ **This Version Removes Support For Python 3.8** ⚠️
+  ([#2521](https://github.com/Pycord-Development/pycord/pull/2521))
 
 ## [2.6.0] - 2024-07-09
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Key Features
 Installing
 ----------
 
-**Python 3.8 or higher is required**
+**Python 3.9 or higher is required**
 
 To install the library without full voice support, run the following command:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "A Python wrapper for the Discord API"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -20,7 +20,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -66,7 +65,7 @@ voice = {file = "requirements/voice.txt"}
 [tool.setuptools_scm]
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py39', 'py310', 'py311', 'py312']
 
 [tool.isort]
 profile = "black"
@@ -85,7 +84,7 @@ extension-pkg-whitelist = [
     "pydantic",
     "ujson"
 ]
-py-version = 3.8
+py-version = 3.9
 
 [tool.pylint.messages_control]
 enable = [


### PR DESCRIPTION
Needed for new docs + python 3.8 is gonna be EOL by october
Next pycord version should be probably 3.x.x
