### PR TITLE
fix: reset exponential backoff after task runs successfully in tasks extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed attachment metadata being set incorrectly in interaction responses causing the
   metadata to be ignored by Discord.
   ([#2679](https://github.com/Pycord-Development/pycord/pull/2679))
-- Fixed unexpected backoff behaviour in the tasks extension's handling of task failure
-  ([#2700](https://github.com/Pycord-Development/pycord/pull/2700))
+- Fixed unexpected backoff behavior in the handling of task failures
+  ([#2700](https://github.com/Pycord-Development/pycord/pull/2700)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed attachment metadata being set incorrectly in interaction responses causing the
   metadata to be ignored by Discord.
   ([#2679](https://github.com/Pycord-Development/pycord/pull/2679))
+- Fixed unexpected backoff behaviour in the tasks extension's handling of task failure
+  ([#2700](https://github.com/Pycord-Development/pycord/pull/2700))
 
 ### Changed
 

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -168,6 +168,7 @@ class Loop(Generic[LF]):
                 try:
                     await self.coro(*args, **kwargs)
                     self._last_iteration_failed = False
+                    backoff = ExponentialBackoff()
                 except self._valid_exception:
                     self._last_iteration_failed = True
                     if not self.reconnect:


### PR DESCRIPTION
## Summary

Fixes: #2698

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
