### PR TITLE
fix: ext.bridge docs

### DIFF
--- a/docs/ext/bridge/api.rst
+++ b/docs/ext/bridge/api.rst
@@ -154,7 +154,7 @@ BridgeContext Subclasses
 
 .. attributetable:: discord.ext.bridge.Context
 
-.. data:: discord.ext.bridge.Context
+.. autoclass:: discord.ext.bridge.Context
 
     Alias of :data:`typing.Union` [ :class:`.BridgeExtContext`, :class:`.BridgeApplicationContext` ] for typing convenience.
 


### PR DESCRIPTION
## Summary

It fixes wrong behavior of ext.bridge docs.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
