### PR TITLE
feat: :wrench: Enable pre-commit autoupdate in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "local>Pycord-Development/renovate-config",
     ":semanticPrefixFixDepsChoreOthers",
-    ":dependencyDashboard"
+    ":dependencyDashboard",
+    ":enablePreCommit"
   ],
   "assigneesFromCodeOwners": true,
   "pip_requirements": {


### PR DESCRIPTION
## Summary

> [!NOTE]
> Since pre-commit CI doesn't offer any option to disable pre-commit autoupdate, this will conflict with it maybe idk

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
