### PR TITLE
fix: Remove deprecated get_event_loop() in favour of alternative methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 - Fixed commands with `BucketType.cagegory` cooldown causing issues in private channels.
   ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
+- Fixed deprecation warnings from use of `get_event_loop`. 
+([#2612](https://github.com/Pycord-Development/pycord/pull/2612))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 - Fixed commands with `BucketType.cagegory` cooldown causing issues in private channels.
   ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
-- Fixed deprecation warnings from use of `get_event_loop`. 
-([#2612](https://github.com/Pycord-Development/pycord/pull/2612))
+- Fixed deprecation warnings from use of `get_event_loop`.
+  ([#2612](https://github.com/Pycord-Development/pycord/pull/2612))
 
 ### Changed
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -229,6 +229,7 @@ class Client:
         self.loop: asyncio.AbstractEventLoop = (
             asyncio.new_event_loop() if loop is None else loop
         )
+        asyncio.set_event_loop(self.loop)
         self._listeners: dict[str, list[tuple[asyncio.Future, Callable[..., bool]]]] = (
             {}
         )

--- a/discord/client.py
+++ b/discord/client.py
@@ -133,7 +133,7 @@ class Client:
     loop: Optional[:class:`asyncio.AbstractEventLoop`]
         The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations.
         Defaults to ``None``, in which case the default event loop is used via
-        :func:`asyncio.get_event_loop()`.
+        :func:`asyncio.new_event_loop()`.
     connector: Optional[:class:`aiohttp.BaseConnector`]
         The connector to use for connection pooling.
     proxy: Optional[:class:`str`]
@@ -227,7 +227,7 @@ class Client:
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
         self.loop: asyncio.AbstractEventLoop = (
-            asyncio.get_event_loop() if loop is None else loop
+            asyncio.new_event_loop() if loop is None else loop
         )
         self._listeners: dict[str, list[tuple[asyncio.Future, Callable[..., bool]]]] = (
             {}

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -308,7 +308,7 @@ class _Semaphore:
 
     def __init__(self, number: int) -> None:
         self.value: int = number
-        self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+        self.loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._waiters: Deque[asyncio.Future] = deque()
 
     def __repr__(self) -> str:

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -330,7 +330,7 @@ class Loop(Generic[LF]):
             args = (self._injected, *args)
 
         if self.loop is MISSING:
-            self.loop = asyncio.get_event_loop()
+            self.loop = asyncio.new_event_loop()
 
         self._task = self.loop.create_task(self._loop(*args, **kwargs))
         return self._task
@@ -771,7 +771,7 @@ def loop(
         one used in :meth:`discord.Client.connect`.
     loop: :class:`asyncio.AbstractEventLoop`
         The loop to use to register the task, if not given
-        defaults to :func:`asyncio.get_event_loop`.
+        defaults to :func:`asyncio.new_event_loop`.
 
     Raises
     ------

--- a/discord/http.py
+++ b/discord/http.py
@@ -173,7 +173,7 @@ class HTTPClient:
         unsync_clock: bool = True,
     ) -> None:
         self.loop: asyncio.AbstractEventLoop = (
-            asyncio.get_event_loop() if loop is None else loop
+            asyncio.new_event_loop() if loop is None else loop
         )
         self.connector = connector
         self.__session: aiohttp.ClientSession = MISSING  # filled in static_login

--- a/discord/http.py
+++ b/discord/http.py
@@ -175,6 +175,7 @@ class HTTPClient:
         self.loop: asyncio.AbstractEventLoop = (
             asyncio.new_event_loop() if loop is None else loop
         )
+        asyncio.set_event_loop(self.loop)
         self.connector = connector
         self.__session: aiohttp.ClientSession = MISSING  # filled in static_login
         self._locks: weakref.WeakValueDictionary = weakref.WeakValueDictionary()

--- a/discord/player.py
+++ b/discord/player.py
@@ -572,7 +572,7 @@ class FFmpegOpusAudio(FFmpegAudio):
             )
 
         codec = bitrate = None
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             codec, bitrate = await loop.run_in_executor(None, lambda: probefunc(source, executable))  # type: ignore
         except Exception:

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -62,12 +62,11 @@ class Modal:
         self._title = title
         self._children: list[InputText] = list(children)
         self._weights = _ModalWeights(self._children)
-        loop = asyncio.get_running_loop()
-        self._stopped: asyncio.Future[bool] = loop.create_future()
+        self.loop = asyncio.get_running_loop()
+        self._stopped: asyncio.Future[bool] = self.loop.create_future()
         self.__cancel_callback: Callable[[Modal], None] | None = None
         self.__timeout_expiry: float | None = None
         self.__timeout_task: asyncio.Task[None] | None = None
-        self.loop = asyncio.get_event_loop()
 
     def _start_listening_from_store(self, store: ModalStore) -> None:
         self.__cancel_callback = partial(store.remove_modal)

--- a/docs/build/locales/api/clients.pot
+++ b/docs/build/locales/api/clients.pot
@@ -3706,7 +3706,7 @@ msgstr ""
 
 #: ../../../discord/client.py:docstring of discord.client.Client:13
 #: 6c88dd4b014e4fd68019bf91e0e79449
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 msgstr ""
 
 #: ../../../discord/client.py:docstring of discord.client.Client:17

--- a/docs/build/locales/ext/tasks/index.pot
+++ b/docs/build/locales/ext/tasks/index.pot
@@ -516,7 +516,7 @@ msgstr ""
 
 #: ../../../discord/ext/tasks/__init__.py:docstring of discord.ext.tasks.loop:36
 #: 7e644a647eaa4981aad624c207683f5a
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 msgstr ""
 
 #: ../../../discord/ext/tasks/__init__.py:docstring of discord.ext.tasks.loop:41

--- a/docs/locales/de/LC_MESSAGES/api/clients.po
+++ b/docs/locales/de/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/de/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/de/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/en/LC_MESSAGES/api/clients.po
+++ b/docs/locales/en/LC_MESSAGES/api/clients.po
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid ""
 "The :class:`asyncio.AbstractEventLoop` to use for asynchronous "
 "operations. Defaults to ``None``, in which case the default event loop is"
-" used via :func:`asyncio.get_event_loop()`."
+" used via :func:`asyncio.new_event_loop()`."
 msgstr ""
 
 #: 21cc11771cf14b8482b82ed348a0bcc9 discord.client.Client:17 of

--- a/docs/locales/en/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/en/LC_MESSAGES/ext/tasks/index.po
@@ -510,7 +510,7 @@ msgstr ""
 #: 7e644a647eaa4981aad624c207683f5a discord.ext.tasks.loop:36 of
 msgid ""
 "The loop to use to register the task, if not given defaults to "
-":func:`asyncio.get_event_loop`."
+":func:`asyncio.new_event_loop`."
 msgstr ""
 
 #: 1b6f0ce5942646378838dbe0ab4fe0a0 discord.ext.tasks.loop:41 of

--- a/docs/locales/es/LC_MESSAGES/api/clients.po
+++ b/docs/locales/es/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/es/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/es/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/fr/LC_MESSAGES/api/clients.po
+++ b/docs/locales/fr/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/fr/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/fr/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "Le nombre de boucles à faire, ``None`` si elle doit être une boucle in
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Si vous voulez gérer les erreurs et redémarrer la tâche en utilisant un algorithme de back-off exponentiel similaire à celui utilisé dans :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "La boucle à utiliser pour enregistrer la tâche, si elle n'est pas donnée par défaut à :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "La boucle à utiliser pour enregistrer la tâche, si elle n'est pas donnée par défaut à :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "La fonction n'était pas une coroutine, une valeur invalide a été passée pour le paramètre ``time``, ou le paramètre ``time`` a été passé en conjonction avec des paramètres de temps relatifs."

--- a/docs/locales/hi/LC_MESSAGES/api/clients.po
+++ b/docs/locales/hi/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/hi/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/hi/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/it/LC_MESSAGES/api/clients.po
+++ b/docs/locales/it/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/it/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/it/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/ja/LC_MESSAGES/api/clients.po
+++ b/docs/locales/ja/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/ja/LC_MESSAGES/build/locales/api/clients.po
+++ b/docs/locales/ja/LC_MESSAGES/build/locales/api/clients.po
@@ -1436,8 +1436,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/ja/LC_MESSAGES/build/locales/ext/tasks/index.po
+++ b/docs/locales/ja/LC_MESSAGES/build/locales/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/ja/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/ja/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/ko/LC_MESSAGES/api/clients.po
+++ b/docs/locales/ko/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/ko/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/ko/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/pt_BR/LC_MESSAGES/api/clients.po
+++ b/docs/locales/pt_BR/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/pt_BR/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/pt_BR/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/ru/LC_MESSAGES/api/clients.po
+++ b/docs/locales/ru/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/ru/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/ru/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/docs/locales/zh_CN/LC_MESSAGES/api/clients.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/api/clients.po
@@ -1427,8 +1427,8 @@ msgstr "The maximum number of messages to store in the internal message cache. T
 msgid "Allow disabling the message cache and change the default size to ``1000``."
 msgstr "Allow disabling the message cache and change the default size to ``1000``."
 
-msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
-msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.get_event_loop()`."
+msgid "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
+msgstr "The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations. Defaults to ``None``, in which case the default event loop is used via :func:`asyncio.new_event_loop()`."
 
 msgid "The connector to use for connection pooling."
 msgstr "The connector to use for connection pooling."

--- a/docs/locales/zh_CN/LC_MESSAGES/ext/tasks/index.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/ext/tasks/index.po
@@ -272,8 +272,8 @@ msgstr "The number of loops to do, ``None`` if it should be an infinite loop."
 msgid "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 msgstr "Whether to handle errors and restart the task using an exponential back-off algorithm similar to the one used in :meth:`discord.Client.connect`."
 
-msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
-msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.get_event_loop`."
+msgid "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
+msgstr "The loop to use to register the task, if not given defaults to :func:`asyncio.new_event_loop`."
 
 msgid "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."
 msgstr "The function was not a coroutine, an invalid value for the ``time`` parameter was passed,     or ``time`` parameter was passed in conjunction with relative time parameters."

--- a/examples/basic_voice.py
+++ b/examples/basic_voice.py
@@ -43,7 +43,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
 
     @classmethod
     async def from_url(cls, url, *, loop=None, stream=False):
-        loop = loop or asyncio.get_event_loop()
+        loop = loop or asyncio.get_running_loop()
         data = await loop.run_in_executor(
             None, lambda: ytdl.extract_info(url, download=not stream)
         )


### PR DESCRIPTION
## Summary

`get_event_loop()` is deprecated. All instances should be replaced in favour of `get_running_loop()` and whatever other alternative.

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested. **(currently in progress. 4/7 files tested...)**
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
