### PR TITLE
docs: Correct type for ui.Container.add_file()

### DIFF
--- a/discord/ui/container.py
+++ b/discord/ui/container.py
@@ -306,7 +306,7 @@ class Container(ViewItem[V]):
         return self.add_item(g)
 
     def add_file(self, url: str, spoiler: bool = False, id: int | None = None) -> Self:
-        """Adds a :class:`TextDisplay` to the container.
+        """Adds a :class:`File` to the container.
 
         Parameters
         ----------


### PR DESCRIPTION
> [!CAUTION]
> Code freeze is active

## Summary
`discord.ui.Container.add_file()` wrongly typed as adding a `discord.ui.TextDisplay` instead of `discord.ui.File`.
This pr corrects this type

<!-- What is this pull request for? Does it fix any issues? -->

<!-- If Generative AI (consisting of but not limited to LLMs and Agentic AI systems) 
has been used to partially or entirely produce this pull request (documentation included), 
disclose it here -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

