### PR TITLE
fix: Colour ignored when `0` is used as british-colour in Embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3231](https://github.com/Pycord-Development/pycord/pull/3231))
 - Allow `ForumTag` to be created without an emoji.
   ([#3245](https://github.com/Pycord-Development/pycord/pull/3245))
-- Fix issue where `0` would be ignored as an `Embed`'s `colour` parameter.
+- Fix an issue where an `Embed` object's `colour` parameter would be ignored when set to `0`.
   ([#3256](https://github.com/Pycord-Development/pycord/pull/3256))
 - Fix a bug where `TextChannel.archived_threads` would ignore any limit parameter
   smaller than 50 and use 50 instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3231](https://github.com/Pycord-Development/pycord/pull/3231))
 - Allow `ForumTag` to be created without an emoji.
   ([#3245](https://github.com/Pycord-Development/pycord/pull/3245))
+- Fix issue where `0` would be ignored as an `Embed`'s `colour` parameter.
+  ([#3256](https://github.com/Pycord-Development/pycord/pull/3256))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3231](https://github.com/Pycord-Development/pycord/pull/3231))
 - Allow `ForumTag` to be created without an emoji.
   ([#3245](https://github.com/Pycord-Development/pycord/pull/3245))
-- Fix an issue where an `Embed` object's `colour` parameter would be ignored when set to `0`.
-  ([#3256](https://github.com/Pycord-Development/pycord/pull/3256))
+- Fix an issue where an `Embed` object's `colour` parameter would be ignored when set to
+  `0`. ([#3256](https://github.com/Pycord-Development/pycord/pull/3256))
 - Fix a bug where `TextChannel.archived_threads` would ignore any limit parameter
   smaller than 50 and use 50 instead.
   ([#3266](https://github.com/Pycord-Development/pycord/pull/3266))

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -40,7 +40,6 @@ __all__ = (
     "EmbedProvider",
 )
 
-
 E = TypeVar("E", bound="Embed")
 
 if TYPE_CHECKING:
@@ -364,7 +363,7 @@ class Embed:
         image: str | EmbedMedia | None = None,
         thumbnail: str | EmbedMedia | None = None,
     ):
-        self.colour = colour if colour else color
+        self.colour = colour if colour is not None else color
         self.title = title
         self.type = type
         self.url = url


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

<!-- If Generative AI (consisting of but not limited to LLMs and Agentic AI systems) 
has been used to partially or entirely produce this pull request (documentation included), 
disclose it here -->
This bug was identified by Anthropic Fable 5, then verified and patched by me.


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [x] AI Usage has been disclosed.
  - [x] If AI has been used, I understand fully what the code does

