### PR TITLE
fix: VoiceClient crashes while receiving audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2779](https://github.com/Pycord-Development/pycord/pull/2779))
 - Fixed GIF-based `Sticker` returning the wrong `url`.
   ([#2781](https://github.com/Pycord-Development/pycord/pull/2781))
+- Fixed `VoiceClient` crashing randomly while receiving audio ([#2800](https://github.com/Pycord-Development/pycord/pull/2800))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2779](https://github.com/Pycord-Development/pycord/pull/2779))
 - Fixed GIF-based `Sticker` returning the wrong `url`.
   ([#2781](https://github.com/Pycord-Development/pycord/pull/2781))
-- Fixed `VoiceClient` crashing randomly while receiving audio ([#2800](https://github.com/Pycord-Development/pycord/pull/2800))
+- Fixed `VoiceClient` crashing randomly while receiving audio
+  ([#2800](https://github.com/Pycord-Development/pycord/pull/2800))
 
 ### Changed
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -613,7 +613,7 @@ class VoiceClient(VoiceProtocol):
 
     @staticmethod
     def strip_header_ext(data):
-        if data[0] == 0xBE and data[1] == 0xDE and len(data) > 4:
+        if len(data) > 4 and data[0] == 0xBE and data[1] == 0xDE:
             _, length = struct.unpack_from(">HH", data)
             offset = 4 + length * 4
             data = data[offset:]


### PR DESCRIPTION
## Summary

I fixed issue #2644.
The problem was a length check taking place _after_ byte checks.
I did extensive testing and it seems to completely get rid of the seemingly random crashes.
fixes: #2644 

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
