### PR TITLE
fix: `is_owner()` `user` type hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ These changes are available on the `master` branch, but have not yet been releas
   documentation. ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
 - Fixed a possible bug where audio would play too fast at the beginning of audio files.
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
+- Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
+  ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
 
 ### Changed
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1407,7 +1407,7 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
         self._after_invoke = coro
         return coro
 
-    async def is_owner(self, user: User) -> bool:
+    async def is_owner(self, user: User | Member) -> bool:
         """|coro|
 
         Checks if a :class:`~discord.User` or :class:`~discord.Member` is the owner of
@@ -1422,7 +1422,7 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
 
         Parameters
         ----------
-        user: :class:`.abc.User`
+        user: Union[:class:`.abc.User`, :class:`.member.Member`]
             The user to check for.
 
         Returns


### PR DESCRIPTION
## Summary

The `user` parameter must accept both a `User` and a `Member`, as the docstring itself says. In practice, it solves this error: `Argument 1 to "is_owner" of "BotBase" has incompatible type "User | Member"; expected "User"mypyarg-type`.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
