### PR TITLE
fix: command syncing edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ These changes are available on the `master` branch, but have not yet been releas
   changes. ([#2671](https://github.com/Pycord-Development/pycord/pull/2671))
 - `Entitlement.ends_at` can now be `None`.
   ([#2564](https://github.com/Pycord-Development/pycord/pull/2564))
+- Changed the default value of `ApplicationCommand.nsfw` to `False`.
+  ([#2797](https://github.com/Pycord-Development/pycord/pull/2797))
 
 ### Deprecated
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -329,8 +329,11 @@ class ApplicationCommandMixin(ABC):
                                 # We have a difference
                                 return True
                     elif getattr(cmd, check, None) != match.get(check):
-                        # We have a difference
-                        if (
+                        # We might have a difference
+                        if "localizations" in check and bool(attr) == bool(found):
+                            # unlike other attrs, localizations are MISSING by default
+                            continue
+                        elif (
                             check == "default_permission"
                             and getattr(cmd, check) is True
                             and match.get(check) is None

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -328,15 +328,15 @@ class ApplicationCommandMixin(ABC):
                             ]:
                                 # We have a difference
                                 return True
-                    elif getattr(cmd, check, None) != match.get(check):
+                    elif (attr := getattr(cmd, check, None)) != (found := match.get(check)):
                         # We might have a difference
                         if "localizations" in check and bool(attr) == bool(found):
                             # unlike other attrs, localizations are MISSING by default
                             continue
                         elif (
                             check == "default_permission"
-                            and getattr(cmd, check) is True
-                            and match.get(check) is None
+                            and attr is True
+                            and found is None
                         ):
                             # This is a special case
                             # TODO: Remove for perms v2

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -328,7 +328,9 @@ class ApplicationCommandMixin(ABC):
                             ]:
                                 # We have a difference
                                 return True
-                    elif (attr := getattr(cmd, check, None)) != (found := match.get(check)):
+                    elif (attr := getattr(cmd, check, None)) != (
+                        found := match.get(check)
+                    ):
                         # We might have a difference
                         if "localizations" in check and bool(attr) == bool(found):
                             # unlike other attrs, localizations are MISSING by default

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -233,7 +233,7 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             "__default_member_permissions__",
             kwargs.get("default_member_permissions", None),
         )
-        self.nsfw: bool | None = getattr(func, "__nsfw__", kwargs.get("nsfw", None))
+        self.nsfw: bool | None = getattr(func, "__nsfw__", kwargs.get("nsfw", False))
 
         integration_types = getattr(
             func, "__integration_types__", kwargs.get("integration_types", None)
@@ -1255,7 +1255,7 @@ class SlashCommandGroup(ApplicationCommand):
         self.default_member_permissions: Permissions | None = kwargs.get(
             "default_member_permissions", None
         )
-        self.nsfw: bool | None = kwargs.get("nsfw", None)
+        self.nsfw: bool | None = kwargs.get("nsfw", False)
 
         integration_types = kwargs.get("integration_types", None)
         contexts = kwargs.get("contexts", None)


### PR DESCRIPTION
## Summary
Fixes some edge cases in desynced commands:
- Discord always returns `nsfw` in command payloads, and as such it should not be `None` by default.
- Checks if `name_localizations` and `description_localizations` are falsey

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
