### PR TITLE
feat: :sparkles: Support formatting `datetime.time` in `format_dt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,11 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2579](https://github.com/Pycord-Development/pycord/pull/2579))
 - Added new `Subscription` object and related methods/events.
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
-- Added ability to change the API's base URL with `Route.API_BASE_URL`.
+- Added the ability to change the API's base URL with `Route.API_BASE_URL`.
   ([#2714](https://github.com/Pycord-Development/pycord/pull/2714))
+- Added the ability to pass a `datetime.time` object to `format_dt` if selecting a
+  time-only style (`"t"` or `"T"`)
+  ([#2747](https://github.com/Pycord-Development/pycord/pull/2747))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
 - Added the ability to change the API's base URL with `Route.API_BASE_URL`.
   ([#2714](https://github.com/Pycord-Development/pycord/pull/2714))
-- Added the ability to pass a `datetime.time` object to `format_dt` if selecting a
-  time-only style (`"t"` or `"T"`)
+- Added the ability to pass a `datetime.time` object to `format_dt`
   ([#2747](https://github.com/Pycord-Development/pycord/pull/2747))
 
 ### Fixed

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1236,7 +1236,9 @@ def resolve_annotation(
 TimestampStyle = Literal["f", "F", "d", "D", "t", "T", "R"]
 
 
-def format_dt(dt: datetime.datetime, /, style: TimestampStyle | None = None) -> str:
+def format_dt(
+    dt: datetime.datetime | datetime.time, /, style: TimestampStyle | None = None
+) -> str:
     """A helper function to format a :class:`datetime.datetime` for presentation within Discord.
 
     This allows for a locale-independent way of presenting data using Discord specific Markdown.
@@ -1266,7 +1268,7 @@ def format_dt(dt: datetime.datetime, /, style: TimestampStyle | None = None) -> 
 
     Parameters
     ----------
-    dt: :class:`datetime.datetime`
+    dt: Union[:class:`datetime.datetime`, :class:`datetime.time`]
         The datetime to format.
     style: :class:`str`
         The style to format the datetime with.
@@ -1276,6 +1278,14 @@ def format_dt(dt: datetime.datetime, /, style: TimestampStyle | None = None) -> 
     :class:`str`
         The formatted string.
     """
+    if isinstance(dt, datetime.time):
+        if style is None:
+            style = "t"
+        elif style not in ("t", "T"):
+            raise ValueError("Time styles must be 't' or 'T'.")
+        dt = datetime.datetime.combine(
+            datetime.datetime.fromtimestamp(DISCORD_EPOCH, tz=datetime.UTC), dt
+        )
     if style is None:
         return f"<t:{int(dt.timestamp())}>"
     return f"<t:{int(dt.timestamp())}:{style}>"

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1279,13 +1279,7 @@ def format_dt(
         The formatted string.
     """
     if isinstance(dt, datetime.time):
-        if style is None:
-            style = "t"
-        elif style not in ("t", "T"):
-            raise ValueError("Time styles must be 't' or 'T'.")
-        dt = datetime.datetime.combine(
-            datetime.datetime.fromtimestamp(DISCORD_EPOCH, tz=datetime.UTC), dt
-        )
+        dt = datetime.datetime.combine(datetime.datetime.now(), dt)
     if style is None:
         return f"<t:{int(dt.timestamp())}>"
     return f"<t:{int(dt.timestamp())}:{style}>"


### PR DESCRIPTION
## Summary
Allow passing a `datetime.time` object to `discord.utils.format_dt`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
