### PR TITLE
fix: :label: Fix types in `Select.__init__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2709](https://github.com/Pycord-Development/pycord/pull/2709))
 - Fixed `ForumChannel.edit` allowing `default_reaction_emoji` to be `None`
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
-- Fixed incorrect type hints in `Select.__init__`.
+- Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2709](https://github.com/Pycord-Development/pycord/pull/2709))
 - Fixed `ForumChannel.edit` allowing `default_reaction_emoji` to be `None`
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
+- Fixed incorrect type hints in `Select.__init__`.
+  ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
 
 ### Changed
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -130,8 +130,8 @@ class Select(Item[V]):
         placeholder: str | None = None,
         min_values: int = 1,
         max_values: int = 1,
-        options: list[SelectOption] = None,
-        channel_types: list[ChannelType] = None,
+        options: list[SelectOption] | None = None,
+        channel_types: list[ChannelType] | None = None,
         disabled: bool = False,
         row: int | None = None,
     ) -> None:


### PR DESCRIPTION
## Summary
Without this change, instantiating any select menu could (depending on your type checker settings) trigger an error, because the default value of the parameters doesn't match the parameter's type.

![image](https://github.com/user-attachments/assets/73d0577a-c9d5-4ade-9096-506c27947fc1)


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
