### PR TITLE
fix: Allow renewal_sku_ids To Handle None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2656](https://github.com/Pycord-Development/pycord/pull/2656))
 - Fixed `AttributeError` when trying to consume a consumable entitlement.
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
+- Fixed `Subscription.renewal_sku_ids` not accepting `None` from discord payload. 
+  ([#2709](https://github.com/Pycord-Development/pycord/pull/2709))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2656](https://github.com/Pycord-Development/pycord/pull/2656))
 - Fixed `AttributeError` when trying to consume a consumable entitlement.
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
-- Fixed `Subscription.renewal_sku_ids` not accepting `None` from discord payload. 
+- Fixed `Subscription.renewal_sku_ids` not accepting `None` from discord payload.
   ([#2709](https://github.com/Pycord-Development/pycord/pull/2709))
 
 ### Changed

--- a/discord/monetization.py
+++ b/discord/monetization.py
@@ -327,7 +327,7 @@ class Subscription(Hashable):
         self.user_id: int = int(data["user_id"])
         self.sku_ids: list[int] = list(map(int, data["sku_ids"]))
         self.entitlement_ids: list[int] = list(map(int, data["entitlement_ids"]))
-        self.renewal_sku_ids: list[int] = list(map(int, data["renewal_sku_ids"]))
+        self.renewal_sku_ids: list[int] = list(map(int, data["renewal_sku_ids"] or []))
         self.current_period_start: datetime = parse_time(data["current_period_start"])
         self.current_period_end: datetime = parse_time(data["current_period_end"])
         self.status: SubscriptionStatus = try_enum(SubscriptionStatus, data["status"])


### PR DESCRIPTION
## Summary
Discord states [`renewal_sku_ids`](https://discord.com/developers/docs/resources/subscription#subscription-object) is nullable. We were treating it if it was always a list.
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
