### PR TITLE
fix: TypeError when adding skus to entitlements() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 - Fixed `BucketType.category` cooldown commands not functioning correctly in private
   channels. ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
+  Fixed `TypeError` when passing `skus` argument with a SKU list in `entitlements()` method.
+  ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ These changes are available on the `master` branch, but have not yet been releas
   channels. ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
 - Fixed `SlashCommand`'s `ctx` parameter couldn't be `Union` type.
   ([#2611](https://github.com/Pycord-Development/pycord/pull/2611))
-- Fixed `TypeError` when passing `skus` parameter in `Client.entitlements()`. 
+- Fixed `TypeError` when passing `skus` parameter in `Client.entitlements()`.
   ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 - Fixed `BucketType.category` cooldown commands not functioning correctly in private
   channels. ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
-  Fixed `TypeError` when passing `skus` argument with a SKU list in `entitlements()` method.
+- Fixed `TypeError` when passing `skus` argument with a SKU list in `entitlements()` method.
   ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2595](https://github.com/Pycord-Development/pycord/pull/2595))
 - Fixed `BucketType.category` cooldown commands not functioning correctly in private
   channels. ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
-- Fixed `TypeError` when passing `skus` argument with a SKU list in `entitlements()` method.
-  ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
+- Fixed `TypeError` when passing `skus` argument with a SKU list in `entitlements()`
+  method. ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ These changes are available on the `master` branch, but have not yet been releas
   channels. ([#2603](https://github.com/Pycord-Development/pycord/pull/2603))
 - Fixed `SlashCommand`'s `ctx` parameter couldn't be `Union` type.
   ([#2611](https://github.com/Pycord-Development/pycord/pull/2611))
-- Fixed `TypeError` when passing `skus` argument with a SKU list in `entitlements()`
-  method. ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
+- Fixed `TypeError` when passing `skus` parameter in `Client.entitlements()`. 
+  ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
 
 ### Changed
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -3012,7 +3012,7 @@ class HTTPClient:
         if user_id is not None:
             params["user_id"] = user_id
         if sku_ids is not None:
-            params["sku_ids"] = ",".join(sku_ids)
+            params["sku_ids"] = ",".join(str(sku_id) for sku_id in sku_ids)
         if before is not None:
             params["before"] = before
         if after is not None:


### PR DESCRIPTION
## Summary
Fix #2627 about the `entitlements()` method that raises TypeError when passing `skus` argument
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
