### PR TITLE
fix(role): ensure secondary and tertiary attributes are not None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fixed `RoleColours.is_holographic` raising `AttributeError` when `secondary` or
+  `tertiary` is `None`.
+  ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed `RoleColours.is_holographic` incorrectly returning `False` when `secondary` or
+- Fixed an `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
   `tertiary` is `None`.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed an `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
   `tertiary` is `None`.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
-- Fixed `Role.edit` not checking if `holographic` is `MISSING`
-  before applying holographic colours.
-  ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
+- Fixed `Role.edit` not checking if `holographic` is `MISSING` before applying
+  holographic colours. ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed an  `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
+- Fixed an `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
   `tertiary` is `None`.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed an `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
   `tertiary` is `None`.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
-- Fixed `Role.edit` not checking if `holographic` is `MISSING`
-  before applying holographic colours.
-  ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,6 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fixed an `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
   `tertiary` is `None`.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
-<<<<<<< HEAD
-=======
-- Fixed `Role.edit` not checking if `holographic` is `MISSING` before applying
-  holographic colours. ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
->>>>>>> d62186cfa8de722a6582656cab6f59020373078f
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))
 - Include `bypass_slowmode` in `Permissions.all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,19 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Added
 
+- Added `RoleColours.HOLOGRAPHIC_PRIMARY`, `RoleColours.HOLOGRAPHIC_SECONDARY`, and
+  `RoleColours.HOLOGRAPHIC_TERTIARY` class constants.
+  ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
+
 ### Changed
 
 ### Fixed
 
 - Fixed an `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
   `tertiary` is `None`.
+  ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
+- Fixed `Role.edit` not checking if `holographic` is `MISSING`
+  before applying holographic colours.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.
   ([#3235](https://github.com/Pycord-Development/pycord/pull/3235))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed an `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
+- Fixed `RoleColours.is_holographic` incorrectly returning `False` when `secondary` or
   `tertiary` is `None`.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
-- Fixed `RoleColours.is_holographic` raising `AttributeError` when `secondary` or
+- Fixed an  `AttributeError` when using `RoleColours.is_holographic` and `secondary` or
   `tertiary` is `None`.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
 - Fix typehint for `SlashCommandGroup.__new__`.

--- a/discord/role.py
+++ b/discord/role.py
@@ -370,7 +370,9 @@ class RoleColours:
         :attr:`HOLOGRAPHIC_PRIMARY`, :attr:`HOLOGRAPHIC_SECONDARY`, and :attr:`HOLOGRAPHIC_TERTIARY`.
         """
         return cls(
-            cls.HOLOGRAPHIC_PRIMARY, cls.HOLOGRAPHIC_SECONDARY, cls.HOLOGRAPHIC_TERTIARY
+            cls.HOLOGRAPHIC_PRIMARY,
+            cls.HOLOGRAPHIC_SECONDARY,
+            cls.HOLOGRAPHIC_TERTIARY,
         )
 
     @property
@@ -866,7 +868,7 @@ class Role(Hashable):
             if isinstance(colour, int):
                 colour = Colour(colour)
             colours = RoleColours(primary=colour)
-        if holographic:
+        if holographic is not MISSING and holographic:
             colours = RoleColours.holographic()
         if colours is not MISSING:
             if not isinstance(colours, RoleColours):

--- a/discord/role.py
+++ b/discord/role.py
@@ -308,8 +308,12 @@ class RoleColours:
     secondary: Optional[:class:`Colour`]
         The secondary colour of the role.
     tertiary: Optional[:class:`Colour`]
-        The tertiary colour of the role. At the moment, only `16761760` is allowed.
+        The tertiary colour of the role. At the moment, only :attr:`HOLOGRAPHIC_TERTIARY` is allowed.
     """
+
+    HOLOGRAPHIC_PRIMARY = Colour(11127295)
+    HOLOGRAPHIC_SECONDARY = Colour(16759788)
+    HOLOGRAPHIC_TERTIARY = Colour(16761760)
 
     def __init__(
         self,
@@ -362,22 +366,26 @@ class RoleColours:
     def holographic(cls) -> RoleColours:
         """Returns a :class:`RoleColours` that makes the role look holographic.
 
-        Currently holographic roles are only supported with colours 11127295, 16759788, and 16761760.
+        Currently holographic roles are only supported with colours defined in
+        :attr:`HOLOGRAPHIC_PRIMARY`, :attr:`HOLOGRAPHIC_SECONDARY`, and :attr:`HOLOGRAPHIC_TERTIARY`.
         """
-        return cls(Colour(11127295), Colour(16759788), Colour(16761760))
+        return cls(
+            cls.HOLOGRAPHIC_PRIMARY, cls.HOLOGRAPHIC_SECONDARY, cls.HOLOGRAPHIC_TERTIARY
+        )
 
     @property
     def is_holographic(self) -> bool:
         """Whether the role is holographic.
 
-        Currently roles are holographic when colours are set to 11127295, 16759788, and 16761760.
+        Currently roles are holographic when colours are set to
+        :attr:`HOLOGRAPHIC_PRIMARY`, :attr:`HOLOGRAPHIC_SECONDARY`, and :attr:`HOLOGRAPHIC_TERTIARY`.
         """
         return (
-            self.primary.value == 11127295
+            self.primary == self.HOLOGRAPHIC_PRIMARY
             and self.secondary is not None
-            and self.secondary.value == 16759788
+            and self.secondary == self.HOLOGRAPHIC_SECONDARY
             and self.tertiary is not None
-            and self.tertiary.value == 16761760
+            and self.tertiary == self.HOLOGRAPHIC_TERTIARY
         )
 
     def __repr__(self) -> str:

--- a/discord/role.py
+++ b/discord/role.py
@@ -390,9 +390,7 @@ class RoleColours:
         """
         return (
             self.primary == self.HOLOGRAPHIC_PRIMARY
-            and self.secondary is not None
             and self.secondary == self.HOLOGRAPHIC_SECONDARY
-            and self.tertiary is not None
             and self.tertiary == self.HOLOGRAPHIC_TERTIARY
         )
 

--- a/discord/role.py
+++ b/discord/role.py
@@ -374,7 +374,9 @@ class RoleColours:
         """
         return (
             self.primary.value == 11127295
+            and self.secondary is not None
             and self.secondary.value == 16759788
+            and self.tertiary is not None
             and self.tertiary.value == 16761760
         )
 

--- a/discord/role.py
+++ b/discord/role.py
@@ -309,6 +309,12 @@ class RoleColours:
         The secondary colour of the role.
     tertiary: Optional[:class:`Colour`]
         The tertiary colour of the role. At the moment, only :attr:`HOLOGRAPHIC_TERTIARY` is allowed.
+    HOLOGRAPHIC_PRIMARY: :class:`Colour`
+            The primary colour used for holographic roles.
+    HOLOGRAPHIC_SECONDARY: :class:`Colour`
+        The secondary colour used for holographic roles.
+    HOLOGRAPHIC_TERTIARY: :class:`Colour`
+        The tertiary colour used for holographic roles.
     """
 
     HOLOGRAPHIC_PRIMARY = Colour(11127295)
@@ -868,7 +874,7 @@ class Role(Hashable):
             if isinstance(colour, int):
                 colour = Colour(colour)
             colours = RoleColours(primary=colour)
-        if holographic is not MISSING and holographic:
+        if holographic:
             colours = RoleColours.holographic()
         if colours is not MISSING:
             if not isinstance(colours, RoleColours):


### PR DESCRIPTION
## Summary

- Fixes `RoleColours.is_holographic` raising `AttributeError` when `secondary` or `tertiary` is `None`;
- Moves holographic colour values to class-level constants to avoid magic numbers.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

