### PR TITLE
chore(reaction): add missing count_details return type annotation

### DIFF
--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -133,7 +133,7 @@ class Reaction:
         return self.burst_colours
 
     @property
-    def count_details(self):
+    def count_details(self) -> ReactionCountDetails:
         """Returns :class:`ReactionCountDetails` for the individual counts of normal and super reactions made."""
         return ReactionCountDetails(self._count_details)
 


### PR DESCRIPTION
## Summary

Adds the missing return type annotation to the `count_details` property on `Reaction`.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

