### PR TITLE
feat: Respect user warning filters for deprecation messages

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -322,7 +322,6 @@ def warn_deprecated(
     stacklevel: :class:`int`
         The stacklevel kwarg passed to :func:`warnings.warn`. Defaults to 3.
     """
-    warnings.simplefilter("always", DeprecationWarning)  # turn off filter
     message = f"{name} is deprecated"
     if since:
         message += f" since version {since}"
@@ -335,7 +334,6 @@ def warn_deprecated(
         message += f" See {reference} for more information."
 
     warnings.warn(message, stacklevel=stacklevel, category=DeprecationWarning)
-    warnings.simplefilter("default", DeprecationWarning)  # reset filter
 
 
 def deprecated(


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR removes the calls to `warnings.simplefilter("always", DeprecationWarning)` and `warnings.simplefilter("default", DeprecationWarning)` in the deprecation helper.

Currently, the implementation forces DeprecationWarning visibility by temporarily setting the filter to "always", and then resets it to "default". This overrides user-defined warning filters, which is not ideal.

With this change, the function simply calls warnings.warn, leaving all filtering behavior up to the user or their framework (e.g. pytest, PYTHONWARNINGS, warnings.filterwarnings).

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
