### PR TITLE
fix: allow PartialMessage to have PartialMessageable as a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2500](https://github.com/Pycord-Development/pycord/pull/2500))
 - Fixed the type of `ForumChannel.default_sort_order`, changing it from `int` to
   `SortOrder`. ([#2500](https://github.com/Pycord-Development/pycord/pull/2500))
-- Fixed `PartialMessage`s causing errors when created from `PartialMessageable`. 
+- Fixed `PartialMessage`s causing errors when created from `PartialMessageable`.
   ([#2568](https://github.com/Pycord-Development/pycord/pull/2500))
 
 ## [2.6.0] - 2024-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2500](https://github.com/Pycord-Development/pycord/pull/2500))
 - Fixed the type of `ForumChannel.default_sort_order`, changing it from `int` to
   `SortOrder`. ([#2500](https://github.com/Pycord-Development/pycord/pull/2500))
+- Fixed `PartialMessage`s causing errors when created from `PartialMessageable`. 
+  ([#2568](https://github.com/Pycord-Development/pycord/pull/2500))
 
 ## [2.6.0] - 2024-07-09
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -42,6 +42,7 @@ from typing import (
 from urllib.parse import parse_qs, urlparse
 
 from . import utils
+from .channel import PartialMessageable
 from .components import _component_factory
 from .embeds import Embed
 from .emoji import Emoji
@@ -2001,6 +2002,7 @@ class PartialMessage(Hashable):
     - :meth:`DMChannel.get_partial_message`
     - :meth:`VoiceChannel.get_partial_message`
     - :meth:`StageChannel.get_partial_message`
+    - :meth:`PartialMessageable.get_partial_message`
 
     Note that this class is trimmed down and has no rich attributes.
 
@@ -2022,7 +2024,7 @@ class PartialMessage(Hashable):
 
     Attributes
     ----------
-    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`VoiceChannel`, :class:`StageChannel`]
+    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`VoiceChannel`, :class:`StageChannel`, :class:`PartialMessageable`]
         The channel associated with this partial message.
     id: :class:`int`
         The message ID.
@@ -2053,9 +2055,9 @@ class PartialMessage(Hashable):
             ChannelType.news_thread,
             ChannelType.public_thread,
             ChannelType.private_thread,
-        ):
+        ) and not isinstance(channel, PartialMessageable):
             raise TypeError(
-                "Expected TextChannel, VoiceChannel, StageChannel, DMChannel or Thread not"
+                "Expected TextChannel, VoiceChannel, StageChannel, DMChannel, Thread or PartialMessageable not"
                 f" {type(channel)!r}"
             )
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
