### PR TITLE
feat: add jump_url method for discord.Member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2818](https://github.com/Pycord-Development/pycord/pull/2818))
 - Added `Interaction.attachment_size_limit`.
   ([#2854](https://github.com/Pycord-Development/pycord/pull/2854))
+- Added `discord.Member.jump_url`
+  ([#2877](https://github.com/Pycord-Development/pycord/pull/2877))
 
 ### Fixed
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -727,6 +727,11 @@ class Member(discord.abc.Messageable, _UserTag):
             > datetime.datetime.now(datetime.timezone.utc)
         )
 
+    @property
+    def jump_url(self) -> str:
+        """Returns a URL that allows the client to jump to the user."""
+        return self._user.jump_url
+
     async def ban(
         self,
         *,


### PR DESCRIPTION
## Summary
This PR adds the method `jump_url` that the `discord.User` has to discord.Member utilizing `User.jump_url`

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] I have searched the open pull requests for duplicates.
- [X] If code changes were made then they have been tested.
  - [X] I have updated the documentation to reflect the changes.
- [X] If `type: ignore` comments were used, a comment is also left explaining why.
- [X] I have updated the changelog to include these changes.
