### PR TITLE
fix: user context command members having a `None` guild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ These changes are available on the `master` branch, but have not yet been releas
   `SortOrder`. ([#2500](https://github.com/Pycord-Development/pycord/pull/2500))
 - Fixed `PartialMessage`s causing errors when created from `PartialMessageable`.
   ([#2568](https://github.com/Pycord-Development/pycord/pull/2500))
+- Fixed the `guild` attribute of `Member`s recieved from a `UserCommand` being `None`.
+  ([#2573](https://github.com/Pycord-Development/pycord/pull/2573))
 
 ## [2.6.0] - 2024-07-09
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1786,12 +1786,8 @@ class UserCommand(ContextMenuCommand):
                 v["id"] = int(i)
                 user = v
             member["user"] = user
-            target = Member(
-                data=member,
-                guild=ctx.interaction._state._get_guild(ctx.interaction.guild_id),
-                state=ctx.interaction._state,
-            )
-
+            cache_flag = ctx.interaction._state.member_cache_flags.interaction
+            target = ctx.guild._get_and_update_member(member, user["id"], cache_flag)
         if self.cog is not None:
             await self.callback(self.cog, ctx, target)
         else:


### PR DESCRIPTION
## Summary

~~read the pr title idiot~~

pretty much just duplicates the behavior of the normal slash command member option (with the added bonus of caching now! yay!)

pre-(this fix) calls to `display_avatar` and similar attrs would fail on user-installed (and not guild-installed) apps because `guild` was `None`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
