### PR TITLE
fix: audio plays in fast forward for first few seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
 - Fixed `codec` option for `FFmpegOpusAudio` class to make it in line with
   documentation. ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
-- Fixed audio plays in fast forward at beginning of audio files.
+- Fixed a possible bug where audio would play too fast at the beginning of audio files.
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Fixed `Enum` options not setting the correct type when only one choice is available.
   ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
+- Fixed audio playing back in fast forward for the first few seconds sometimes.
+  ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
 - Fixed `codec` option for `FFmpegOpusAudio` class to make it in line with
   documentation. ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
-- Fixed audio playing back in fast forward for the first few seconds sometimes.
+- Fixed audio plays in fast forward at beginning of audio files.
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
 
 ### Changed

--- a/discord/player.py
+++ b/discord/player.py
@@ -717,6 +717,9 @@ class AudioPlayer(threading.Thread):
             raise TypeError('Expected a callable for the "after" parameter.')
 
     def _do_run(self) -> None:
+        # attempt to read first audio segment from source before starting
+        # some sources can take a few seconds and may cause problems
+        first_data = self.source.read()
         self.loops = 0
         self._start = time.perf_counter()
 
@@ -740,7 +743,13 @@ class AudioPlayer(threading.Thread):
                 self._start = time.perf_counter()
 
             self.loops += 1
-            data = self.source.read()
+            # Send the data read from the start of the function if it is not None
+            if first_data is not None:
+                data = first_data
+                first_data = None
+            # Else read the next bit from the source
+            else:
+                data = self.source.read()
 
             if not data:
                 self.stop()


### PR DESCRIPTION
## Summary

Audio may in some cases play in fast forward for the first few seconds when the source is slow to start, such as ffmpeg

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
