### PR TITLE
feat: :sparkles: Allow changing base url with `Route.API_BASE_URL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2579](https://github.com/Pycord-Development/pycord/pull/2579))
 - Added new `Subscription` object and related methods/events.
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
+- Added ability to change the API's base URL with `Route.API_BASE_URL`.
+  ([#2714](https://github.com/Pycord-Development/pycord/pull/2714))
 
 ### Fixed
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -106,6 +106,8 @@ async def json_or_text(response: aiohttp.ClientResponse) -> dict[str, Any] | str
 
 
 class Route:
+    API_BASE_URL: str = "https://discord.com/api/v{API_VERSION}"
+
     def __init__(self, method: str, path: str, **parameters: Any) -> None:
         self.path: str = path
         self.method: str = method
@@ -127,7 +129,7 @@ class Route:
 
     @property
     def base(self) -> str:
-        return f"https://discord.com/api/v{API_VERSION}"
+        return self.API_BASE_URL.format(API_VERSION=API_VERSION)
 
     @property
     def bucket(self) -> str:


### PR DESCRIPTION
## Summary
Allows to change the base url e.g. if you wanna use canary. It's a very simple implementation idk if this would be enough to get merged. 
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
