### PR TITLE
feat: :sparkles: Add creator monetization analytics perms (`1 << 41`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2587](https://github.com/Pycord-Development/pycord/pull/2587/))
 - Added optional `filter` parameter to `utils.basic_autocomplete()`.
   ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
+- Added
+  [VIEW_CREATOR_MONETIZATION_ANALYTICS](https://discord.com/developers/docs/topics/permissions#:~:text=VIEW_CREATOR_MONETIZATION_ANALYTICS)
+  permission: `Permissions.view_creator_monetization_analytics`
+  ([#2622](https://github.com/Pycord-Development/pycord/pull/2622))
 
 ### Fixed
 

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -611,6 +611,14 @@ class Permissions(BaseFlags):
         return 1 << 40
 
     @flag_value
+    def view_creator_monetization_analytics(self) -> int:
+        """:class:`bool`: Returns ``True`` if a user can view creator monetization (role subscription) analytics.
+
+        .. versionadded:: 2.7
+        """
+        return 1 << 41
+
+    @flag_value
     def send_voice_messages(self) -> int:
         """:class:`bool`: Returns ``True`` if a member can send voice messages.
 


### PR DESCRIPTION
## Summary

See https://discord.com/developers/docs/topics/permissions#:~:text=VIEW_CREATOR_MONETIZATION_ANALYTICS
I don't have setup to test this so pls if you think it needs to be tested, wait for someone to test it.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
