### PR TITLE
fix: Single Member Enums Fail Converting To Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `Member.guild_banner` and `Member.display_banner` properties.
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
 
+### Fixed
+- Fix `Enum` options not setting the correct type when only one choice is available.
+  ([#2575](https://github.com/Pycord-Development/pycord/pull/2575))
+
 ### Changed
 
 - Renamed `cover` property of `ScheduledEvent` and `cover` argument of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 - Fix `Enum` options not setting the correct type when only one choice is available.
-  ([#2575](https://github.com/Pycord-Development/pycord/pull/2575))
+  ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -411,6 +411,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Updated the values of the `Color.embed_background()` classmethod to correspond with
   new theme colors in the app.
+  ([#1931](https://github.com/Pycord-Development/pycord/pull/1931))
 
 ### Fixed
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -209,7 +209,8 @@ class Option:
                     )
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__
-            if all(isinstance(elem.value, value_class) for elem in enum_choices):
+            if (enum_choices[0].value.__class__ in SlashCommandOptionType.__members__ and
+                    all(isinstance(elem.value, value_class) for elem in enum_choices)):
                 input_type = SlashCommandOptionType.from_datatype(
                     enum_choices[0].value.__class__
                 )

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -198,7 +198,7 @@ class Option:
         enum_choices = []
         input_type_is_class = isinstance(input_type, type)
         if input_type_is_class and issubclass(input_type, (Enum, DiscordEnum)):
-            if description is None:
+            if description is None and input_type.__doc__ is not None:
                 description = inspect.cleandoc(input_type.__doc__)
                 if description and len(description) > 100:
                     description = description[:97] + "..."

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -209,9 +209,7 @@ class Option:
                     )
             enum_choices = [OptionChoice(e.name, e.value) for e in input_type]
             value_class = enum_choices[0].value.__class__
-            if enum_choices[
-                0
-            ].value.__class__ in SlashCommandOptionType.__members__ and all(
+            if value_class in SlashCommandOptionType.__members__ and all(
                 isinstance(elem.value, value_class) for elem in enum_choices
             ):
                 input_type = SlashCommandOptionType.from_datatype(


### PR DESCRIPTION
## Summary
This fixes an issue where a Enum with one member that is not of a type accepted by discord an error would be thrown during option conversion. 
It also solves #2558 
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
