### PR TITLE
fix: `PollAnswer.to_dict` sets id as a tuple instead of int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3231](https://github.com/Pycord-Development/pycord/pull/3231))
 - Allow `ForumTag` to be created without an emoji.
   ([#3245](https://github.com/Pycord-Development/pycord/pull/3245))
-- Fix `PollAnswer.to_dict()` incorrectly setting `answer_id` attribute as a tuple instead of an integer.
+- Fix `PollAnswer.to_dict()` incorrectly setting `answer_id` attribute as a tuple
+  instead of an integer.
   ([#3260](https://github.com/Pycord-Development/pycord/pull/3260))
 - Fix an issue where an `Embed` object's `colour` parameter would be ignored when set to
   `0`. ([#3256](https://github.com/Pycord-Development/pycord/pull/3256))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3231](https://github.com/Pycord-Development/pycord/pull/3231))
 - Allow `ForumTag` to be created without an emoji.
   ([#3245](https://github.com/Pycord-Development/pycord/pull/3245))
+- Fix `PollAnswer.to_dict` incorrectly setting `answer_id` as a tuple instead of an int.
+  ([#3260](https://github.com/Pycord-Development/pycord/pull/3260))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3231](https://github.com/Pycord-Development/pycord/pull/3231))
 - Allow `ForumTag` to be created without an emoji.
   ([#3245](https://github.com/Pycord-Development/pycord/pull/3245))
-- Fix `PollAnswer.to_dict` incorrectly setting `answer_id` as a tuple instead of an int.
+- Fix `PollAnswer.to_dict()` incorrectly setting `answer_id` attribute as a tuple instead of an integer.
   ([#3260](https://github.com/Pycord-Development/pycord/pull/3260))
 - Fix an issue where an `Embed` object's `colour` parameter would be ignored when set to
   `0`. ([#3256](https://github.com/Pycord-Development/pycord/pull/3256))

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -41,7 +41,6 @@ __all__ = (
     "Poll",
 )
 
-
 if TYPE_CHECKING:
     from .abc import Snowflake
     from .emoji import AppEmoji, GuildEmoji
@@ -163,7 +162,7 @@ class PollAnswer:
             "poll_media": self.media.to_dict(),
         }
         if self.id is not None:
-            dict_["answer_id"] = (self.id,)
+            dict_["answer_id"] = self.id
         return dict_
 
     @classmethod


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

<!-- If Generative AI (consisting of but not limited to LLMs and Agentic AI systems) 
has been used to partially or entirely produce this pull request (documentation included), 
disclose it here -->
This bug was identified by Anthropic Fable 5, then verified and patched by me.


## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

