### PR TITLE
fix(guild): create_sticker limit error message; implicit None return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fix error message for `Guild.create_sticker`.
+  ([#3263](https://github.com/Pycord-Development/pycord/pull/3263))
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3084,7 +3084,7 @@ class Guild(Hashable):
             raise TypeError('"name" parameter must be 2 to 30 characters long.')
 
         if description and not (2 <= len(description) <= 100):
-            raise TypeError('"description" parameter must be 2 to 200 characters long.')
+            raise TypeError('"description" parameter must be 2 to 100 characters long.')
 
         payload = {"name": name, "description": description or ""}
 
@@ -3327,7 +3327,7 @@ class Guild(Hashable):
         data = await self._state.http.get_role(self.id, role_id)
         return Role(guild=self, state=self._state, data=data)
 
-    async def _fetch_role(self, role_id: int) -> Role:
+    async def _fetch_role(self, role_id: int) -> Role | None:
         """|coro|
 
         Retrieves a :class:`Role` that the guild has.


### PR DESCRIPTION
## Summary

Fixes the error message mismatch with description limit enforcement in  `create_sticker()`;   
Fixes implicit `None` return type in private `_fetch_role` method.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does