### PR TITLE
fix: Fixed Attachment Metadata Being Set Incorrectly In Interaction Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed an error when responding non-ephemerally with a `Paginator` to an ephemerally
   deferred interaction.
   ([#2661](https://github.com/Pycord-Development/pycord/pull/2661))
-- Fixed attachment metadata being set incorrectly in interaction responses causing the metadata to
-  be ignored by Discord. ([#2679](https://github.com/Pycord-Development/pycord/pull/2679))
+- Fixed attachment metadata being set incorrectly in interaction responses causing the
+  metadata to be ignored by Discord.
+  ([#2679](https://github.com/Pycord-Development/pycord/pull/2679))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ These changes are available on the `master` branch, but have not yet been releas
   apps. ([#2650](https://github.com/Pycord-Development/pycord/pull/2650))
 - Fixed type annotations of cached properties.
   ([#2635](https://github.com/Pycord-Development/pycord/issues/2635))
+- Fixed attachment metadata being set incorrectly in interaction responses causing it to
+  be ignored. ([#2679](https://github.com/Pycord-Development/pycord/pull/2679))
 
 ### Changed
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -503,6 +503,8 @@ class AsyncWebhookAdapter:
 
         if data is not None:
             payload["data"] = data
+        else:
+            payload["data"] = {}
         form = [{"name": "payload_json"}]
         attachments = []
         files = files or []
@@ -522,7 +524,8 @@ class AsyncWebhookAdapter:
                     "content_type": "application/octet-stream",
                 }
             )
-        payload["data"]["attachments"] = attachments
+        if attachments:
+            payload["data"]["attachments"] = attachments
         form[0]["value"] = utils._to_json(payload)
 
         route = Route(

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -522,7 +522,7 @@ class AsyncWebhookAdapter:
                     "content_type": "application/octet-stream",
                 }
             )
-        payload["attachments"] = attachments
+        payload["data"]["attachments"] = attachments
         form[0]["value"] = utils._to_json(payload)
 
         route = Route(

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -502,10 +502,7 @@ class AsyncWebhookAdapter:
             "type": type,
         }
 
-        if data is not None:
-            payload["data"] = data
-        else:
-            payload["data"] = {}
+        payload["data"] = data if data is not None else {}
         form = [{"name": "payload_json"}]
         attachments = []
         files = files or []


### PR DESCRIPTION
## Summary
In interaction responses attachment metadata was being placed in the wrong spot in the request body causing discord to ignore it.

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
