### PR TITLE
feat: Add optional filter parameter to utils.basic_autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These changes are available on the `master` branch, but have not yet been releas
   `tags`. ([#2520](https://github.com/Pycord-Development/pycord/pull/2520))
 - Added `Member.guild_banner` and `Member.display_banner` properties.
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
-- Added optional `filter` parameter to `utils.basic_autocomplete`.
+- Added optional `filter` parameter to `utils.basic_autocomplete()`.
   ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ These changes are available on the `master` branch, but have not yet been releas
   `tags`. ([#2520](https://github.com/Pycord-Development/pycord/pull/2520))
 - Added `Member.guild_banner` and `Member.display_banner` properties.
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
+- Added optional `check` parameter in `utils.basic_autocomplete`. ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ These changes are available on the `master` branch, but have not yet been releas
   `tags`. ([#2520](https://github.com/Pycord-Development/pycord/pull/2520))
 - Added `Member.guild_banner` and `Member.display_banner` properties.
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
-- Added optional `check` parameter in `utils.basic_autocomplete`. ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
+- Added optional `check` parameter in `utils.basic_autocomplete`.
+  ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These changes are available on the `master` branch, but have not yet been releas
   `tags`. ([#2520](https://github.com/Pycord-Development/pycord/pull/2520))
 - Added `Member.guild_banner` and `Member.display_banner` properties.
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
-- Added optional `check` parameter in `utils.basic_autocomplete`.
+- Added optional `filter` parameter in `utils.basic_autocomplete`.
   ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These changes are available on the `master` branch, but have not yet been releas
   `tags`. ([#2520](https://github.com/Pycord-Development/pycord/pull/2520))
 - Added `Member.guild_banner` and `Member.display_banner` properties.
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
-- Added optional `filter` parameter in `utils.basic_autocomplete`.
+- Added optional `filter` parameter to `utils.basic_autocomplete`.
   ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
 
 ### Fixed

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1324,8 +1324,8 @@ def basic_autocomplete(
         Possible values for the option. Accepts an iterable of :class:`str`, a callable (sync or async) that takes a
         single argument of :class:`.AutocompleteContext`, or a coroutine. Must resolve to an iterable of :class:`str`.
     filter: Optional[Callable[[:class:`.AutocompleteContext`, Any], Union[:class:`bool`, Awaitable[:class:`bool`]]]]
-        Predicate callable (sync or async) used to filter the autocomplete options. This function should accept two arguments:
-        the :class:`.AutocompleteContext` and an item from ``values``. If ``None`` is provided, a default filter is used that includes items whose string representation starts with the user's input value, case-insensitive.
+        An optional callable (sync or async) used to filter the autocomplete options. It accepts two arguments:
+        the :class:`.AutocompleteContext` and an item from ``values`` iteration treated as callback parameters. If ``None`` is provided, a default filter is used that includes items whose string representation starts with the user's input value, case-insensitive.
 
         .. versionadded:: 2.7
 
@@ -1338,8 +1338,10 @@ def basic_autocomplete(
     ----
     Autocomplete cannot be used for options that have specified choices.
 
-    Example
+    Examples
     -------
+
+    Basic usage:
 
     .. code-block:: python3
 
@@ -1351,6 +1353,12 @@ def basic_autocomplete(
             return "foo", "bar", "baz", ctx.interaction.user.name
 
         Option(str, "name", autocomplete=basic_autocomplete(autocomplete))
+
+    With filter parameter:
+
+    .. code-block:: python3
+
+        Option(str, "color", autocomplete=basic_autocomplete(("red", "green", "blue"), filter=lambda c, i: str(c.value or "") in i))
 
     .. versionadded:: 2.0
     """

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1327,6 +1327,8 @@ def basic_autocomplete(
         Predicate callable (sync or async) used to filter the autocomplete options. This function should accept two arguments:
         the :class:`.AutocompleteContext` and an item from ``values``. If ``None`` is provided, a default filter is used that includes items whose string representation starts with the user's input value, case-insensitive.
 
+        .. versionadded:: 2.7
+
     Returns
     -------
     Callable[[:class:`.AutocompleteContext`], Awaitable[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1334,12 +1334,8 @@ def basic_autocomplete(
     Callable[[:class:`.AutocompleteContext`], Awaitable[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         A wrapped callback for the autocomplete.
 
-    Note
-    ----
-    Autocomplete cannot be used for options that have specified choices.
-
     Examples
-    -------
+    --------
 
     Basic usage:
 
@@ -1361,6 +1357,10 @@ def basic_autocomplete(
         Option(str, "color", autocomplete=basic_autocomplete(("red", "green", "blue"), filter=lambda c, i: str(c.value or "") in i))
 
     .. versionadded:: 2.0
+
+    Note
+    ----
+    Autocomplete cannot be used for options that have specified choices.
     """
 
     async def autocomplete_callback(ctx: AutocompleteContext) -> V:


### PR DESCRIPTION
## Summary

Add optional ``check`` parameter in ``utils.basic_autocomplete``.

If ``check`` is provided with ``None``, a default check is used that includes items whose string representation starts with the user's input value, case-insensitive.

## Information

- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [X] I have searched the open pull requests for duplicates.
- [X] If code changes were made then they have been tested.
  - [X] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [X] I have updated the changelog to include these changes.
