### PR TITLE
fix: make FFmpegOpusAudio codec behave as docs suggest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fix `Enum` options not setting the correct type when only one choice is available.
   ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
+- Fix `codec` option for `FFmpegOpusAudio` class to make it in line with documentation.
+  ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fix `Enum` options not setting the correct type when only one choice is available.
   ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
-- Fixed `codec` option for `FFmpegOpusAudio` class to make it in line with documentation.
-  ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
+- Fixed `codec` option for `FFmpegOpusAudio` class to make it in line with
+  documentation. ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fix `Enum` options not setting the correct type when only one choice is available.
   ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
-- Fix `codec` option for `FFmpegOpusAudio` class to make it in line with documentation.
+- Fixed `codec` option for `FFmpegOpusAudio` class to make it in line with documentation.
   ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
 
 ### Changed

--- a/discord/player.py
+++ b/discord/player.py
@@ -355,8 +355,10 @@ class FFmpegOpusAudio(FFmpegAudio):
         The codec to use to encode the audio data.  Normally this would be
         just ``libopus``, but is used by :meth:`FFmpegOpusAudio.from_probe` to
         opportunistically skip pointlessly re-encoding Opus audio data by passing
-        ``copy`` as the codec value.  Any values other than ``copy``, ``opus``, or
-        ``libopus`` will be considered ``libopus``.  Defaults to ``libopus``.
+        ``copy`` as the codec value.  Any values other than ``copy``, or
+        ``libopus`` will be considered ``libopus``. ``opus`` will also be considered
+        ``libopus`` since the ``opus`` encoder is still in development. Defaults to ``libopus``.
+        
 
         .. warning::
 
@@ -407,7 +409,9 @@ class FFmpegOpusAudio(FFmpegAudio):
         args.append("-i")
         args.append("-" if pipe else source)
 
-        codec = "copy" if codec in ("opus", "libopus") else "libopus"
+        # use "libopus" when "opus" is specified since the "opus" encoder is incomplete
+        # link to ffmpeg docs: https://www.ffmpeg.org/ffmpeg-codecs.html#opus 
+        codec = "copy" if codec == "copy" else "libopus"
 
         args.extend(
             (
@@ -417,16 +421,23 @@ class FFmpegOpusAudio(FFmpegAudio):
                 "opus",
                 "-c:a",
                 codec,
-                "-ar",
-                "48000",
-                "-ac",
-                "2",
-                "-b:a",
-                f"{bitrate}k",
                 "-loglevel",
                 "warning",
             )
         )
+
+        # only pass in bitrate, sample rate, channels arguments when actually encoding to avoid ffmpeg warnings
+        if codec != "copy":
+            args.extend(
+                (
+                    "-ar",
+                    "48000",
+                    "-ac",
+                    "2",
+                    "-b:a",
+                    f"{bitrate}k",
+                )
+            )
 
         if isinstance(options, str):
             args.extend(shlex.split(options))
@@ -501,6 +512,8 @@ class FFmpegOpusAudio(FFmpegAudio):
 
         executable = kwargs.get("executable")
         codec, bitrate = await cls.probe(source, method=method, executable=executable)
+        # only re-encode ir source isn't already opus, else directly copy source audio stream
+        codec = "copy" if codec in ("opus", "libopus") else "libopus"
         return cls(source, bitrate=bitrate, codec=codec, **kwargs)  # type: ignore
 
     @classmethod

--- a/discord/player.py
+++ b/discord/player.py
@@ -511,7 +511,7 @@ class FFmpegOpusAudio(FFmpegAudio):
 
         executable = kwargs.get("executable")
         codec, bitrate = await cls.probe(source, method=method, executable=executable)
-        # only re-encode ir source isn't already opus, else directly copy source audio stream
+        # only re-encode if the source isn't already opus, else directly copy the source audio stream
         codec = "copy" if codec in ("opus", "libopus") else "libopus"
         return cls(source, bitrate=bitrate, codec=codec, **kwargs)  # type: ignore
 

--- a/discord/player.py
+++ b/discord/player.py
@@ -358,7 +358,6 @@ class FFmpegOpusAudio(FFmpegAudio):
         ``copy`` as the codec value.  Any values other than ``copy``, or
         ``libopus`` will be considered ``libopus``. ``opus`` will also be considered
         ``libopus`` since the ``opus`` encoder is still in development. Defaults to ``libopus``.
-        
 
         .. warning::
 
@@ -410,7 +409,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         args.append("-" if pipe else source)
 
         # use "libopus" when "opus" is specified since the "opus" encoder is incomplete
-        # link to ffmpeg docs: https://www.ffmpeg.org/ffmpeg-codecs.html#opus 
+        # link to ffmpeg docs: https://www.ffmpeg.org/ffmpeg-codecs.html#opus
         codec = "copy" if codec == "copy" else "libopus"
 
         args.extend(


### PR DESCRIPTION
## Summary

make FFmpegOpusAudio "codec" parameter behave as what the inline docs suggest

Original behavior:
passing in "libopus" or "opus" will result in "copy" being passed into ffmpeg
passing in anything else (including "copy") will result in "libopus" being passed into ffmpeg

New behavior:
passing in "copy" will result in "copy" being passed into ffmpeg
passing in anything else (including "libopus", "opus") will result in "libopus" being passed into ffmpeg

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
