### PR TITLE
fix(member): give up deprecated datetime.utcnow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fix use of deprecated `datetime.utcnow()` in `Member.edit` and
-  `Member.request_to_speak`.
-  ([#3259](https://github.com/Pycord-Development/pycord/pull/3259))
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ These changes are available on the `master` branch, but have not yet been releas
 ### Fixed
 
 - Fix use of deprecated `datetime.utcnow()` in `Member.edit` and
-  `Member.request_to_speak`
+  `Member.request_to_speak`.
+  ([#3259](https://github.com/Pycord-Development/pycord/pull/3259))
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fix use of deprecated `datetime.utcnow()` in `Member.edit` and `Member.request_to_speak`
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fix use of deprecated `datetime.utcnow()` in `Member.edit` and `Member.request_to_speak`
+- Fix use of deprecated `datetime.utcnow()` in `Member.edit` and
+  `Member.request_to_speak`
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/discord/member.py
+++ b/discord/member.py
@@ -1172,7 +1172,9 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         payload = {
             "channel_id": self.voice.channel.id,
-            "request_to_speak_timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "request_to_speak_timestamp": datetime.datetime.now(
+                datetime.timezone.utc
+            ).isoformat(),
         }
 
         if self._state.self_id != self.id:

--- a/discord/member.py
+++ b/discord/member.py
@@ -821,8 +821,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         return (
             self.communication_disabled_until is not None
-            and self.communication_disabled_until
-            > utcnow()
+            and self.communication_disabled_until > utcnow()
         )
 
     async def ban(
@@ -1122,9 +1121,7 @@ class Member(discord.abc.Messageable, _UserTag):
         HTTPException
             An error occurred doing the request.
         """
-        await self.timeout(
-            utcnow() + duration, reason=reason
-        )
+        await self.timeout(utcnow() + duration, reason=reason)
 
     async def remove_timeout(self, *, reason: str | None = None) -> None:
         """|coro|

--- a/discord/member.py
+++ b/discord/member.py
@@ -149,7 +149,7 @@ class VoiceState:
         self.self_deaf: bool = data.get("self_deaf", False)
         self.self_stream: bool = data.get("self_stream", False)
         self.self_video: bool = data.get("self_video", False)
-        self.afk: bool = data.get("afk", False)
+        self.afk: bool = data.get("suppress", False)
         self.mute: bool = data.get("mute", False)
         self.deaf: bool = data.get("deaf", False)
         self.suppress: bool = data.get("suppress", False)

--- a/discord/member.py
+++ b/discord/member.py
@@ -48,7 +48,7 @@ from .primary_guild import PrimaryGuild
 from .role import RoleColours
 from .types.collectibles import AvatarDecoration
 from .user import BaseUser, User, _UserTag
-from .utils import MISSING
+from .utils import MISSING, utcnow
 
 __all__ = (
     "VoiceState",
@@ -822,7 +822,7 @@ class Member(discord.abc.Messageable, _UserTag):
         return (
             self.communication_disabled_until is not None
             and self.communication_disabled_until
-            > datetime.datetime.now(datetime.timezone.utc)
+            > utcnow()
         )
 
     async def ban(
@@ -1019,8 +1019,9 @@ class Member(discord.abc.Messageable, _UserTag):
             else:
                 if not suppress:
                     voice_state_payload["request_to_speak_timestamp"] = (
-                        datetime.datetime.now(datetime.timezone.utc).isoformat()
+                        utcnow().isoformat()
                     )
+
                 await http.edit_voice_state(guild_id, self.id, voice_state_payload)
 
         if voice_channel is not MISSING:
@@ -1122,7 +1123,7 @@ class Member(discord.abc.Messageable, _UserTag):
             An error occurred doing the request.
         """
         await self.timeout(
-            datetime.datetime.now(datetime.timezone.utc) + duration, reason=reason
+            utcnow() + duration, reason=reason
         )
 
     async def remove_timeout(self, *, reason: str | None = None) -> None:
@@ -1172,7 +1173,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         payload = {
             "channel_id": self.voice.channel.id,
-            "request_to_speak_timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "request_to_speak_timestamp": utcnow().isoformat(),
         }
 
         if self._state.self_id != self.id:

--- a/discord/member.py
+++ b/discord/member.py
@@ -149,7 +149,7 @@ class VoiceState:
         self.self_deaf: bool = data.get("self_deaf", False)
         self.self_stream: bool = data.get("self_stream", False)
         self.self_video: bool = data.get("self_video", False)
-        self.afk: bool = data.get("suppress", False)
+        self.afk: bool = data.get("afk", False)
         self.mute: bool = data.get("mute", False)
         self.deaf: bool = data.get("deaf", False)
         self.suppress: bool = data.get("suppress", False)
@@ -1019,7 +1019,7 @@ class Member(discord.abc.Messageable, _UserTag):
             else:
                 if not suppress:
                     voice_state_payload["request_to_speak_timestamp"] = (
-                        datetime.datetime.utcnow().isoformat()
+                        datetime.datetime.now(datetime.timezone.utc).isoformat()
                     )
                 await http.edit_voice_state(guild_id, self.id, voice_state_payload)
 
@@ -1172,7 +1172,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         payload = {
             "channel_id": self.voice.channel.id,
-            "request_to_speak_timestamp": datetime.datetime.utcnow().isoformat(),
+            "request_to_speak_timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         }
 
         if self._state.self_id != self.id:


### PR DESCRIPTION
## Summary

Replace deprecated `datetime.datetime.utcnow()` and/or manual `datetime.datetime.now(datetime.timezone.utc)` usage with `utils.utcnow()`  in `discord/members.py`.
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does