### PR TITLE
feat: allow usage of unicode emoji in PartialEmojiConverter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -852,7 +852,8 @@ class EmojiConverter(IDConverter[discord.GuildEmoji]):
 class PartialEmojiConverter(Converter[discord.PartialEmoji]):
     """Converts to a :class:`~discord.PartialEmoji`.
 
-    This is done by extracting the animated flag, name and ID from the emoji.
+    This is done by extracting the animated flag, name, and ID for custom emojis,
+    or by using the standard Unicode emojis supported by Discord.
 
     .. versionchanged:: 1.5
          Raise :exc:`.PartialEmojiConversionFailure` instead of generic :exc:`.BadArgument`

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -41,6 +41,7 @@ from typing import (
 )
 
 import discord
+from discord.partial_emoji import EMOJIS_MAP
 
 from .errors import *
 
@@ -872,8 +873,13 @@ class PartialEmojiConverter(Converter[discord.PartialEmoji]):
                 id=emoji_id,
             )
 
-        if argument:
-            return discord.PartialEmoji(name=argument)
+        if argument in EMOJIS_MAP.values():
+            return discord.PartialEmoji.with_state(
+                ctx.bot._connection,
+                animated=False,
+                name=argument,
+                id=None,
+            )
 
         raise PartialEmojiConversionFailure(argument)
 

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -872,6 +872,9 @@ class PartialEmojiConverter(Converter[discord.PartialEmoji]):
                 id=emoji_id,
             )
 
+        if argument:
+            return discord.PartialEmoji(name=argument)
+
         raise PartialEmojiConversionFailure(argument)
 
 
@@ -1094,7 +1097,11 @@ _GenericAlias = type(List[T])
 
 
 def is_generic_type(tp: Any, *, _GenericAlias: type = _GenericAlias) -> bool:
-    return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, _GenericAlias)  # type: ignore
+    return (
+        isinstance(tp, type)
+        and issubclass(tp, Generic)
+        or isinstance(tp, _GenericAlias)
+    )  # type: ignore
 
 
 CONVERTER_MAPPING: dict[type[Any], Any] = {


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Currently only custom emoji are supported by the converter, now unicode emoji (and other emoji) are supported.
I implemented a check that rely on #2815 to make sure the emoji is a valid unicode

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
