### PR TITLE
fix: Send correct data to http.create_test_entitlement()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
 - Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
   ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
+- Fixed `guild.create_test_entitlement()` and `user.create_test_entitlement()` to send
+  `application_id` instead of `guild_id`/`user_id` to `http.create_test_entitlement()`.
+  ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
 - Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
   ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
-- Fixed `guild.create_test_entitlement()` and `user.create_test_entitlement()` to use
-  the application endpoint with the correct ID.
+- Fixed `Guild.create_test_entitlement()` and `User.create_test_entitlement()` using
+  the guild/user ID instead of the application ID.
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
 - Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
   ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
-- Fixed `guild.create_test_entitlement()` and `user.create_test_entitlement()` to send
-  `application_id` instead of `guild_id`/`user_id` to `http.create_test_entitlement()`.
+- Fixed `guild.create_test_entitlement()` and `user.create_test_entitlement()` to use
+  the application endpoint with the right ID.
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2584](https://github.com/Pycord-Development/pycord/pull/2584))
 - Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
   ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
-- Fixed `Guild.create_test_entitlement()` and `User.create_test_entitlement()` using
-  the guild/user ID instead of the application ID.
+- Fixed `Guild.create_test_entitlement()` and `User.create_test_entitlement()` using the
+  guild/user ID instead of the application ID.
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed the `is_owner()` `user` type hint: `User` -> `User | Member`.
   ([#2593](https://github.com/Pycord-Development/pycord/pull/2593))
 - Fixed `guild.create_test_entitlement()` and `user.create_test_entitlement()` to use
-  the application endpoint with the right ID.
+  the application endpoint with the correct ID.
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 
 ### Changed

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -4089,7 +4089,9 @@ class Guild(Hashable):
             "owner_id": self.id,
             "owner_type": EntitlementOwnerType.guild.value,
         }
-        data = await self._state.http.create_test_entitlement(self._state.application_id, payload)
+        data = await self._state.http.create_test_entitlement(
+            self._state.application_id, payload
+        )
         return Entitlement(data=data, state=self._state)
 
     def entitlements(

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -4089,7 +4089,7 @@ class Guild(Hashable):
             "owner_id": self.id,
             "owner_type": EntitlementOwnerType.guild.value,
         }
-        data = await self._state.http.create_test_entitlement(self.id, payload)
+        data = await self._state.http.create_test_entitlement(self._state.application_id, payload)
         return Entitlement(data=data, state=self._state)
 
     def entitlements(

--- a/discord/user.py
+++ b/discord/user.py
@@ -636,7 +636,9 @@ class User(BaseUser, discord.abc.Messageable):
             "owner_id": self.id,
             "owner_type": 2,
         }
-        data = await self._state.http.create_test_entitlement(self._state.application_id, payload)
+        data = await self._state.http.create_test_entitlement(
+            self._state.application_id, payload
+        )
         return Entitlement(data=data, state=self._state)
 
     def entitlements(

--- a/discord/user.py
+++ b/discord/user.py
@@ -636,7 +636,7 @@ class User(BaseUser, discord.abc.Messageable):
             "owner_id": self.id,
             "owner_type": 2,
         }
-        data = await self._state.http.create_test_entitlement(self.id, payload)
+        data = await self._state.http.create_test_entitlement(self._state.application_id, payload)
         return Entitlement(data=data, state=self._state)
 
     def entitlements(


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
http.create_test_entitlement() asks for (application_id, payload). Previously, guild.create_test_entitlement() was sending (guild_id, payload) and user.create_test_entitlement() was sending (user_id, payload). I've fixed them to send the correct data.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
