### PR TITLE
feat(loop): add optional overlap support to allow concurrent loop executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2714](https://github.com/Pycord-Development/pycord/pull/2714))
 - Added the ability to pass a `datetime.time` object to `format_dt`
   ([#2747](https://github.com/Pycord-Development/pycord/pull/2747))
+- Added the ability to pass an `overlap` parameter to the `loop` decorator and `Loop` class, allowing concurrent iterations if enabled ([#2765](https://github.com/Pycord-Development/pycord/pull/2765))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2714](https://github.com/Pycord-Development/pycord/pull/2714))
 - Added the ability to pass a `datetime.time` object to `format_dt`
   ([#2747](https://github.com/Pycord-Development/pycord/pull/2747))
-- Added the ability to pass an `overlap` parameter to the `loop` decorator and `Loop` class, allowing concurrent iterations if enabled ([#2765](https://github.com/Pycord-Development/pycord/pull/2765))
+- Added the ability to pass an `overlap` parameter to the `loop` decorator and `Loop`
+  class, allowing concurrent iterations if enabled
+  ([#2765](https://github.com/Pycord-Development/pycord/pull/2765))
 
 ### Fixed
 

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -60,8 +60,8 @@ class SleepHandle:
         self.handle = loop.call_later(relative_delta, future.set_result, True)
 
     def _set_result_safe(self):
-    if not self.future.done():
-        self.future.set_result(True)
+        if not self.future.done():
+            self.future.set_result(True)
 
     def recalculate(self, dt: datetime.datetime) -> None:
         self.handle.cancel()

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -783,6 +783,8 @@ def loop(
     overlap: :class:`bool`
         Whether to allow the next iteration of the loop to run even if the previous one has not completed.
 
+        .. versionadded:: 2.7
+
     Raises
     ------
     ValueError

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -59,10 +59,14 @@ class SleepHandle:
         relative_delta = discord.utils.compute_timedelta(dt)
         self.handle = loop.call_later(relative_delta, future.set_result, True)
 
+    def _set_result_safe(self):
+    if not self.future.done():
+        self.future.set_result(True)
+
     def recalculate(self, dt: datetime.datetime) -> None:
         self.handle.cancel()
         relative_delta = discord.utils.compute_timedelta(dt)
-        self.handle = self.loop.call_later(relative_delta, self.future.set_result, True)
+        self.handle = loop.call_later(relative_delta, self._set_result_safe)
 
     def wait(self) -> asyncio.Future[Any]:
         return self.future

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -223,6 +223,7 @@ class Loop(Generic[LF]):
             count=self.count,
             reconnect=self.reconnect,
             loop=self.loop,
+            overlap=self.overlap,
         )
         copy._injected = obj
         copy._before_loop = self._before_loop

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -91,7 +91,7 @@ class Loop(Generic[LF]):
         count: int | None,
         reconnect: bool,
         loop: asyncio.AbstractEventLoop,
-        overlap: bool
+        overlap: bool,
     ) -> None:
         self.coro: LF = coro
         self.reconnect: bool = reconnect
@@ -802,7 +802,7 @@ def loop(
             time=time,
             reconnect=reconnect,
             loop=loop,
-            overlap=overlap
+            overlap=overlap,
         )
 
     return decorator


### PR DESCRIPTION
…xecutions

Added a new overlap parameter to the loop decorator and Loop class to control whether loop iterations can run concurrently. When set to True, the next iteration will not wait for the previous one to finish, allowing overlapping executions—useful for long-running tasks that should not delay subsequent runs. Defaults to False to preserve current behavior.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
