### PR TITLE
fix: :bug: Union type cannot be used in `ctx`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 - Fixed `BucketType.category` cooldown commands not functioning correctly in private
   channels. ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
+- Fixed `SlashCommand`'s `ctx` parameter couldn't be `Union` type.
+  ([#2611](https://github.com/Pycord-Development/pycord/pull/2611))
 
 ### Changed
 

--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -45,6 +45,7 @@ from ..enums import SlashCommandOptionType
 from ..utils import MISSING, basic_autocomplete
 
 if TYPE_CHECKING:
+    from ..commands import ApplicationContext
     from ..ext.commands import Converter
     from ..member import Member
     from ..message import Attachment
@@ -226,6 +227,13 @@ class Option:
             self.input_type = input_type
         else:
             from ..ext.commands import Converter
+
+            if isinstance(input_type, tuple) and any(
+                issubclass(op, ApplicationContext) for op in input_type
+            ):
+                input_type = next(
+                    op for op in input_type if issubclass(op, ApplicationContext)
+                )
 
             if (
                 isinstance(input_type, Converter)


### PR DESCRIPTION
## Summary

A command's `ctx` parameter could not be typed as a `Union` which was especially problematic when using bridge
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
fixes: #2378 
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
