### PR TITLE
feat: Add guild_id parameter to Client.entitlements()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2556](https://github.com/Pycord-Development/pycord/pull/2556))
 - Added optional `filter` parameter to `utils.basic_autocomplete()`.
   ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
+- Added optional `guild_id` parameter to `Client.entitlements()`.
+  ([#2597](https://github.com/Pycord-Development/pycord/pull/2597))
 
 ### Fixed
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -2058,6 +2058,7 @@ class Client:
         after: SnowflakeTime | None = None,
         limit: int | None = 100,
         guild: Snowflake | None = None,
+        guild_id: int | None = None,
         exclude_ended: bool = False,
     ) -> EntitlementIterator:
         """Returns an :class:`.AsyncIterator` that enables fetching the application's entitlements.
@@ -2084,6 +2085,9 @@ class Client:
             Defaults to ``100``.
         guild: :class:`.abc.Snowflake` | None
             Limit the fetched entitlements to entitlements owned by this guild.
+            If not ``None``, ``guild`` takes priority over ``guild_id``.
+        guild_id: :class:`int` | None
+            Limit the fetched entitlements to entitlements owned by a guild with this ID.
         exclude_ended: :class:`bool`
             Whether to limit the fetched entitlements to those that have not ended.
             Defaults to ``False``.
@@ -2119,7 +2123,7 @@ class Client:
             before=before,
             after=after,
             limit=limit,
-            guild_id=guild.id if guild else None,
+            guild_id=guild.id if guild else guild_id if guild_id else None,
             exclude_ended=exclude_ended,
         )
 


### PR DESCRIPTION
## Summary

Entitlements can be owned by guilds that the bot is no longer a member of. The added `guild_id` parameter allows the `Client.entitlements()` function to filter by raw `guild_id` rather than requiring a `Snowflake` (guild) object.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
