### PR TITLE
fix: `default` param for checkbox not respected

### DIFF
--- a/discord/ui/checkbox.py
+++ b/discord/ui/checkbox.py
@@ -92,7 +92,7 @@ class Checkbox(ModalItem):
         return CheckboxComponent._raw_construct(
             type=ComponentType.checkbox,
             custom_id=custom_id or self.custom_id,
-            required=default if default is not None else self.default,
+            default=default if default is not None else self.default,
             id=id or self.id,
         )
 


### PR DESCRIPTION
## Summary

The `default` parameter for checkboxes was not working, so all boxes were always unticked.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

