### PR TITLE
feat: add ThreadAutoArchiveDuration enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2747](https://github.com/Pycord-Development/pycord/pull/2747))
 - Added `discord.Interaction.created_at`.
   ([#2801](https://github.com/Pycord-Development/pycord/pull/2801))
+- Added `ThreadAutoArchiveDuration` enum to get thread archive duration more efficiently.
+  ([#2826](https://github.com/Pycord-Development/pycord/pull/2826))
 
 ### Fixed
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -78,6 +78,7 @@ __all__ = (
     "InteractionContextType",
     "PollLayoutType",
     "MessageReferenceType",
+    "ThreadAutoArchiveDuration"
 )
 
 
@@ -1076,6 +1077,15 @@ class SubscriptionStatus(Enum):
     active = 0
     ending = 1
     inactive = 2
+
+
+class ThreadAutoArchiveDuration(Enum):
+    """Time set before the thread is auto archived"""
+
+    one_hour = 60
+    one_day = 1440
+    three_days = 4320
+    one_week = 10080
 
 
 T = TypeVar("T")

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Iterable
 
 from .abc import Messageable, _purge_messages_helper
-from .enums import ChannelType, try_enum
+from .enums import ChannelType, try_enum, ThreadAutoArchiveDuration
 from .errors import ClientException
 from .flags import ChannelFlags
 from .mixins import Hashable
@@ -602,7 +602,7 @@ class Thread(Messageable, Hashable):
         locked: bool = MISSING,
         invitable: bool = MISSING,
         slowmode_delay: int = MISSING,
-        auto_archive_duration: ThreadArchiveDuration = MISSING,
+        auto_archive_duration: ThreadAutoArchiveDuration | ThreadArchiveDuration = MISSING,
         pinned: bool = MISSING,
         applied_tags: list[ForumTag] = MISSING,
         reason: str | None = None,
@@ -632,6 +632,7 @@ class Thread(Messageable, Hashable):
         auto_archive_duration: :class:`int`
             The new duration in minutes before a thread is automatically archived for inactivity.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
+            **ThreadAutoArchiveDuration** enum can be used for better understanding.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
@@ -662,7 +663,9 @@ class Thread(Messageable, Hashable):
         if archived is not MISSING:
             payload["archived"] = archived
         if auto_archive_duration is not MISSING:
-            payload["auto_archive_duration"] = auto_archive_duration
+            payload["auto_archive_duration"] = auto_archive_duration.value \
+                if isinstance(auto_archive_duration, ThreadAutoArchiveDuration) \
+                else auto_archive_duration
         if locked is not MISSING:
             payload["locked"] = locked
         if invitable is not MISSING:


### PR DESCRIPTION
Add an enumeration ThreadAutoArchiveDuration to get time before the thread was archived.

The selected enumeration value is automatically retrieved. You can always set the archiving time as a number without using this enumeration.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request doesn't make any corrections to the code, but adds an enumeration to help find the available thread archive times.
It's not necessarily necessary, but it makes the code easier to read and understand.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
