### PR TITLE
fix: add Member import for typehinting

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -34,7 +34,7 @@ import logging
 import sys
 import traceback
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Coroutine, Generator, Literal, Mapping, TypeVar
+from typing import Any, Callable, Coroutine, Generator, Literal, Mapping, TYPE_CHECKING, TypeVar
 
 from .client import Client
 from .cog import CogMixin
@@ -55,6 +55,9 @@ from .shard import AutoShardedClient
 from .types import interactions
 from .user import User
 from .utils import MISSING, async_all, find, get
+
+if TYPE_CHECKING:
+    from .member import Member
 
 CoroFunc = Callable[..., Coroutine[Any, Any, Any]]
 CFT = TypeVar("CFT", bound=CoroFunc)

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -34,7 +34,16 @@ import logging
 import sys
 import traceback
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Coroutine, Generator, Literal, Mapping, TYPE_CHECKING, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Generator,
+    Literal,
+    Mapping,
+    TypeVar,
+)
 
 from .client import Client
 from .cog import CogMixin


### PR DESCRIPTION
## Summary

Fixes issue introduced in #2593 causing flake8 to fail

No changelog; minor patch on a bug that doesn't affect runtime

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
