### PR TITLE
fix: Role Edit TypeHint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2746])(https://github.com/Pycord-Development/pycord/pull/2746)
 - Updated `valid_locales` to support `in` and `es-419`.
   ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
+- Fixed support emoji aliases like `:smile:` in PartialEmoji.from_str
+  ([#2774](https://github.com/Pycord-Development/pycord/pull/2774))
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,11 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed missing `None` type hints in `Select.__init__`.
   ([#2746](https://github.com/Pycord-Development/pycord/pull/2746))
 - Updated `valid_locales` to support `in` and `es-419`.
-  ([#2767])(https://github.com/Pycord-Development/pycord/pull/2767)
+  ([#2767](https://github.com/Pycord-Development/pycord/pull/2767))
+- Fixed `Webhook.edit` not working with `attachments=[]`.
+  ([#2779](https://github.com/Pycord-Development/pycord/pull/2779))
+- Fixed GIF-based `Sticker` returning the wrong `url`.
+  ([#2781](https://github.com/Pycord-Development/pycord/pull/2781))
 
 ### Changed
 

--- a/discord/role.py
+++ b/discord/role.py
@@ -458,7 +458,7 @@ class Role(Hashable):
         reason: str | None = MISSING,
         icon: bytes | None = MISSING,
         unicode_emoji: str | None = MISSING,
-    ) -> Role | None:
+    ) -> Role:
         """|coro|
 
         Edits the role.


### PR DESCRIPTION
## Summary
remove the | None for the role edit typehint since it only return Role
<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
