### PR TITLE
docs: improve docstring wording for display properties

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -663,9 +663,8 @@ class Member(discord.abc.Messageable, _UserTag):
     def display_avatar(self) -> Asset:
         """Returns the member's display avatar.
 
-        For regular members this is just their avatar, but
-        if they have a guild specific avatar then that
-        is returned instead.
+        If the member has a guild-specific avatar, that is returned.
+        Otherwise, their user avatar or default avatar is used.
 
         .. versionadded:: 2.0
         """
@@ -688,9 +687,8 @@ class Member(discord.abc.Messageable, _UserTag):
     def display_avatar_decoration(self) -> Asset | None:
         """Returns the member's displayed avatar decoration.
 
-        For regular members this is just their avatar decoration, but
-        if they have a guild specific avatar decoration then that
-        is returned instead.
+        If the member has a guild-specific avatar decoration, that is
+        returned. Otherwise, their user avatar decoration is used.
 
         .. versionadded:: 2.8
         """
@@ -713,9 +711,8 @@ class Member(discord.abc.Messageable, _UserTag):
     def display_banner(self) -> Asset | None:
         """Returns the member's display banner.
 
-        For regular members this is just their banner, but
-        if they have a guild specific banner then that
-        is returned instead.
+        If the member has a guild-specific banner, that is returned.
+        Otherwise, their user banner is used.
 
         .. versionadded:: 2.7
         """

--- a/discord/user.py
+++ b/discord/user.py
@@ -251,7 +251,8 @@ class BaseUser(_UserTag):
     def display_avatar(self) -> Asset:
         """Returns the user's display avatar.
 
-        For regular users this is just their default avatar or uploaded avatar.
+        This is the user's uploaded avatar if available,
+        otherwise their default avatar.
 
         .. versionadded:: 2.0
         """


### PR DESCRIPTION
Replaces the awkward "for regular members" / "for regular users" phrasing in
`display_avatar`, `display_avatar_decoration`, `display_banner` (in `Member`),
and `display_avatar` (in `User`) with clearer descriptions of the
guild-specific fallback behavior.

The original wording ("for regular members this is just their avatar, but...")
reads a bit oddly and implies the existence of "irregular" members. The updated
docstrings now directly describe what the property returns depending on whether
a guild-specific override is set.

Closes #3117