### PR TITLE
refactor: :recycle: update deprecated usage to use `typing.deprecated`

### DIFF
--- a/discord/_version.py
+++ b/discord/_version.py
@@ -36,7 +36,9 @@ __all__ = ("__version__", "VersionInfo", "version_info")
 
 from typing import Literal, NamedTuple
 
-from .utils import deprecated
+from typing_extensions import deprecated
+
+from .utils import deprecated_message
 
 try:
     __version__ = version("py-cord")
@@ -84,27 +86,27 @@ class VersionInfo(NamedTuple):
         _advanced = value
 
     @property
-    @deprecated("releaselevel", "2.4")
+    @deprecated(deprecated_message("release_level", "releaselevel", "2.4"))
     def release_level(self) -> Literal["alpha", "beta", "candidate", "final"]:
         return self.releaselevel
 
     @property
-    @deprecated('.advanced["serial"]', "2.4")
+    @deprecated(deprecated_message("serial", '.advanced["serial"]', "2.4"))
     def serial(self) -> int:
         return self.advanced["serial"]
 
     @property
-    @deprecated('.advanced["build"]', "2.4")
+    @deprecated(deprecated_message("build", '.advanced["build"]', "2.4"))
     def build(self) -> int | None:
         return self.advanced["build"]
 
     @property
-    @deprecated('.advanced["commit"]', "2.4")
+    @deprecated(deprecated_message("commit", '.advanced["commit"]', "2.4"))
     def commit(self) -> str | None:
         return self.advanced["commit"]
 
     @property
-    @deprecated('.advanced["date"]', "2.4")
+    @deprecated(deprecated_message("date", '.advanced["date"]', "2.4"))
     def date(self) -> datetime.date | None:
         return self.advanced["date"]
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -29,6 +29,8 @@ import asyncio
 import datetime
 from typing import TYPE_CHECKING, Any, Coroutine, Union
 
+from typing_extensions import deprecated
+
 from . import utils
 from .channel import ChannelType, PartialMessageable, _threaded_channel_factory
 from .enums import (
@@ -47,6 +49,7 @@ from .monetization import Entitlement
 from .object import Object
 from .permissions import Permissions
 from .user import User
+from .utils import deprecated_message
 from .webhook.async_ import (
     Webhook,
     WebhookMessage,
@@ -315,7 +318,10 @@ class Interaction:
         return self.type == InteractionType.component
 
     @utils.cached_slot_property("_cs_channel")
-    @utils.deprecated("Interaction.channel", "2.7", stacklevel=4)
+    @deprecated(
+        deprecated_message("Interaction.cached_channel", "Interaction.channel", "2.7"),
+        stacklevel=2,
+    )
     def cached_channel(self) -> InteractionChannel | None:
         """The cached channel from which the interaction was sent.
         DM channels are not resolved. These are :class:`PartialMessageable` instead.
@@ -457,7 +463,11 @@ class Interaction:
         self._original_response = message
         return message
 
-    @utils.deprecated("Interaction.original_response", "2.2")
+    @deprecated(
+        deprecated_message(
+            "Interaction.original_message", "Interaction.original_response", "2.2"
+        )
+    )
     async def original_message(self):
         """An alias for :meth:`original_response`.
 
@@ -584,7 +594,13 @@ class Interaction:
 
         return message
 
-    @utils.deprecated("Interaction.edit_original_response", "2.2")
+    @deprecated(
+        deprecated_message(
+            "Interaction.edit_original_message",
+            "Interaction.edit_original_response",
+            "2.2",
+        )
+    )
     async def edit_original_message(self, **kwargs):
         """An alias for :meth:`edit_original_response`.
 
@@ -642,7 +658,13 @@ class Interaction:
         else:
             await func
 
-    @utils.deprecated("Interaction.delete_original_response", "2.2")
+    @deprecated(
+        deprecated_message(
+            "Interaction.delete_original_message",
+            "Interaction.delete_original_response",
+            "2.2",
+        )
+    )
     async def delete_original_message(self, **kwargs):
         """An alias for :meth:`delete_original_response`.
 
@@ -1288,7 +1310,13 @@ class InteractionResponse:
         self._parent._state.store_modal(modal, self._parent.user.id)
         return self._parent
 
-    @utils.deprecated("a button with type ButtonType.premium", "2.6")
+    @deprecated(
+        deprecated_message(
+            "InteractionResponse.premium_required",
+            "a button with type ButtonType.premium",
+            "2.6",
+        )
+    )
     async def premium_required(self) -> Interaction:
         """|coro|
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -75,7 +75,7 @@ else:
 __all__ = (
     "parse_time",
     "warn_deprecated",
-    "deprecated",
+    "deprecated_message",
     "oauth_url",
     "snowflake_time",
     "time_snowflake",
@@ -283,6 +283,40 @@ def copy_doc(original: Callable) -> Callable[[T], T]:
     return decorator
 
 
+def deprecated_message(
+    name: str,
+    instead: str | None = None,
+    since: str | None = None,
+    removed: str | None = None,
+    reference: str | None = None,
+) -> str:
+    """
+    Generates a deprecation message, with the ability to specify details about the deprecation.
+
+    Parameters
+    ----------
+    name
+    instead
+    since
+    removed
+    reference
+
+    Returns
+    -------
+    """
+    message = f"{name} is deprecated"
+    if since:
+        message += f" since version {since}"
+    if removed:
+        message += f" and will be removed in version {removed}"
+    if instead:
+        message += f", consider using {instead} instead"
+    message += "."
+    if reference:
+        message += f" See {reference} for more information."
+    return message
+
+
 def warn_deprecated(
     name: str,
     instead: str | None = None,
@@ -313,16 +347,13 @@ def warn_deprecated(
         The stacklevel kwarg passed to :func:`warnings.warn`. Defaults to 3.
     """
     warnings.simplefilter("always", DeprecationWarning)  # turn off filter
-    message = f"{name} is deprecated"
-    if since:
-        message += f" since version {since}"
-    if removed:
-        message += f" and will be removed in version {removed}"
-    if instead:
-        message += f", consider using {instead} instead"
-    message += "."
-    if reference:
-        message += f" See {reference} for more information."
+    message = deprecated_message(
+        name=name,
+        instead=instead,
+        since=since,
+        removed=removed,
+        reference=reference,
+    )
 
     warnings.warn(message, stacklevel=stacklevel, category=DeprecationWarning)
     warnings.simplefilter("default", DeprecationWarning)  # reset filter


### PR DESCRIPTION

## Summary

Fixes #1917 
Redo of #2655

The previous version of the PR did not work correctly with type checkers, this one does, with the compromise of needing to use the `@deprecated(deprecated_message(...))` syntax. This allows for type checkers to mark methods as deprecated and do some kind of strike trough like shown below:

<img width="1839" height="344" alt="image" src="https://github.com/user-attachments/assets/c0439ba9-1e44-4b3f-933f-05c91d7b2981" />

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
