### PR TITLE
fix: :bug: Fix `ValueError` when using `Flag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
+- Fixed `TypeError` when using `Flag` with python 3.11+
+  ([#2759])(https://github.com/Pycord-Development/pycord/pull/2759)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,10 +103,10 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
-- Fixed `TypeError` when using `Flag` with python 3.11+
-  ([#2759])(https://github.com/Pycord-Development/pycord/pull/2759)
 - Updated `valid_locales` to support `in` and `es-419`.
   ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
+- Fixed `TypeError` when using `Flag` with Python 3.11+.
+  ([#2759])(https://github.com/Pycord-Development/pycord/pull/2759)
 
 ### Changed
 

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -31,12 +31,12 @@ import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterator, Literal, Pattern, TypeVar, Union
 
-from discord.utils import MISSING, MissingField, maybe_coroutine, resolve_annotation
-
-if sys.version_info >= (3, 11):
-    _MISSING = MissingField
-else:
-    _MISSING = MISSING
+from discord.utils import (
+    MISSING,
+    maybe_coroutine,
+    missing_field_factory,
+    resolve_annotation,
+)
 
 from .converter import run_converters
 from .errors import (
@@ -86,13 +86,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = _MISSING
+    name: str = missing_field_factory()
     aliases: list[str] = field(default_factory=list)
-    attribute: str = _MISSING
-    annotation: Any = _MISSING
-    default: Any = _MISSING
-    max_args: int = _MISSING
-    override: bool = _MISSING
+    attribute: str = missing_field_factory()
+    annotation: Any = missing_field_factory()
+    default: Any = missing_field_factory()
+    max_args: int = missing_field_factory()
+    override: bool = missing_field_factory()
     cast_to_dict: bool = False
 
     @property

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -34,7 +34,6 @@ from typing import TYPE_CHECKING, Any, Iterator, Literal, Pattern, TypeVar, Unio
 from discord.utils import (
     MISSING,
     maybe_coroutine,
-    missing_field_factory,
     resolve_annotation,
 )
 
@@ -57,6 +56,10 @@ __all__ = (
 
 if TYPE_CHECKING:
     from .context import Context
+
+
+def _missing_field_factory() -> field:
+    return field(default_factory=lambda: MISSING)
 
 
 @dataclass
@@ -86,13 +89,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = missing_field_factory()
+    name: str = _missing_field_factory()
     aliases: list[str] = field(default_factory=list)
-    attribute: str = missing_field_factory()
-    annotation: Any = missing_field_factory()
-    default: Any = missing_field_factory()
-    max_args: int = missing_field_factory()
-    override: bool = missing_field_factory()
+    attribute: str = _missing_field_factory()
+    annotation: Any = _missing_field_factory()
+    default: Any = _missing_field_factory()
+    max_args: int = _missing_field_factory()
+    override: bool = _missing_field_factory()
     cast_to_dict: bool = False
 
     @property

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -39,7 +39,6 @@ import unicodedata
 import warnings
 from base64 import b64encode
 from bisect import bisect_left
-from dataclasses import field
 from inspect import isawaitable as _isawaitable
 from inspect import signature as _signature
 from operator import attrgetter
@@ -115,14 +114,6 @@ class _MissingSentinel:
 
 
 MISSING: Any = _MissingSentinel()
-# As of 3.11, directly setting a dataclass field to MISSING causes a ValueError. Using
-# field(default=MISSING) produces the same error, but passing a lambda to
-# default_factory produces the same behavior as default=MISSING and does not raise an
-# error.
-
-
-def missing_field_factory() -> field:
-    return field(default_factory=lambda: MISSING)
 
 
 class _cached_property:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -119,7 +119,10 @@ MISSING: Any = _MissingSentinel()
 # field(default=MISSING) produces the same error, but passing a lambda to
 # default_factory produces the same behavior as default=MISSING and does not raise an
 # error.
-MissingField = field(default_factory=lambda: MISSING)
+
+
+def missing_field_factory() -> field:
+    return field(default_factory=lambda: MISSING)
 
 
 class _cached_property:


### PR DESCRIPTION
## Summary
See also [my comment](https://github.com/Pycord-Development/pycord/pull/2443#pullrequestreview-2709464860) on #2443 .

The issue was that a `dataclasses.field` object could not be reused and caused unhelpful `TypeError`s.

This, or something fixing this issue should ideally be merged before #2443 is merged, and then master merged into #2443 .

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
fixes: #2758 
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
