### PR TITLE
fix: 🐛 update `valid_locales` variable to support `id` and `es-419`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
+- Fixed `valid_locates` mismatch with Discord API locales by adding `id` (Indonesian) and `es-419` (Spanish, LATAM)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
-- Fixed `valid_locates` mismatch with Discord API locales by adding `id` (Indonesian)
-  and `es-419` (Spanish, LATAM)
+- Updated `valid_locales` to support `in` and `es-419`.
   ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
 - Fixed `valid_locates` mismatch with Discord API locales by adding `id` (Indonesian)
   and `es-419` (Spanish, LATAM)
+  ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
-- Fixed `valid_locates` mismatch with Discord API locales by adding `id` (Indonesian) and `es-419` (Spanish, LATAM)
+- Fixed `valid_locates` mismatch with Discord API locales by adding `id` (Indonesian)
+  and `es-419` (Spanish, LATAM)
 
 ### Changed
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -2042,11 +2042,13 @@ def command(**kwargs):
 
 docs = "https://discord.com/developers/docs"
 valid_locales = [
+    "id",
     "da",
     "de",
     "en-GB",
     "en-US",
     "es-ES",
+    "es-419",
     "fr",
     "hr",
     "it",


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR adds Indonesian (`id`) and Spanish (LATAM) (`es-419`) to the `valid_locates` variable to prevent the following errors:

`ValidationError: Locale 'id' is not a valid locale. See https://discord.com/developers/docs/reference#locales for a list of supported locales.`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
