### PR TITLE
fix: Update event loop retrieval to support Python 3.14+

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -70,7 +70,13 @@ from .template import Template
 from .threads import Thread
 from .ui.view import BaseView
 from .user import ClientUser, User
-from .utils import _D, _FETCHABLE, MISSING, warn_if_voice_dependencies_missing
+from .utils import (
+    _D,
+    _FETCHABLE,
+    MISSING,
+    _get_event_loop,
+    warn_if_voice_dependencies_missing,
+)
 from .webhook import Webhook
 from .widget import Widget
 
@@ -147,7 +153,7 @@ class Client:
     loop: Optional[:class:`asyncio.AbstractEventLoop`]
         The :class:`asyncio.AbstractEventLoop` to use for asynchronous operations.
         Defaults to ``None``, in which case the default event loop is used via
-        :func:`asyncio.get_event_loop()`.
+        :func:`asyncio.get_event_loop()` if it exists or one is created via :func:`asyncio.new_event_loop()`.
     connector: Optional[:class:`aiohttp.BaseConnector`]
         The connector to use for connection pooling.
     proxy: Optional[:class:`str`]
@@ -245,7 +251,7 @@ class Client:
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
         self.loop: asyncio.AbstractEventLoop = (
-            asyncio.get_event_loop() if loop is None else loop
+            _get_event_loop() if loop is None else loop
         )
         self._listeners: dict[str, list[tuple[asyncio.Future, Callable[..., bool]]]] = (
             {}

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, Callable, Deque, TypeVar
 
 import discord.abc
 from discord.enums import Enum
+from discord.utils import _get_event_loop
 
 from ...abc import PrivateChannel
 from .errors import MaxConcurrencyReached
@@ -308,7 +309,7 @@ class _Semaphore:
 
     def __init__(self, number: int) -> None:
         self.value: int = number
-        self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+        self.loop: asyncio.AbstractEventLoop = _get_event_loop()
         self._waiters: Deque[asyncio.Future] = deque()
 
     def __repr__(self) -> str:

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -38,7 +38,7 @@ import aiohttp
 
 import discord
 from discord.backoff import ExponentialBackoff
-from discord.utils import MISSING
+from discord.utils import MISSING, _get_event_loop
 
 __all__ = ("loop",)
 
@@ -384,7 +384,7 @@ class Loop(Generic[LF]):
             args = (self._injected, *args)
 
         if self.loop is MISSING:
-            self.loop = asyncio.get_event_loop()
+            self.loop = _get_event_loop()
 
         self._task = self.loop.create_task(self._loop(*args, **kwargs))
         return self._task
@@ -825,8 +825,8 @@ def loop(
         using an exponential back-off algorithm similar to the
         one used in :meth:`discord.Client.connect`.
     loop: :class:`asyncio.AbstractEventLoop`
-        The loop to use to register the task, if not given
-        defaults to :func:`asyncio.get_event_loop`.
+        The loop to use to register the task, if not given the default event loop is used via
+        :func:`asyncio.get_event_loop()` if it exists or one is created via :func:`asyncio.new_event_loop()`.
     overlap: Union[:class:`bool`, :class:`int`]
         Controls whether overlapping executions of the task loop are allowed.
         Set to False (default) to run iterations one at a time, True for unlimited overlap, or an int to cap the number of concurrent runs.

--- a/discord/http.py
+++ b/discord/http.py
@@ -55,7 +55,7 @@ from .errors import (
 from .file import VoiceMessage
 from .gateway import DiscordClientWebSocketResponse
 from .soundboard import PartialSoundboardSound, SoundboardSound
-from .utils import MISSING
+from .utils import MISSING, _get_event_loop
 
 _log = logging.getLogger(__name__)
 
@@ -192,7 +192,7 @@ class HTTPClient:
         unsync_clock: bool = True,
     ) -> None:
         self.loop: asyncio.AbstractEventLoop = (
-            asyncio.get_event_loop() if loop is None else loop
+            _get_event_loop() if loop is None else loop
         )
         self.connector = connector
         self.__session: aiohttp.ClientSession = MISSING  # filled in static_login

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -33,7 +33,7 @@ from itertools import groupby
 from typing import TYPE_CHECKING, Any, Iterator, TypeVar
 
 from ..enums import ComponentType
-from ..utils import find
+from ..utils import _get_event_loop, find
 from .core import ItemInterface
 from .input_text import InputText
 from .item import ModalItem
@@ -91,7 +91,7 @@ class BaseModal(ItemInterface):
         for item in children:
             self.add_item(item)
         self._title = title
-        self.loop = asyncio.get_event_loop()
+        self.loop = _get_event_loop()
 
     def __repr__(self) -> str:
         attrs = " ".join(

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1680,7 +1680,7 @@ def _get_event_loop() -> asyncio.AbstractEventLoop:
     """
     if sys.version_info >= (3, 14):
         try:
-            loop = asyncio.get_running_loop()
+            loop = asyncio.get_event_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1665,3 +1665,21 @@ def warn_if_voice_dependencies_missing() -> None:
         deps,
         "is" if len(missing) == 1 else "are",
     )
+
+
+def _get_event_loop() -> asyncio.AbstractEventLoop:
+    """Get the current event loop, creating one if necessary.
+
+    Returns
+    -------
+    asyncio.AbstractEventLoop
+        The current event loop.
+    """
+    if sys.version_info >= (3, 14):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return loop
+    return asyncio.get_event_loop()

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1670,6 +1670,9 @@ def warn_if_voice_dependencies_missing() -> None:
 def _get_event_loop() -> asyncio.AbstractEventLoop:
     """Get the current event loop, creating one if necessary.
 
+    If no event loop is running and none is set, a new event loop
+    is created and set as the current event loop.
+
     Returns
     -------
     asyncio.AbstractEventLoop

--- a/examples/basic_voice.py
+++ b/examples/basic_voice.py
@@ -42,11 +42,8 @@ class YTDLSource(discord.PCMVolumeTransformer):
         self.url = data.get("url")
 
     @classmethod
-    async def from_url(cls, url, *, loop=None, stream=False):
-        loop = loop or asyncio.get_event_loop()
-        data = await loop.run_in_executor(
-            None, lambda: ytdl.extract_info(url, download=not stream)
-        )
+    async def from_url(cls, url, *, stream=False):
+        data = await asyncio.to_thread(ytdl.extract_info, url, download=not stream)
 
         if "entries" in data:
             # Takes the first item from a playlist


### PR DESCRIPTION
> [!CAUTION]
> Feature freeze is active, as described by our [Release Schedule](https://github.com/Pycord-Development/pycord/blob/master/RELEASE_SCHEDULE.md).

## Summary

This is a minimal fix that allows py-cord to work in python 3.14 (allegedly, seems to work though). It is not the most elegant and our entire asyncio stack should eventually be replaced to be more idomatic, but should allow us to ship 3.14 support in the current state.

See #2645 for a later, more future proof solution.

This does nto have changelog as it is an internal refactor in preparation for 3.14 - the actual changelog is in #2948 

<!-- What is this pull request for? Does it fix any issues? -->

<!-- If Generative AI (consisting of but not limited to LLMs and Agentic AI systems) 
has been used to partially or entirely produce this pull request (documentation included), 
disclose it here -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

