### PR TITLE
fix: retain original File item urls for editing 

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -670,6 +670,7 @@ class UnfurledMediaItem(AssetMixin):
     def __init__(self, url: str):
         self._state = None
         self._url: str = url
+        self._static_url: str | None = url if url and url.startswith("attachment://") else None
         self.proxy_url: str | None = None
         self.height: int | None = None
         self.width: int | None = None
@@ -677,10 +678,21 @@ class UnfurledMediaItem(AssetMixin):
         self.flags: AttachmentFlags | None = None
         self.attachment_id: int | None = None
 
+    def __repr__(self) -> str:
+        return f"<UnfurledMediaItem url={self.url!r} attachment_id={self.attachment_id}>"
+
+    def __str__(self) -> str:
+        return self.url or self.__repr__()
+
     @property
     def url(self) -> str:
         """Returns this media item's url."""
         return self._url
+
+    @url.setter
+    def url(self, value: str) -> None:
+        self._url = value
+        self._static_url = value if value and value.startswith("attachment://") else None
 
     @classmethod
     def from_dict(cls, data: UnfurledMediaItemPayload, state=None) -> UnfurledMediaItem:
@@ -696,7 +708,7 @@ class UnfurledMediaItem(AssetMixin):
         return r
 
     def to_dict(self) -> dict[str, str]:
-        return {"url": self.url}
+        return {"url": self._static_url or self.url}
 
 
 class Thumbnail(Component):

--- a/discord/ui/file.py
+++ b/discord/ui/file.py
@@ -90,6 +90,11 @@ class File(Item[V]):
         """The size of this file in bytes, if provided by Discord."""
         return self._underlying.size
 
+    def refresh_component(self, component: Component) -> None:
+        original = self._underlying.file
+        component.file._static_url = original._static_url
+        self._underlying = component
+
     def to_component_dict(self) -> FileComponentPayload:
         return self._underlying.to_dict()
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Editing components on CV2 messages is awkward when dealing with `File` retention; this mitigates the issue.

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
