### PR TITLE
docs: Fix typo in enums.rst documentation

### DIFF
--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -7,7 +7,7 @@ Enumerations
 ============
 
 The API provides some enumerations for certain types of strings to avoid the API
-from being stringly typed in case the strings change in the future.
+from being strongly typed in case the strings change in the future.
 
 All enumerations are subclasses of an internal class which mimics the behaviour
 of :class:`enum.Enum`.


### PR DESCRIPTION
fix "stringly typed" to "strongly typed"

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
