### PR TITLE
fix: sending polls with PartialWebhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,6 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2587](https://github.com/Pycord-Development/pycord/pull/2587/))
 - Added optional `filter` parameter to `utils.basic_autocomplete()`.
   ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
-- Added `store_poll` method to `Webhook._WebhookState`.
-  ([#2624](https://github.com/Pycord-Development/pycord/pull/2624))
 
 ### Fixed
 
@@ -50,6 +48,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 - Fixed `BucketType.category` cooldown commands not functioning correctly in private
   channels. ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
+- Fixed `Webhook._WebhookState` missing `store_poll` method.
+  ([#2624](https://github.com/Pycord-Development/pycord/pull/2624))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2587](https://github.com/Pycord-Development/pycord/pull/2587/))
 - Added optional `filter` parameter to `utils.basic_autocomplete()`.
   ([#2590](https://github.com/Pycord-Development/pycord/pull/2590))
+- Added `store_poll` method to `Webhook._WebhookState`.
+  ([#2624](https://github.com/Pycord-Development/pycord/pull/2624))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2611](https://github.com/Pycord-Development/pycord/pull/2611))
 - Fixed `TypeError` when passing `skus` parameter in `Client.entitlements()`.
   ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
-- Fixed `Webhook._WebhookState` missing `store_poll` method.
+- Fixed `AttributeError` when sending polls with `PartialWebook`.
   ([#2624](https://github.com/Pycord-Development/pycord/pull/2624))
 
 ### Changed

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -803,6 +803,12 @@ class _WebhookState:
         # state parameter is artificial
         return BaseUser(state=self, data=data)  # type: ignore
 
+    def store_poll(self, poll: Poll, message_id: int):
+        if self._parent is not None:
+            return self._parent.store_poll(poll, message_id)
+        # state parameter is artificial
+        return None
+
     @property
     def http(self):
         if self._parent is not None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

When attempting to send a poll through a PartialWebook with wait set to True, an AttributeError is raised. Full example code below

```py
from discord import Client, Intents, Message, Webhook
from discord.abc import GuildChannel
from aiohttp import ClientSession


BOT_TOKEN = 'token'


client = Client(
    intents=Intents.default() | Intents.message_content
)


@client.event
async def on_message(message: Message) -> None:
    if message.author.bot or message.poll is None:
        return

    assert isinstance(message.channel, GuildChannel)

    full_webhook = await message.channel.create_webhook(name='webhook state bug demo')

    async with ClientSession() as session:
        webhook = Webhook.from_url(
            url=full_webhook.url,
            session=session
        )

        await webhook.send(
            poll=message.poll,
            wait=True
        )

    await full_webhook.delete(reason='webhook state bug demo')


if __name__ == '__main__':
    client.run(BOT_TOKEN)
```


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
