### PR TITLE
fix: Exclude read-only members from owner IDs

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1441,7 +1441,8 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
         this bot.
 
         If an :attr:`owner_id` is not set, it is fetched automatically
-        through the use of :meth:`~.Bot.application_info`.
+        through the use of :meth:`~.Bot.application_info`, returning 
+        the application owner, or all non read-only team members.
 
         .. versionchanged:: 1.3
             The function also checks if the application is team-owned if
@@ -1493,11 +1494,12 @@ class Bot(BotBase, Client):
     owner_id: Optional[:class:`int`]
         The user ID that owns the bot. If this is not set and is then queried via
         :meth:`.is_owner` then it is fetched automatically using
-        :meth:`~.Bot.application_info`.
+        :meth:`~.Bot.application_info`, returning the application owner.
     owner_ids: Optional[Collection[:class:`int`]]
         The user IDs that owns the bot. This is similar to :attr:`owner_id`.
         If this is not set and the application is team based, then it is
-        fetched automatically using :meth:`~.Bot.application_info`.
+        fetched automatically using :meth:`~.Bot.application_info`, 
+        returning all non read-only team members.
         For performance reasons it is recommended to use a :class:`set`
         for the collection. You cannot set both ``owner_id`` and ``owner_ids``.
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1441,7 +1441,7 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
         this bot.
 
         If an :attr:`owner_id` is not set, it is fetched automatically
-        through the use of :meth:`~.Bot.application_info`, returning 
+        through the use of :meth:`~.Bot.application_info`, returning
         the application owner, or all non read-only team members.
 
         .. versionchanged:: 1.3
@@ -1498,7 +1498,7 @@ class Bot(BotBase, Client):
     owner_ids: Optional[Collection[:class:`int`]]
         The user IDs that owns the bot. This is similar to :attr:`owner_id`.
         If this is not set and the application is team based, then it is
-        fetched automatically using :meth:`~.Bot.application_info`, 
+        fetched automatically using :meth:`~.Bot.application_info`,
         returning all non read-only team members.
         For performance reasons it is recommended to use a :class:`set`
         for the collection. You cannot set both ``owner_id`` and ``owner_ids``.

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1465,7 +1465,7 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
         else:
             app = await self.application_info()  # type: ignore
             if app.team:
-                self.owner_ids = ids = {m.id for m in app.team.members}
+                self.owner_ids = ids = {m.id for m in app.team.members if m.role != "read_only"}
                 return user.id in ids
             else:
                 self.owner_id = owner_id = app.owner.id

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1465,7 +1465,9 @@ class BotBase(ApplicationCommandMixin, CogMixin, ABC):
         else:
             app = await self.application_info()  # type: ignore
             if app.team:
-                self.owner_ids = ids = {m.id for m in app.team.members if m.role != "read_only"}
+                self.owner_ids = ids = {
+                    m.id for m in app.team.members if m.role != "read_only"
+                }
                 return user.id in ids
             else:
                 self.owner_id = owner_id = app.owner.id

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -45,6 +45,7 @@ __all__ = (
     "ActivityType",
     "NotificationLevel",
     "TeamMembershipState",
+    "TeamRole",
     "WebhookType",
     "ExpireBehaviour",
     "ExpireBehavior",
@@ -627,6 +628,15 @@ class TeamMembershipState(Enum):
 
     invited = 1
     accepted = 2
+
+
+class TeamRole(Enum):
+    """Role of a team member."""
+
+    owner = ""
+    admin = "admin"
+    developer = "developer"
+    read_only = "read_only"
 
 
 class WebhookType(Enum):

--- a/discord/team.py
+++ b/discord/team.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 
 from . import utils
 from .asset import Asset
-from .enums import TeamMembershipState, try_enum
+from .enums import TeamMembershipState, TeamRole, try_enum
 from .user import BaseUser
 
 if TYPE_CHECKING:
@@ -136,16 +136,18 @@ class TeamMember(BaseUser):
         The team that the member is from.
     membership_state: :class:`TeamMembershipState`
         The membership state of the member (e.g. invited or accepted)
+    role: :class:`TeamRole`
+        The role of the team member (e.g. admin, developer, read_only).
     """
 
-    __slots__ = ("team", "membership_state", "permissions")
+    __slots__ = ("team", "membership_state", "role")
 
     def __init__(self, team: Team, state: ConnectionState, data: TeamMemberPayload):
         self.team: Team = team
         self.membership_state: TeamMembershipState = try_enum(
             TeamMembershipState, data["membership_state"]
         )
-        self.permissions: list[str] = data["permissions"]
+        self.role: TeamRole = try_enum(TeamRole, data["role"])
         super().__init__(state=state, data=data["user"])
 
     def __repr__(self) -> str:

--- a/discord/types/team.py
+++ b/discord/types/team.py
@@ -34,7 +34,7 @@ from .user import PartialUser
 class TeamMember(TypedDict):
     user: PartialUser
     membership_state: int
-    permissions: list[str]
+    role: str
     team_id: Snowflake
 
 


### PR DESCRIPTION
> [!CAUTION]
> Feature freeze is active, as described by our [Release Schedule](https://github.com/Pycord-Development/pycord/blob/master/RELEASE_SCHEDULE.md).

## Summary
also backfill changelog
<!-- What is this pull request for? Does it fix any issues? -->

<!-- If Generative AI (consisting of but not limited to LLMs and Agentic AI systems) 
has been used to partially or entirely produce this pull request (documentation included), 
disclose it here -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [x] AI Usage has been disclosed.
  - [x] If AI has been used, I understand fully what the code does

