### PR TITLE
feat: :sparkles: Update to support python 3.14

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -40,7 +40,7 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements/docs.txt"
           check-latest: true

--- a/.github/workflows/docs-localization-download.yml
+++ b/.github/workflows/docs-localization-download.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Install Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements/_locale.txt"
       - name: "Install Dependencies"

--- a/.github/workflows/docs-localization-upload.yml
+++ b/.github/workflows/docs-localization-upload.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Install Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements/_locale.txt"
       - name: "Install Dependencies"

--- a/.github/workflows/lib-checks.yml
+++ b/.github/workflows/lib-checks.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements/dev.txt"
       - name: "Install dependencies"
@@ -56,7 +56,7 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements/dev.txt"
       - name: "Install dependencies"
@@ -74,7 +74,7 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements/dev.txt"
       - name: "Install dependencies"
@@ -98,7 +98,7 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements/dev.txt"
       - name: "Install dependencies"
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - { python-version: "3.9", os: "macos-latest" }
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           version-branch-name: ${{ needs.pre_config.outputs.branch_name }}
           ref: ${{ github.ref_name }}
           repository: ${{ github.repository }}
-          python-version: "3.13"
+          python-version: "3.14"
           release-requirements: "requirements/_release.txt"
           version: ${{ needs.pre_config.outputs.version }}
           is-rc: ${{ needs.pre_config.outputs.is_rc }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ formats: []
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.14"
 
 sphinx:
   configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Pycord is a modern, easy to use, feature-rich, and async ready API wrapper for D
 Note
 ----
 
-Pycord supports Python ``3.9`` - ``3.13``
+Pycord supports Python ``3.9`` - ``3.14``
 
 Key Features
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary
Depends on: #2645 
The above pull request is required as it refactors asyncio usage in a way that does not make use of deprecated methods. See: https://docs.python.org/3.14/whatsnew/3.14.html#deprecated

⚠️ **This requires testing**.

Python 3.14 is currently at alpha 7. This should not be merged before the official release, and only serves as a way not to stay behind.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
