### PR TITLE
fix: gif stickers use a different base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
 - Fixed `Webhook.edit` not working with `attachments=[]`.
   ([#2779])(https://github.com/Pycord-Development/pycord/pull/2779)
+- Fixed GIF-based `Sticker` returning the wrong `url`.
+  ([#2781])(https://github.com/Pycord-Development/pycord/pull/2781)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,16 +99,16 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
 - Fixed `Subscription.renewal_sku_ids` not accepting `None` from the received payload.
   ([#2709](https://github.com/Pycord-Development/pycord/pull/2709))
-- Fixed `ForumChannel.edit` allowing `default_reaction_emoji` to be `None`
+- Fixed `ForumChannel.edit` allowing `default_reaction_emoji` to be `None`.
   ([#2739](https://github.com/Pycord-Development/pycord/pull/2739))
 - Fixed missing `None` type hints in `Select.__init__`.
-  ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
+  ([#2746](https://github.com/Pycord-Development/pycord/pull/2746))
 - Updated `valid_locales` to support `in` and `es-419`.
-  ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
+  ([#2767](https://github.com/Pycord-Development/pycord/pull/2767))
 - Fixed `Webhook.edit` not working with `attachments=[]`.
-  ([#2779])(https://github.com/Pycord-Development/pycord/pull/2779)
+  ([#2779](https://github.com/Pycord-Development/pycord/pull/2779))
 - Fixed GIF-based `Sticker` returning the wrong `url`.
-  ([#2781])(https://github.com/Pycord-Development/pycord/pull/2781)
+  ([#2781](https://github.com/Pycord-Development/pycord/pull/2781))
 
 ### Changed
 

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -212,7 +212,8 @@ class StickerItem(_StickerTag):
         self.format: StickerFormatType = try_enum(
             StickerFormatType, data["format_type"]
         )
-        self.url: str = f"{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}"
+        base = "https://media.discordapp.net" if self.format is StickerFormatType.gif else Asset.BASE
+        self.url: str = f"{base}/stickers/{self.id}.{self.format.file_extension}"
 
     def __repr__(self) -> str:
         return f"<StickerItem id={self.id} name={self.name!r} format={self.format}>"
@@ -288,7 +289,8 @@ class Sticker(_StickerTag):
         self.format: StickerFormatType = try_enum(
             StickerFormatType, data["format_type"]
         )
-        self.url: str = f"{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}"
+        base = "https://media.discordapp.net" if self.format is StickerFormatType.gif else Asset.BASE
+        self.url: str = f"{base}/stickers/{self.id}.{self.format.file_extension}"
 
     def __repr__(self) -> str:
         return f"<Sticker id={self.id} name={self.name!r}>"

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -212,7 +212,11 @@ class StickerItem(_StickerTag):
         self.format: StickerFormatType = try_enum(
             StickerFormatType, data["format_type"]
         )
-        base = "https://media.discordapp.net" if self.format is StickerFormatType.gif else Asset.BASE
+        base = (
+            "https://media.discordapp.net"
+            if self.format is StickerFormatType.gif
+            else Asset.BASE
+        )
         self.url: str = f"{base}/stickers/{self.id}.{self.format.file_extension}"
 
     def __repr__(self) -> str:
@@ -289,7 +293,11 @@ class Sticker(_StickerTag):
         self.format: StickerFormatType = try_enum(
             StickerFormatType, data["format_type"]
         )
-        base = "https://media.discordapp.net" if self.format is StickerFormatType.gif else Asset.BASE
+        base = (
+            "https://media.discordapp.net"
+            if self.format is StickerFormatType.gif
+            else Asset.BASE
+        )
         self.url: str = f"{base}/stickers/{self.id}.{self.format.file_extension}"
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary

As stated in docs https://discord.com/developers/docs/reference#image-formatting
> Sticker GIFs do not use the CDN base url, and can be accessed at `https://media.discordapp.net/stickers/<sticker_id>.gif`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
