### PR TITLE
fix: swap `SubscriptionStatus` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fix a bug where `TextChannel.archived_threads` would ignore any limit parameter
   smaller than 50 and use 50 instead.
   ([#3266](https://github.com/Pycord-Development/pycord/pull/3266))
+- Fix an issue where `SubscriptionStatus.inactive` and `SubscriptionStatus.ending` were swapped.
+  ([#3278](https://github.com/Pycord-Development/pycord/pull/3278))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fix a bug where `TextChannel.archived_threads` would ignore any limit parameter
   smaller than 50 and use 50 instead.
   ([#3266](https://github.com/Pycord-Development/pycord/pull/3266))
-- Fix an issue where `SubscriptionStatus.inactive` and `SubscriptionStatus.ending` were swapped.
-  ([#3278](https://github.com/Pycord-Development/pycord/pull/3278))
+- Fix an issue where `SubscriptionStatus.inactive` and `SubscriptionStatus.ending` were
+  swapped. ([#3278](https://github.com/Pycord-Development/pycord/pull/3278))
 
 ### Deprecated
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -1115,8 +1115,8 @@ class SubscriptionStatus(Enum):
     """The status of a subscription."""
 
     active = 0
-    ending = 1
-    inactive = 2
+    inactive = 1
+    ending = 2
 
 
 class ThreadArchiveDuration(IntEnum):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

<!-- If Generative AI (consisting of but not limited to LLMs and Agentic AI systems) 
has been used to partially or entirely produce this pull request (documentation included), 
disclose it here -->
[Fix Subscription Status Values](https://docs.discord.com/developers/change-log#documentation-fix-subscription-status-values)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [x] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

