### PR TITLE
fix: raise intended exception for ephemeral paginator with >=15min timeout

### DIFF
--- a/discord/ext/pages/pagination.py
+++ b/discord/ext/pages/pagination.py
@@ -1163,7 +1163,7 @@ class Paginator(discord.ui.View):
         if target is not None and not isinstance(target, discord.abc.Messageable):
             raise TypeError(f"expected abc.Messageable not {target.__class__!r}")
 
-        if ephemeral and (self.timeout >= 900 or self.timeout is None):
+        if ephemeral and (self.timeout is None or self.timeout >= 900):
             raise ValueError(
                 "paginator responses cannot be ephemeral if the paginator timeout is 15"
                 " minutes or greater"


### PR DESCRIPTION
## Summary

If a paginator has a timeout of 15min or more and is set to be ephemeral, the intended exception notifying the user they can't do that fails to get raised because it attempts to compare `None` with `int`.

Example traceback:
```
Traceback (most recent call last):
  File "/Users/derek/Code/pzsd-bot/.venv/lib/python3.12/site-packages/discord/commands/core.py", line 138, in wrapped
    ret = await coro(arg)
          ^^^^^^^^^^^^^^^
  File "/Users/derek/Code/pzsd-bot/.venv/lib/python3.12/site-packages/discord/commands/core.py", line 1078, in _invoke
    await self.callback(self.cog, ctx, **kwargs)
  File "/Users/derek/Code/pzsd-bot/pzsd_bot/cogs/points/admin.py", line 178, in users
    await paginator.respond(ctx.interaction, ephemeral=True)
  File "/Users/derek/Code/pzsd-bot/.venv/lib/python3.12/site-packages/discord/ext/pages/pagination.py", line 1155, in respond
    if ephemeral and (self.timeout >= 900 or self.timeout is None):
                      ^^^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
