### PR TITLE
feat: add Message.get_component and related functions

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -39,7 +39,7 @@ from .enums import (
 )
 from .flags import AttachmentFlags
 from .partial_emoji import PartialEmoji, _EmojiTag
-from .utils import MISSING, get_slots
+from .utils import MISSING, get_slots, find
 
 if TYPE_CHECKING:
     from .emoji import AppEmoji, GuildEmoji
@@ -186,6 +186,25 @@ class ActionRow(Component):
 
     def walk_components(self) -> Iterator[Component]:
         yield from self.children
+
+    def get_component(self, id: str | int) -> Component | None:
+        """Get a component from this action row. Roughly equivalent to `utils.get(row.children, ...)`.
+        If an ``int`` is provided, the component will be retrieved by ``id``, otherwise by ``custom_id``.
+
+        Parameters
+        ----------
+        id: Union[:class:`str`, :class:`int`]
+            The custom_id or id of the component to get.
+
+        Returns
+        -------
+        Optional[:class:`Component`]
+            The component with the matching ``id`` or ``custom_id`` if it exists.
+        """
+        if not id:
+            return None
+        attr = "id" if isinstance(id, int) else "custom_id"
+        return find(lambda i: getattr(i, attr, None) == id, self.children)
 
     @classmethod
     def with_components(cls, *components, id=None):
@@ -620,6 +639,28 @@ class Section(Component):
             yield from r + [self.accessory]
         yield from r
 
+    def get_component(self, id: str | int) -> Component | None:
+        """Get a component from this section. Roughly equivalent to `utils.get(section.walk_components(), ...)`.
+        If an ``int`` is provided, the component will be retrieved by ``id``, otherwise by ``custom_id``.
+
+        Parameters
+        ----------
+        id: Union[:class:`str`, :class:`int`]
+            The custom_id or id of the component to get.
+
+        Returns
+        -------
+        Optional[:class:`Component`]
+            The component with the matching ``id`` or ``custom_id`` if it exists.
+        """
+        if not id:
+            return None
+        attr = "id" if isinstance(id, int) else "custom_id"
+        if self.accessory and id == getattr(self.accessory, attr, None):
+            return self.accessory
+        component = find(lambda i: getattr(i, attr, None) == id, self.components)
+        return component
+
 
 class TextDisplay(Component):
     """Represents a Text Display from Components V2.
@@ -1035,6 +1076,32 @@ class Container(Component):
                 yield from c.walk_components()
             else:
                 yield c
+
+    def get_component(self, id: str | int) -> Component | None:
+        """Get a component from this container. Roughly equivalent to `utils.get(container.components, ...)`.
+        If an ``int`` is provided, the component will be retrieved by ``id``, otherwise by ``custom_id``.
+        This method will also search for nested components.
+
+        Parameters
+        ----------
+        id: Union[:class:`str`, :class:`int`]
+            The custom_id or id of the component to get.
+
+        Returns
+        -------
+        Optional[:class:`Component`]
+            The component with the matching ``id`` or ``custom_id`` if it exists.
+        """
+        if not id:
+            return None
+        attr = "id" if isinstance(id, int) else "custom_id"
+        component = find(lambda i: getattr(i, attr, None) == id, self.components)
+        if not component:
+            for i in self.components:
+                if hasattr(i, "get_component"):
+                    if component := i.get_component(id):
+                        return component
+        return component
 
 
 COMPONENT_MAPPINGS = {

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -434,7 +434,7 @@ class View:
 
         Parameters
         ----------
-        custom_id: :class:`str`
+        custom_id: Union[:class:`str`, :class:`int`]
             The custom_id of the item to get
 
         Returns


### PR DESCRIPTION
## Summary

Added to compliment `View.get_item` so users don't need to reconstruct `View` just to retrieve data.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
