### PR TITLE
add missing property decorator

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -267,6 +267,7 @@ class Attachment(Hashable):
             return None
         return datetime.datetime.utcfromtimestamp(int(self._is, 16))
 
+    @property
     def is_spoiler(self) -> bool:
         """Whether this attachment contains a spoiler."""
         return self.filename.startswith("SPOILER_")
@@ -416,7 +417,7 @@ class Attachment(Hashable):
             "proxy_url": self.proxy_url,
             "size": self.size,
             "url": self.url,
-            "spoiler": self.is_spoiler(),
+            "spoiler": self.is_spoiler,
         }
         if self.height:
             result["height"] = self.height


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
i think need missing property decorator in is_spoiler function of Attachment class because it can confusion and bugs
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
