### PR TITLE
fix: :bug: Fix `4014` voice close event code incorrectly handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2843](https://github.com/Pycord-Development/pycord/pull/2843))
 - Fixed `TypeError` when using `@option` with certain annotations and along with
   `channel_types`. ([#2835](https://github.com/Pycord-Development/pycord/pull/2835))
+- Fixed reconnection issues with `VoiceClient` due to incorrectly trying to reconnect
+  with status code `4014`.
+  ([#2870](https://github.com/Pycord-Development/pycord/pull/2870))
 
 ### Changed
 


### PR DESCRIPTION
## Summary

fixes: #2865

Docs reference: https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes

For some reason, when receiving `4014` `py-cord` tried to resume the connection, even though discord explicitly stated 
> Disconnect individual client (you were kicked, the main gateway session was dropped, etc.). **Should not reconnect.**

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
