### PR TITLE
feat: :technologist: Make `Client.intents` writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2176](https://github.com/Pycord-Development/pycord/pull/2176))
 - Updated `Guild.filesize_limit` to 10 MB instead of 25 MB following Discord's API
   changes. ([#2671](https://github.com/Pycord-Development/pycord/pull/2671))
-- Made `Client.intents` writable as long as the client wasn't started.
-  ([#2687](https://github.com/Pycord-Development/pycord/pull/2687))
+- Made `Client.intents` and `ConnectionState.intents` writable as long as the client
+  wasn't started. ([#2687](https://github.com/Pycord-Development/pycord/pull/2687))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2176](https://github.com/Pycord-Development/pycord/pull/2176))
 - Updated `Guild.filesize_limit` to 10 MB instead of 25 MB following Discord's API
   changes. ([#2671](https://github.com/Pycord-Development/pycord/pull/2671))
+- Made `Client.intents` writable as long as the client wasn't started.
+  ([#2687](https://github.com/Pycord-Development/pycord/pull/2687))
 
 ### Deprecated
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -908,7 +908,9 @@ class Client:
                 f"Intents must be an instance of Intents not {value.__class__!r}"
             )
         if self._was_connected:
-            raise ClientException("Cannot change intents on a running client.")
+            raise AttributeError(
+                "Cannot change intents after the connection is established."
+            )
         self._connection.intents = value
 
     # helpers/getters

--- a/discord/client.py
+++ b/discord/client.py
@@ -901,7 +901,8 @@ class Client:
         ------
         TypeError
             The value is not an instance of Intents.
-        R
+        AttributeError
+            The intents cannot be changed after the connection is established.
         """
         if not isinstance(value, Intents):
             raise TypeError(

--- a/discord/state.py
+++ b/discord/state.py
@@ -352,6 +352,11 @@ class ConnectionState:
         """
         if not isinstance(value, Intents):
             raise TypeError(f"Intents must be of type Intents not {value.__class__!r}")
+        ws = self._get_websocket()
+        if ws and ws.open:
+            raise AttributeError(
+                "Cannot change intents after the connection is established."
+            )
         self._intents.value = value.value
 
     @property

--- a/discord/state.py
+++ b/discord/state.py
@@ -334,6 +334,26 @@ class ConnectionState:
         ret.value = self._intents.value
         return ret
 
+    @intents.setter
+    def intents(self, value: Any) -> None:  # pyright: ignore [reportExplicitAny]
+        """
+        Set the intents for the connection. This can only be set before the connection is
+        started or else the connection will crash.
+
+        Parameters
+        ----------
+        value: :class:`Intents`
+            The intents to use for the connection.
+
+        Raises
+        ------
+        TypeError
+            The value passed is not of type :class:`Intents`.
+        """
+        if not isinstance(value, Intents):
+            raise TypeError(f"Intents must be of type Intents not {value.__class__!r}")
+        self._intents.value = value.value
+
     @property
     def voice_clients(self) -> list[VoiceClient]:
         return list(self._voice_clients.values())

--- a/discord/state.py
+++ b/discord/state.py
@@ -349,6 +349,8 @@ class ConnectionState:
         ------
         TypeError
             The value passed is not of type :class:`Intents`.
+        AttributeError
+            The intents cannot be changed after the connection is established.
         """
         if not isinstance(value, Intents):
             raise TypeError(f"Intents must be of type Intents not {value.__class__!r}")


### PR DESCRIPTION
## Summary

~~I have no idea why intents were read-only in the first place. Maybe they should stay so, or maybe smth different should be done about it.~~

This PR allows to edit intents of a `Client` as long as the client wasn't connected yet.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
