### PR TITLE
fix(components): double-yield in Section.walk_components

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -850,11 +850,9 @@ class Section(Component):
         return payload
 
     def walk_components(self) -> Iterator[Component]:
-        r = self.components
+        yield from self.components
         if self.accessory:
-            yield from r + [self.accessory]
-        else:
-            yield from r
+            yield self.accessory
 
     def get_component(self, id: str | int) -> Component | None:
         """Get a component from this section. Roughly equivalent to `utils.get(section.walk_components(), ...)`.

--- a/discord/components.py
+++ b/discord/components.py
@@ -853,7 +853,8 @@ class Section(Component):
         r = self.components
         if self.accessory:
             yield from r + [self.accessory]
-        yield from r
+        else:
+            yield from r
 
     def get_component(self, id: str | int) -> Component | None:
         """Get a component from this section. Roughly equivalent to `utils.get(section.walk_components(), ...)`.


### PR DESCRIPTION
## Summary

This PR fixes a bug in _NOT usable by end-users_ `discord.components.Section`, which yielded twice (from both if/else branches), which could cause unexpected output. Furthermore, I've simplified the generator logic.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

