### PR TITLE
fix: :adhesive_bandage: Fix typo `is` instead of `in`

### DIFF
--- a/discord/ext/bridge/core.py
+++ b/discord/ext/bridge/core.py
@@ -232,7 +232,7 @@ class BridgeCommand:
         except AttributeError as e:
             # if it doesn't exist, check this list, if the name of
             # the parameter is here
-            if name is self.__special_attrs__:
+            if name in self.__special_attrs__:
                 raise e
 
             # looks up the result in the variants.


### PR DESCRIPTION
## Summary

I was working on smth else when I stumbeld upon this, which is obviously wrong since rn it always evaulates to `False`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ^x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
