### PR TITLE
Fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fixed `Message.system_content()` raised an error if the message is an application_command
+  ([#2825](https://github.com/Pycord-Development/pycord/pull/2825))
 - Fixed `Enum` options not setting the correct type when only one choice is available.
   ([#2577](https://github.com/Pycord-Development/pycord/pull/2577))
 - Fixed `codec` option for `FFmpegOpusAudio` class to make it in line with

--- a/discord/message.py
+++ b/discord/message.py
@@ -1593,6 +1593,10 @@ class Message(Hashable):
                 " build the server!"
             )
 
+        if self.type is MessageType.application_command:
+            return (f"{self.author.name} sent an application command to {self.channel.name} channel in"
+                    f" {self.guild.name if self.guild is not None else 'NoneGuild'} guild.")
+
     async def delete(
         self, *, delay: float | None = None, reason: str | None = None
     ) -> None:


### PR DESCRIPTION
### Message.system_content(...):

add one condition to check if the message is an application_command. Return basic message.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The purpose of this pull request is to correct a problem with the **system_content** function in the **Message** class. This function is supposed to return a string, but when an _application_command_ is detected, it returns `None` because it was not processed.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
