### PR TITLE
fix: reset exponential backoff after task runs successfully in the tasks extension

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -168,6 +168,7 @@ class Loop(Generic[LF]):
                 try:
                     await self.coro(*args, **kwargs)
                     self._last_iteration_failed = False
+                    backoff = ExponentialBackoff()
                 except self._valid_exception:
                     self._last_iteration_failed = True
                     if not self.reconnect:


### PR DESCRIPTION
## Summary

Fixes: #2698

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
