### PR TITLE
fix: :ambulance: Fix `typing.TypeAliasType` not present in python <3.12

### DIFF
--- a/discord/commands/options.py
+++ b/discord/commands/options.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import sys
 import types
 from enum import Enum
 from typing import (
@@ -33,10 +34,14 @@ from typing import (
     Literal,
     Optional,
     Type,
-    TypeAliasType,
     Union,
     get_args,
 )
+
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:
+    from typing_extensions import TypeAliasType
 
 from ..abc import GuildChannel, Mentionable
 from ..channel import (


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
