### PR TITLE
fix(voice): correct ssrc↔user_id cache direction in DAVE decrypt fallback

### DIFF
--- a/discord/voice/receive/reader.py
+++ b/discord/voice/receive/reader.py
@@ -288,7 +288,7 @@ class PacketDecryptor:
                             raw_payload,
                         )
                         # Successfully decrypted - cache the mapping for next time
-                        self.client._connection.user_ssrc_map[int_uid] = packet.ssrc
+                        self.client._connection.ssrc_user_map[packet.ssrc] = int_uid
                         uid = int_uid
                         raw_payload = decrypted_audio
                         _log.debug(
@@ -299,6 +299,10 @@ class PacketDecryptor:
                         break
                     except ValueError:
                         continue
+                else:
+                    # All candidates failed to decrypt; return silence to avoid
+                    # passing encrypted audio data downstream.
+                    return OPUS_SILENCE
             elif uid:
                 try:
                     raw_payload = dave.decrypt(


### PR DESCRIPTION
## Summary

- Fixed a cache write bug in `decrypt_rtp()` where a successfully inferred SSRC→user_id mapping was written to the **wrong** map (`user_ssrc_map[uid] = ssrc`) instead of `ssrc_user_map[ssrc] = uid`.
- Added a `for/else` fallback that returns `OPUS_SILENCE` when all candidate user IDs fail to decrypt, preventing raw encrypted bytes from being passed downstream to sinks.

## Problem

Inside `PacketDecryptor.decrypt_rtp()`, when `ssrc_user_map` does not yet contain a mapping for the incoming SSRC (a normal race with `member_connect`), the code iterates over every user ID known to the DAVE session and tries to decrypt with each one. On a successful decrypt it is supposed to cache `ssrc → uid` so the expensive scan is skipped on the next packet.

However, the cache write was inverted:

```python
# Before (buggy)
self.client._connection.user_ssrc_map[int_uid] = packet.ssrc  # uid → ssrc (wrong map)

# After (fixed)
self.client._connection.ssrc_user_map[packet.ssrc] = int_uid  # ssrc → uid (correct map)
```

Because the write went into `user_ssrc_map` (uid→ssrc) instead of `ssrc_user_map` (ssrc→uid), the lookup on the next packet (`state.ssrc_user_map.get(packet.ssrc)`) always missed, causing the full brute-force loop to run on **every single packet** for the lifetime of the session.

## Reproduction

Start voice receive in a DAVE-enabled VC. With DEBUG logging enabled, observe:

```
DAVE: inferred ssrc 12345 -> user_id 987654321 from decryption
DAVE: inferred ssrc 12345 -> user_id 987654321 from decryption
DAVE: inferred ssrc 12345 -> user_id 987654321 from decryption
... (repeats every packet indefinitely)
```

After this fix the log line appears only once per SSRC — the cached mapping is hit on all subsequent packets.

## Changes

| File | Change |
|------|--------|
| `discord/voice/receive/reader.py` | Swap `user_ssrc_map[uid] = ssrc` → `ssrc_user_map[ssrc] = uid` |
| `discord/voice/receive/reader.py` | Add `for/else` returning `OPUS_SILENCE` when all candidate decryptions fail |

## Why only this fix now

This is a clear, isolated implementation mistake — the wrong dict key/value order. It requires no new tests and is safe to merge independently.

The related epoch-transition passthrough (`can_passthrough()`) improvement involves more complex timing logic and needs separate testing and review. It will be submitted as a follow-up PR.

## Related

- #3139