### PR TITLE
fix: don't try to do an interaction_check if there isn't a user available to check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ These changes are available on the `master` branch, but have not yet been releas
   `tags`. ([#2520](https://github.com/Pycord-Development/pycord/pull/2520))
 - Added `Member.guild_banner` and `Member.display_banner` properties.
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
+- Added optional `filter` parameter to `utils.basic_autocomplete()`.
+  ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ These changes are available on the `master` branch, but have not yet been releas
   documentation. ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
 - Fixed a possible bug where audio would play too fast at the beginning of audio files.
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
-- Fixed paginator buttons not responding when using `Paginator.edit()` with its default parameters ([#2594](https://github.com/Pycord-Development/pycord/pull/2594))
+- Fixed paginator buttons not responding when using `Paginator.edit()` with its default
+  parameters ([#2594](https://github.com/Pycord-Development/pycord/pull/2594))
 - Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
   ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ These changes are available on the `master` branch, but have not yet been releas
   documentation. ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
 - Fixed a possible bug where audio would play too fast at the beginning of audio files.
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
-- Fixed paginator buttons not responding when using `Paginator.edit()` with its default
-  parameters ([#2594](https://github.com/Pycord-Development/pycord/pull/2594))
+- Fixed paginator not responding when using `Paginator.edit()` with default parameters.
+  ([#2594](https://github.com/Pycord-Development/pycord/pull/2594))
 - Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
   ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ These changes are available on the `master` branch, but have not yet been releas
   documentation. ([#2581](https://github.com/Pycord-Development/pycord/pull/2581))
 - Fixed a possible bug where audio would play too fast at the beginning of audio files.
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
+- Fixed paginator buttons not responding when using `Paginator.edit()` with its default parameters ([#2594](https://github.com/Pycord-Development/pycord/pull/2594))
 
 ### Changed
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1090,9 +1090,9 @@ class Paginator(discord.ui.View):
 
         if page_content.custom_view:
             self.update_custom_view(page_content.custom_view)
-            
+
         self.user = user or self.user
-        
+
         if not self.user:
             self.usercheck = False
 

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1090,8 +1090,10 @@ class Paginator(discord.ui.View):
 
         if page_content.custom_view:
             self.update_custom_view(page_content.custom_view)
-
-        self.user = user or self.user
+        if user or self.user:
+            self.user = user or self.user
+        else:
+            self.usercheck = False
 
         try:
             self.message = await message.edit(

--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1090,9 +1090,10 @@ class Paginator(discord.ui.View):
 
         if page_content.custom_view:
             self.update_custom_view(page_content.custom_view)
-        if user or self.user:
-            self.user = user or self.user
-        else:
+            
+        self.user = user or self.user
+        
+        if not self.user:
             self.usercheck = False
 
         try:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1306,9 +1306,12 @@ V = Union[Iterable[OptionChoice], Iterable[str], Iterable[int], Iterable[float]]
 AV = Awaitable[V]
 Values = Union[V, Callable[[AutocompleteContext], Union[V, AV]], AV]
 AutocompleteFunc = Callable[[AutocompleteContext], AV]
+FilterFunc = Callable[[AutocompleteContext, Any], Union[bool, Awaitable[bool]]]
 
 
-def basic_autocomplete(values: Values) -> AutocompleteFunc:
+def basic_autocomplete(
+    values: Values, *, filter: FilterFunc | None = None
+) -> AutocompleteFunc:
     """A helper function to make a basic autocomplete for slash commands. This is a pretty standard autocomplete and
     will return any options that start with the value from the user, case-insensitive. If the ``values`` parameter is
     callable, it will be called with the AutocompleteContext.
@@ -1320,18 +1323,21 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
     values: Union[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Callable[[:class:`.AutocompleteContext`], Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         Possible values for the option. Accepts an iterable of :class:`str`, a callable (sync or async) that takes a
         single argument of :class:`.AutocompleteContext`, or a coroutine. Must resolve to an iterable of :class:`str`.
+    filter: Optional[Callable[[:class:`.AutocompleteContext`, Any], Union[:class:`bool`, Awaitable[:class:`bool`]]]]
+        An optional callable (sync or async) used to filter the autocomplete options. It accepts two arguments:
+        the :class:`.AutocompleteContext` and an item from ``values`` iteration treated as callback parameters. If ``None`` is provided, a default filter is used that includes items whose string representation starts with the user's input value, case-insensitive.
+
+        .. versionadded:: 2.7
 
     Returns
     -------
     Callable[[:class:`.AutocompleteContext`], Awaitable[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
         A wrapped callback for the autocomplete.
 
-    Note
-    ----
-    Autocomplete cannot be used for options that have specified choices.
+    Examples
+    --------
 
-    Example
-    -------
+    Basic usage:
 
     .. code-block:: python3
 
@@ -1344,7 +1350,17 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
 
         Option(str, "name", autocomplete=basic_autocomplete(autocomplete))
 
+    With filter parameter:
+
+    .. code-block:: python3
+
+        Option(str, "color", autocomplete=basic_autocomplete(("red", "green", "blue"), filter=lambda c, i: str(c.value or "") in i))
+
     .. versionadded:: 2.0
+
+    Note
+    ----
+    Autocomplete cannot be used for options that have specified choices.
     """
 
     async def autocomplete_callback(ctx: AutocompleteContext) -> V:
@@ -1355,11 +1371,23 @@ def basic_autocomplete(values: Values) -> AutocompleteFunc:
         if asyncio.iscoroutine(_values):
             _values = await _values
 
-        def check(item: Any) -> bool:
-            item = getattr(item, "name", item)
-            return str(item).lower().startswith(str(ctx.value or "").lower())
+        if filter is None:
 
-        gen = (val for val in _values if check(val))
+            def _filter(ctx: AutocompleteContext, item: Any) -> bool:
+                item = getattr(item, "name", item)
+                return str(item).lower().startswith(str(ctx.value or "").lower())
+
+            gen = (val for val in _values if _filter(ctx, val))
+
+        elif asyncio.iscoroutinefunction(filter):
+            gen = (val for val in _values if await filter(ctx, val))
+
+        elif callable(filter):
+            gen = (val for val in _values if filter(ctx, val))
+
+        else:
+            raise TypeError("``filter`` must be callable.")
+
         return iter(itertools.islice(gen, 25))
 
     return autocomplete_callback


### PR DESCRIPTION

## Summary
Fixes #1877
By default, `user=None` in `Paginator` and `Paginator.edit()`. With `author_check=True` being the default in `Paginator`, this ultimately causes the `interaction_check` of `Paginator` to fail as it doesn't have a user to compare which ultimately means `Paginator.edit()` is broken by default. Disabling the author check if there is no user to compare allows `Paginator.edit()` to work by default.
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
