### PR TITLE
feat: :sparkles: Allow usage of `functools.partial` as slash or ext command callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
 - Added ability to change the API's base URL with `Route.API_BASE_URL`.
   ([#2714](https://github.com/Pycord-Development/pycord/pull/2714))
+- Added the ability to use `functools.partial` as `Command` and `SlashCommand`
+  callbacks. ([#2724](https://github.com/Pycord-Development/pycord/pull/2724))
 
 ### Fixed
 

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -31,6 +31,7 @@ import os
 import pathlib
 import sys
 import types
+from functools import partial
 from typing import Any, Callable, ClassVar, Generator, Mapping, TypeVar, overload
 
 import discord.utils
@@ -256,8 +257,14 @@ class CogMeta(type):
             if not isinstance(command, SlashCommandGroup) and not hasattr(
                 command, "add_to"
             ):
+                actual_callback = (
+                    command.callback.func
+                    if isinstance(command.callback, partial)
+                    else command.callback
+                )
+
                 # ignore bridge commands
-                cmd = getattr(new_cls, command.callback.__name__, None)
+                cmd = getattr(new_cls, actual_callback.__name__, None)
                 if hasattr(cmd, "add_to"):
                     setattr(
                         cmd,
@@ -265,7 +272,7 @@ class CogMeta(type):
                         command,
                     )
                 else:
-                    setattr(new_cls, command.callback.__name__, command)
+                    setattr(new_cls, actual_callback.__name__, command)
 
                 parent = command.parent
                 if parent is not None:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -153,7 +153,9 @@ def get_signature_parameters(
             raise TypeError("Unparameterized Greedy[...] is disallowed in signature.")
 
         params[name] = parameter.replace(annotation=annotation)
-
+    if isinstance(function, functools.partial):
+        for param in function.keywords:
+            params.pop(param, None)
     return params
 
 
@@ -328,7 +330,9 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         if not asyncio.iscoroutinefunction(func):
             raise TypeError("Callback must be a coroutine.")
 
-        name = kwargs.get("name") or func.__name__
+        actual_func = func if not isinstance(func, functools.partial) else func.func
+
+        name = kwargs.get("name", actual_func.__name__)
         if not isinstance(name, str):
             raise TypeError("Name of a command must be a string.")
         self.name: str = name


### PR DESCRIPTION
## Summary

Allow to use a partial as a slash or ext command. See comments for example usage. I might have missed some places where other checks for partial should be used but didn't find any other based on e my testing. I will add them later if needed.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
