### PR TITLE
fix: :bug: `TypeError` when specifying `thread_name` in Webhook.send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
-- Fixed `TypeError` when specifying `thread_name` in `Webhook.send`
+- Fixed `TypeError` when specifying `thread_name` in `Webhook.send`.
   ([#2761])(https://github.com/Pycord-Development/pycord/pull/2761)
 - Updated `valid_locales` to support `in` and `es-419`.
   ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
+- Fixed `TypeError` when specifying `thread_name` in `Webhook.send`
+  ([#2761])(https://github.com/Pycord-Development/pycord/pull/2761)
 
 ### Changed
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -337,15 +337,11 @@ class AsyncWebhookAdapter:
         multipart: list[dict[str, Any]] | None = None,
         files: list[File] | None = None,
         thread_id: int | None = None,
-        thread_name: str | None = None,
         wait: bool = False,
     ) -> Response[MessagePayload | None]:
         params = {"wait": int(wait)}
         if thread_id:
             params["thread_id"] = thread_id
-
-        if thread_name:
-            payload["thread_name"] = thread_name
 
         route = Route(
             "POST",
@@ -633,6 +629,7 @@ def handle_message_parameters(
     allowed_mentions: AllowedMentions | None = MISSING,
     previous_allowed_mentions: AllowedMentions | None = None,
     suppress: bool = False,
+    thread_name: str | None = None,
 ) -> ExecuteWebhookParameters:
     if files is not MISSING and file is not MISSING:
         raise TypeError("Cannot mix file and files keyword arguments.")
@@ -716,6 +713,9 @@ def handle_message_parameters(
         payload["attachments"] = _attachments
 
     payload["flags"] = flags.value
+
+    if thread_name:
+        payload["thread_name"] = thread_name
 
     if multipart_files:
         multipart.append({"name": "payload_json", "value": utils._to_json(payload)})
@@ -1808,6 +1808,7 @@ class Webhook(BaseWebhook):
             applied_tags=applied_tags,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            thread_name=thread_name,
         )
         adapter = async_context.get()
         thread_id: int | None = None
@@ -1824,7 +1825,6 @@ class Webhook(BaseWebhook):
             multipart=params.multipart,
             files=params.files,
             thread_id=thread_id,
-            thread_name=thread_name,
             wait=wait,
         )
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -307,15 +307,11 @@ class WebhookAdapter:
         multipart: list[dict[str, Any]] | None = None,
         files: list[File] | None = None,
         thread_id: int | None = None,
-        thread_name: str | None = None,
         wait: bool = False,
     ):
         params = {"wait": int(wait)}
         if thread_id:
             params["thread_id"] = thread_id
-
-        if thread_name:
-            payload["thread_name"] = thread_name
 
         route = Route(
             "POST",
@@ -1080,6 +1076,7 @@ class SyncWebhook(BaseWebhook):
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
             suppress=suppress,
+            thread_name=thread_name,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
         thread_id: int | None = None
@@ -1094,7 +1091,6 @@ class SyncWebhook(BaseWebhook):
             multipart=params.multipart,
             files=params.files,
             thread_id=thread_id,
-            thread_name=thread_name,
             wait=wait,
         )
         if wait:


### PR DESCRIPTION
## Summary

CC @Lumabots

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
