### PR TITLE
fix: handle improper 1000 closures by discord

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -588,9 +588,16 @@ class DiscordWebSocket:
     def _can_handle_close(self):
         code = self._close_code or self.socket.close_code
         is_improper_close = self._close_code is None and self.socket.close_code == 1000
-        return is_improper_close or code not in (1000, 4004, 4010, 4011, 4012, 4013, 4014)
-    
-    
+        return is_improper_close or code not in (
+            1000,
+            4004,
+            4010,
+            4011,
+            4012,
+            4013,
+            4014,
+        )
+
     async def poll_event(self):
         """Polls for a DISPATCH event and handles the general gateway loop.
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -587,8 +587,10 @@ class DiscordWebSocket:
 
     def _can_handle_close(self):
         code = self._close_code or self.socket.close_code
-        return code not in (1000, 4004, 4010, 4011, 4012, 4013, 4014)
-
+        is_improper_close = self._close_code is None and self.socket.close_code == 1000
+        return is_improper_close or code not in (1000, 4004, 4010, 4011, 4012, 4013, 4014)
+    
+    
     async def poll_event(self):
         """Polls for a DISPATCH event and handles the general gateway loop.
 


### PR DESCRIPTION
## Summary

Due to an oversight, the library doesn't handle improper 1000 closures by Discord well. 
This causes bots to burn sessions and potentially get a token reset.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
