### PR TITLE
docs: fix sphinx warnings and errors

### DIFF
--- a/docs/api/application_commands.rst
+++ b/docs/api/application_commands.rst
@@ -38,6 +38,9 @@ Shortcut Decorators
 .. autofunction:: discord.commands.message_command
     :decorator:
 
+.. autofunction:: discord.commands.option
+    :decorator:
+
 Objects
 ~~~~~~~
 
@@ -60,17 +63,6 @@ Objects
 .. attributetable:: MessageCommand
 .. autoclass:: MessageCommand
     :members:
-
-Options
--------
-
-Shortcut Decorators
-~~~~~~~~~~~~~~~~~~~
-.. autofunction:: discord.commands.option
-    :decorator:
-
-Objects
-~~~~~~~
 
 .. attributetable:: Option
 .. autoclass:: Option


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Just a bunch of sphinx stuff

### To-do list
- [ ] I:\Development\GitHub\pycord\docs\api\application_commands.rst:68: WARNING: duplicate label shortcut decorators, other instance in I:\Development\GitHub\pycord\docs\api\application_commands.rst [autosectionlabel.api/application_commands]
- [ ] I:\Development\GitHub\pycord\docs\api\application_commands.rst:73: WARNING: duplicate label objects, other instance in I:\Development\GitHub\pycord\docs\api\application_commands.rst [autosectionlabel.api/application_commands]
- [ ] I:\Development\GitHub\pycord\discord\bot.py:docstring of discord.client.Client.get_all_channels:8: WARNING: Literal block ends without a blank line; unexpected unindent. [docutils]
- [ ] I:\Development\GitHub\pycord\discord\client.py:docstring of discord.client.Client.get_all_channels:8: WARNING: Literal block ends without a blank line; unexpected unindent. [docutils]
- [ ] I:\Development\GitHub\pycord\discord\client.py:docstring of discord.client.Client.listen:8: ERROR: Unknown target name: "on". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\bot.py:docstring of discord.client.Client.add_listener:11: ERROR: Unknown target name: "on". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\client.py:docstring of discord.client.Client.listen:8: ERROR: Unknown target name: "on". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\client.py:docstring of discord.client.Client.add_listener:11: ERROR: Unknown target name: "on". [docutils]
- [ ] I:\Development\GitHub\pycord\docs\api\enums.rst:2365: WARNING: Inline literal start-string without end-string. [docutils]
- [ ] I:\Development\GitHub\pycord\docs\api\events.rst:60: WARNING: duplicate label application commands, other instance in I:\Development\GitHub\pycord\docs\api\application_commands.rst [autosectionlabel.api/events]
- [ ] I:\Development\GitHub\pycord\docs\api\exceptions.rst:46: WARNING: duplicate label objects, other instance in I:\Development\GitHub\pycord\docs\api\application_commands.rst [autosectionlabel.api/exceptions]
- [ ] WARNING: Cannot resolve forward reference in type annotations of "discord.Guild.edit_onboarding": name 'OnboardingPrompt' is not defined
- [ ] I:\Development\GitHub\pycord\discord\guild.py:docstring of discord.Guild.invites_disabled:1: WARNING: duplicate object description of discord.Guild.invites_disabled, other instance in api/models, use :no-index: for one of them
- [ ] I:\Development\GitHub\pycord\discord\automod.py:docstring of discord.automod.AutoModTriggerMetadata:72: WARNING: Duplicate explicit target name: "here". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawTypingEvent:45: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawMessageDeleteEvent:37: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawBulkMessageDeleteEvent:37: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawMessageUpdateEvent:40: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawReactionActionEvent:91: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawReactionClearEvent:31: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawReactionClearEmojiEvent:65: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawIntegrationDeleteEvent:33: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawThreadDeleteEvent:45: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawScheduledEventSubscription:43: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawMemberRemoveEvent:29: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawThreadUpdateEvent:43: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawThreadMembersUpdateEvent:33: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawAuditLogEntryEvent:64: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\raw_models.py:docstring of discord.raw_models.RawVoiceChannelStatusUpdateEvent:31: WARNING: Duplicate explicit target name: "gateway". [docutils]
- [ ] I:\Development\GitHub\pycord\docs\api\models.rst:75: WARNING: duplicate label messages, other instance in I:\Development\GitHub\pycord\docs\api\events.rst [autosectionlabel.api/models]
- [ ] I:\Development\GitHub\pycord\docs\api\models.rst:166: WARNING: duplicate label automod, other instance in I:\Development\GitHub\pycord\docs\api\events.rst [autosectionlabel.api/models]
- [ ] I:\Development\GitHub\pycord\docs\api\models.rst:189: WARNING: duplicate label invites, other instance in I:\Development\GitHub\pycord\docs\api\events.rst [autosectionlabel.api/models]
- [ ] I:\Development\GitHub\pycord\docs\api\models.rst:299: WARNING: duplicate label threads, other instance in I:\Development\GitHub\pycord\docs\api\events.rst [autosectionlabel.api/models]
- [ ] I:\Development\GitHub\pycord\docs\api\models.rst:334: WARNING: duplicate label interactions, other instance in I:\Development\GitHub\pycord\docs\api\events.rst [autosectionlabel.api/models]
- [ ] I:\Development\GitHub\pycord\docs\api\models.rst:404: WARNING: duplicate label channels, other instance in I:\Development\GitHub\pycord\docs\api\events.rst [autosectionlabel.api/models]
- [ ] I:\Development\GitHub\pycord\docs\api\ui_kit.rst:10: WARNING: duplicate label shortcut decorators, other instance in I:\Development\GitHub\pycord\docs\api\application_commands.rst [autosectionlabel.api/ui_kit]
- [ ] I:\Development\GitHub\pycord\docs\api\ui_kit.rst:34: WARNING: duplicate label objects, other instance in I:\Development\GitHub\pycord\docs\api\exceptions.rst [autosectionlabel.api/ui_kit]
- [ ] I:\Development\GitHub\pycord\docs\api\voice.rst:7: WARNING: duplicate label objects, other instance in I:\Development\GitHub\pycord\docs\api\ui_kit.rst [autosectionlabel.api/voice]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:92: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:128: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:218: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:253: WARNING: duplicate label removed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:260: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:370: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:376: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:389: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:416: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:426: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:444: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:455: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:462: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:483: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:493: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:502: WARNING: duplicate label removed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:509: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:517: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:522: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:533: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:565: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:579: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:586: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:594: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:601: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:632: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:642: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:695: WARNING: duplicate label security, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:702: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:734: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:743: WARNING: duplicate label removed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:748: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:791: WARNING: duplicate label added, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:841: WARNING: duplicate label changed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:854: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\changelog.md:891: WARNING: duplicate label fixed, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.changelog]
- [ ] I:\Development\GitHub\pycord\docs\cogs.rst:7: WARNING: duplicate label cogs, other instance in I:\Development\GitHub\pycord\docs\api\cogs.rst
- [ ] I:\Development\GitHub\pycord\docs\cogs.rst:7: WARNING: duplicate label cogs, other instance in I:\Development\GitHub\pycord\docs\cogs.rst [autosectionlabel.cogs]
- [ ] I:\Development\GitHub\pycord\discord\ext\bridge\core.py:docstring of discord.ext.bridge.BridgeCommand.name_localizations:4: ERROR: Unexpected indentation. [docutils]
- [ ] I:\Development\GitHub\pycord\discord\ext\bridge\core.py:docstring of discord.ext.bridge.BridgeCommand.description_localizations:4: ERROR: Unexpected indentation. [docutils]
- [ ] I:\Development\GitHub\pycord\docs\ext\bridge\api.rst:4: WARNING: duplicate label api reference, other instance in I:\Development\GitHub\pycord\docs\api\index.rst [autosectionlabel.ext/bridge/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\bridge\api.rst:17: WARNING: duplicate label bots, other instance in I:\Development\GitHub\pycord\docs\api\clients.rst [autosectionlabel.ext/bridge/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\bridge\api.rst:44: WARNING: duplicate label event reference, other instance in I:\Development\GitHub\pycord\docs\api\events.rst [autosectionlabel.ext/bridge/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\bridge\api.rst:81: WARNING: duplicate label commands, other instance in I:\Development\GitHub\pycord\docs\api\application_commands.rst [autosectionlabel.ext/bridge/api]
- [ ] I:\Development\GitHub\pycord\discord\ext\commands\bot.py:docstring of discord.client.Client.get_all_channels:8: WARNING: Literal block ends without a blank line; unexpected unindent. [docutils]
- [ ] I:\Development\GitHub\pycord\discord\ext\commands\core.py:docstring of discord.ext.commands.core.check_any:21: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
- [ ] I:\Development\GitHub\pycord\discord\client.py:docstring of discord.client.Client.listen:8: ERROR: Unknown target name: "on". [docutils]
- [ ] I:\Development\GitHub\pycord\discord\ext\commands\bot.py:docstring of discord.client.Client.add_listener:11: ERROR: Unknown target name: "on". [docutils]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:4: WARNING: duplicate label api reference, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:16: WARNING: duplicate label bots, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:19: WARNING: duplicate label bot, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:53: WARNING: duplicate label autoshardedbot, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:70: WARNING: duplicate label event reference, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:111: WARNING: duplicate label commands, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:114: WARNING: duplicate label decorators, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:184: WARNING: duplicate label cogs, other instance in I:\Development\GitHub\pycord\docs\cogs.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:347: WARNING: duplicate label context, other instance in I:\Development\GitHub\pycord\docs\ext\bridge\api.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:451: WARNING: duplicate label exceptions, other instance in I:\Development\GitHub\pycord\docs\api\exceptions.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\api.rst:602: WARNING: duplicate label exception hierarchy, other instance in I:\Development\GitHub\pycord\docs\api\exceptions.rst [autosectionlabel.ext/commands/api]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\cogs.rst:6: WARNING: duplicate label cogs, other instance in I:\Development\GitHub\pycord\docs\ext\commands\api.rst [autosectionlabel.ext/commands/cogs]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\cogs.rst:21: WARNING: duplicate label quick example, other instance in I:\Development\GitHub\pycord\docs\cogs.rst [autosectionlabel.ext/commands/cogs]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\cogs.rst:55: WARNING: duplicate label cog registration, other instance in I:\Development\GitHub\pycord\docs\cogs.rst [autosectionlabel.ext/commands/cogs]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\cogs.rst:72: WARNING: duplicate label using cogs, other instance in I:\Development\GitHub\pycord\docs\cogs.rst [autosectionlabel.ext/commands/cogs]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\commands.rst:6: WARNING: duplicate label commands, other instance in I:\Development\GitHub\pycord\docs\ext\commands\api.rst [autosectionlabel.ext/commands/commands]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\commands.rst:188: WARNING: duplicate label converters, other instance in I:\Development\GitHub\pycord\docs\ext\commands\api.rst [autosectionlabel.ext/commands/commands]
- [ ] I:\Development\GitHub\pycord\docs\ext\commands\commands.rst:794: WARNING: duplicate label checks, other instance in I:\Development\GitHub\pycord\docs\ext\commands\api.rst [autosectionlabel.ext/commands/commands]
- [ ] I:\Development\GitHub\pycord\docs\ext\pages\index.rst:292: WARNING: duplicate label api reference, other instance in I:\Development\GitHub\pycord\docs\ext\commands\api.rst [autosectionlabel.ext/pages/index]
- [ ] I:\Development\GitHub\pycord\docs\ext\pages\index.rst:303: WARNING: duplicate label paginator, other instance in I:\Development\GitHub\pycord\docs\ext\commands\api.rst [autosectionlabel.ext/pages/index]
- [ ] I:\Development\GitHub\pycord\docs\ext\tasks\index.rst:136: WARNING: duplicate label api reference, other instance in I:\Development\GitHub\pycord\docs\ext\pages\index.rst [autosectionlabel.ext/tasks/index]
- [ ] I:\Development\GitHub\pycord\docs\index.rst:56: WARNING: duplicate label extensions, other instance in I:\Development\GitHub\pycord\docs\ext\commands\extensions.rst [autosectionlabel.index]
- [ ] I:\Development\GitHub\pycord\docs\installing.rst:23: WARNING: duplicate label installing, other instance in I:\Development\GitHub\pycord\docs\installing.rst [autosectionlabel.installing]
- [ ] I:\Development\GitHub\pycord\docs\migrating_to_v1.rst:924: WARNING: duplicate label event changes, other instance in I:\Development\GitHub\pycord\docs\migrating_to_v1.rst [autosectionlabel.migrating_to_v1]
- [ ] I:\Development\GitHub\pycord\docs\migrating_to_v2.rst:13: WARNING: duplicate label python version change, other instance in I:\Development\GitHub\pycord\docs\migrating_to_v1.rst [autosectionlabel.migrating_to_v2]
- [ ] I:\Development\GitHub\pycord\docs\migrating_to_v2.rst:20: WARNING: duplicate label major model changes, other instance in I:\Development\GitHub\pycord\docs\migrating_to_v1.rst [autosectionlabel.migrating_to_v2]
- [ ] I:\Development\GitHub\pycord\docs\migrating_to_v2.rst:193: WARNING: duplicate label event changes, other instance in I:\Development\GitHub\pycord\docs\migrating_to_v1.rst [autosectionlabel.migrating_to_v2]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:10: WARNING: duplicate label changelog, other instance in I:\Development\GitHub\pycord\docs\changelog.md [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:72: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:84: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:143: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:179: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:216: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:232: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:249: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:261: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:282: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:302: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:317: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:336: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:351: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:362: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:376: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:433: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:461: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:484: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:494: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:509: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:527: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:533: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:546: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:612: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:636: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:663: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:673: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:688: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:702: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:712: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:725: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:748: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:756: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:778: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:783: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:793: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:820: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:830: WARNING: duplicate label `discord.ext.commands, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:841: WARNING: duplicate label miscellaneous, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:849: WARNING: duplicate label `discord.ext.commands, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:860: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:879: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:895: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:909: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:915: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:941: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:963: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:974: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:980: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:990: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1003: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1017: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1030: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1053: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1066: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1105: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1126: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1149: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1172: WARNING: duplicate label new features, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\old_changelog.rst:1215: WARNING: duplicate label bug fixes, other instance in I:\Development\GitHub\pycord\docs\old_changelog.rst [autosectionlabel.old_changelog]
- [ ] I:\Development\GitHub\pycord\docs\quickstart.rst:8: WARNING: duplicate label quickstart, other instance in I:\Development\GitHub\pycord\docs\quickstart.rst [autosectionlabel.quickstart]


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
