### PR TITLE
fix: Remove Extra Bytes Added By Discord Before OPUS Decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#2916](https://github.com/Pycord-Development/pycord/pull/2916))
 - Fixed a crash when processing message edit events while message cache was disabled.
   ([#2924](https://github.com/Pycord-Development/pycord/pull/2924))
+- Fixed OPUS Decode Error when recording audio.
+  ([#2925](https://github.com/Pycord-Development/pycord/pull/2925))
 
 ### Removed
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -652,9 +652,10 @@ class VoiceClient(VoiceProtocol):
         nonce[:4] = data[-4:]
         data = data[:-4]
 
-        return self.strip_header_ext(
-            box.decrypt(bytes(data), bytes(header), bytes(nonce))
-        )
+        r = box.decrypt(bytes(data), bytes(header), bytes(nonce))
+        # Discord adds 8 bytes of data before the opus data.
+        # This can be removed, and at this time, discarded as it is unclear what they are for.
+        return r[8:]
 
     @staticmethod
     def strip_header_ext(data):
@@ -774,7 +775,7 @@ class VoiceClient(VoiceProtocol):
         data: :class:`bytes`
             Bytes received by Discord via the UDP connection used for sending and receiving voice data.
         """
-        if data[1] != 0x78:
+        if data[1] & 0x78 != 0x78:
             # We Should Ignore Any Payload Types We Do Not Understand
             # Ref RFC 3550 5.1 payload type
             # At Some Point We Noted That We Should Ignore Only Types 200 - 204 inclusive.


### PR DESCRIPTION
## Summary

Discord adds 8 bytes of data to the beginning of OPUS packets. So after transport layer decryption the first 8 bytes should be stripped before decoding with OPUS.

This also changes the packet whitelist to not include an unrelated bit in the check potentially causing dropped packets.
Fixes: #2921 

From my testing these 8 bytes are always present. Legacy code suggests that there may be times where these 8 bytes are not present. I would like someone else to test before this is merged.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
