### PR TITLE
fix(flags): decorators and docstrings mismatches; 

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1495,8 +1495,8 @@ class ApplicationFlags(BaseFlags):
 
     @flag_value
     def gateway_message_content_limited(self):
-        """:class:`bool`: Returns ``True`` if the application is currently pending verification
-        and has hit the guild limit.
+        """:class:`bool`: Returns ``True`` if the application is allowed to receive limited
+        message content information over the gateway.
         """
         return 1 << 19
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -765,15 +765,6 @@ class Intents(BaseFlags):
         return 1 << 2
 
     @flag_value
-    def emojis(self):
-        """:class:`bool`: Alias of :attr:`.emojis_and_stickers`.
-
-        .. versionchanged:: 2.0
-            Changed to an alias.
-        """
-        return 1 << 3
-
-    @alias_flag_value
     def emojis_and_stickers(self):
         """:class:`bool`: Whether guild emoji and sticker related events are enabled.
 
@@ -794,6 +785,15 @@ class Intents(BaseFlags):
         - :meth:`Client.stickers`
         - :attr:`Guild.emojis`
         - :attr:`Guild.stickers`
+        """
+        return 1 << 3
+
+    @alias_flag_value
+    def emojis(self):
+        """:class:`bool`: Alias of :attr:`.emojis_and_stickers`.
+
+        .. versionchanged:: 2.0
+            Changed to an alias.
         """
         return 1 << 3
 


### PR DESCRIPTION
## Summary

- Fixed swapped `@flag_value`/`@alias_flag_value` decorators on `emojis`/`emojis_and_stickers`;
- Corrected a copy-paste error in the `gateway_message_content_limited` docstring.

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

