### PR TITLE
fix: use `functools.cached_property` to fix propert type annotations for context attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2611](https://github.com/Pycord-Development/pycord/pull/2611))
 - Fixed `TypeError` when passing `skus` parameter in `Client.entitlements()`.
   ([#2627](https://github.com/Pycord-Development/pycord/issues/2627))
+- Fixed type annotations for attributes of `context`
+  ([#2635](https://github.com/Pycord-Development/pycord/issues/2635))
 
 ### Changed
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -151,7 +151,7 @@ if TYPE_CHECKING:
     class _RequestLike(Protocol):
         headers: Mapping[str, Any]
 
-    cached_property = NewType("cached_property", property)
+    cached_property = functools.cached_property
 
     P = ParamSpec("P")
 


### PR DESCRIPTION
fix: use `functools.cached_property` to fix propert type annotations for context attributes

## Summary
context attributes like `guild`, `message`, `user` and such have wrong type annotations. They are typed as methods instead of properties.
This is because a NewType based on `property` was used instead of `functools.cached_property`, like in other spots in the codebase already.
This PR implements `functools.cached_property` for context, which fixes these type annotations.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
