### PR TITLE
fix: Unbound `raw` reference in `parse_message_update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2808](https://github.com/Pycord-Development/pycord/pull/2808))
 - Unbound `raw` reference in `parse_message_update` causing errors on message edits.
   ([#2905](https://github.com/Pycord-Development/pycord/pull/2905))
+
 ### Removed
 
 ## [2.7.0rc1] - 2025-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Manage silence for new SSRC with existing user_id.
   ([#2808](https://github.com/Pycord-Development/pycord/pull/2808))
-- Unbound `raw` reference in `parse_message_update` causing errors on message edits.
+- Unbound `raw` reference in `parse_message_update` causing errors on message updates.
   ([#2905](https://github.com/Pycord-Development/pycord/pull/2905))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Manage silence for new SSRC with existing user_id.
   ([#2808](https://github.com/Pycord-Development/pycord/pull/2808))
-
+- Unbound `raw` reference in `parse_message_update` causing errors on message edits.
+  ([#2905](https://github.com/Pycord-Development/pycord/pull/2905))
 ### Removed
 
 ## [2.7.0rc1] - 2025-08-30

--- a/discord/state.py
+++ b/discord/state.py
@@ -777,10 +777,10 @@ class ConnectionState:
 
     def parse_message_update(self, data) -> None:
         old_message = self._get_message(int(data["id"]))
-        if old_message is not None:
-            self._messages.remove(old_message)
         channel, _ = self._get_guild_channel(data)
         message = Message(channel=channel, data=data, state=self)
+        if old_message is not None:
+            self._messages.remove(old_message)
         self._messages.append(message)
         raw = RawMessageUpdateEvent(data, message)
         self.dispatch("raw_message_edit", raw)

--- a/discord/state.py
+++ b/discord/state.py
@@ -604,7 +604,6 @@ class ConnectionState:
             raise
 
     async def _delay_ready(self) -> None:
-
         if self.cache_app_emojis and self.application_id:
             data = await self.http.get_all_application_emojis(self.application_id)
             for e in data.get("items", []):
@@ -677,7 +676,9 @@ class ConnectionState:
             else:
                 self.application_id = utils._get_as_snowflake(application, "id")
                 # flags will always be present here
-                self.application_flags = ApplicationFlags._from_value(application["flags"])  # type: ignore
+                self.application_flags = ApplicationFlags._from_value(
+                    application["flags"]
+                )  # type: ignore
 
         for guild_data in data["guilds"]:
             self._add_guild_from_data(guild_data)
@@ -775,7 +776,7 @@ class ConnectionState:
                 self._messages.remove(msg)  # type: ignore
 
     def parse_message_update(self, data) -> None:
-        old_message = self._get_message(raw.message_id)
+        old_message = self._get_message(int(data["id"]))
         if old_message is not None:
             self._messages.remove(old_message)
         channel, _ = self._get_guild_channel(data)
@@ -1376,7 +1377,9 @@ class ConnectionState:
         for emoji in before_stickers:
             self._stickers.pop(emoji.id, None)
         # guild won't be None here
-        guild.stickers = tuple(map(lambda d: self.store_sticker(guild, d), data["stickers"]))  # type: ignore
+        guild.stickers = tuple(
+            map(lambda d: self.store_sticker(guild, d), data["stickers"])
+        )  # type: ignore
         self.dispatch("guild_stickers_update", guild, before_stickers, guild.stickers)
 
     def _get_create_guild(self, data):
@@ -1581,7 +1584,10 @@ class ConnectionState:
         presences = data.get("presences", [])
 
         # the guild won't be None here
-        members = [Member(guild=guild, data=member, state=self) for member in data.get("members", [])]  # type: ignore
+        members = [
+            Member(guild=guild, data=member, state=self)
+            for member in data.get("members", [])
+        ]  # type: ignore
         _log.debug(
             "Processed a chunk for %s members in guild ID %s.", len(members), guild_id
         )


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Here’s a nicely formatted **PR draft** you can use for your change 👇

---

## 📖 Description

This PR fixes an issue in the `parse_message_update` method where the variable `raw` was being referenced before assignment when retrieving `old_message`.

Previously, the method tried to access `raw.message_id` before `raw` was defined, causing an **unbound variable error**.
Now, the method correctly retrieves the message ID directly from `data["id"]` before creating the `RawMessageUpdateEvent`.

---

## 🔧 Changes Made

* Updated `old_message` retrieval to use `int(data["id"])` instead of `raw.message_id`.
* Ensured `raw` is created **after** both `old_message` and the new `Message` object are initialized.
* Maintained existing event dispatch logic (`raw_message_edit`, `message_edit`, poll handling, and component tracking).

---

## ✅ Why This Fix Matters

* Prevents runtime errors caused by referencing an uninitialized `raw` variable.
* Ensures message updates are processed consistently.
* Improves code clarity by keeping the order of operations correct.


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
