### PR TITLE
fix(emoji): return type mismatch

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -364,7 +364,7 @@ class AppEmoji(BaseEmoji):
         return f"<AppEmoji id={self.id} name={self.name!r} animated={self.animated}>"
 
     @property
-    def guild(self) -> Guild:
+    def guild(self) -> None:
         """The guild this emoji belongs to. This is always `None` for :class:`AppEmoji`."""
         return None
 


### PR DESCRIPTION
## Summary

Fixes a return type mismatch on `AppEmoji.guild`, which was annotated as `-> Guild` but always returns `None`. 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

