### PR TITLE
fix: webhook/interaction editing with attachments param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
 - Updated `valid_locales` to support `in` and `es-419`.
   ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
+- Fixed `Webhook.edit` not working with `attachments=[]`.
+  ([#2779])(https://github.com/Pycord-Development/pycord/pull/2779)
 
 ### Changed
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -712,7 +712,7 @@ def handle_message_parameters(
         if voice_message:
             flags = flags + MessageFlags(is_voice_message=True)
 
-    if _attachments:
+    if attachments is not MISSING or _attachments:
         payload["attachments"] = _attachments
 
     payload["flags"] = flags.value


### PR DESCRIPTION
## Summary

Fixes passing `attachments=[]` into webhook/interaction edits

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
