### PR TITLE
fix: guard guild_only against unset contexts (#3282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3266](https://github.com/Pycord-Development/pycord/pull/3266))
 - Fix an issue where `SubscriptionStatus.inactive` and `SubscriptionStatus.ending` were
   swapped. ([#3278](https://github.com/Pycord-Development/pycord/pull/3278))
+- Fix a `TypeError` when accessing `guild_only` on a `SlashCommand` or
+  `SlashCommandGroup` whose `contexts` was never set (e.g. when only
+  `integration_types` is passed).
+  ([#3282](https://github.com/Pycord-Development/pycord/issues/3282))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fix an issue where `SubscriptionStatus.inactive` and `SubscriptionStatus.ending` were
   swapped. ([#3278](https://github.com/Pycord-Development/pycord/pull/3278))
 - Fix a `TypeError` when accessing `guild_only` on a `SlashCommand` or
-  `SlashCommandGroup` whose `contexts` was never set (e.g. when only
-  `integration_types` is passed).
-  ([#3282](https://github.com/Pycord-Development/pycord/issues/3282))
+  `SlashCommandGroup` whose `contexts` was never set (e.g. when only `integration_types`
+  is passed). ([#3282](https://github.com/Pycord-Development/pycord/issues/3282))
 
 ### Deprecated
 

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -310,6 +310,8 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             "2.6",
             reference="https://docs.discord.com/developers/change-log#user-installable-apps-preview",
         )
+        if self.contexts is None:
+            return False
         return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
 
     @guild_only.setter
@@ -1345,6 +1347,8 @@ class SlashCommandGroup(ApplicationCommand):
     @property
     def guild_only(self) -> bool:
         warn_deprecated("guild_only", "contexts", "2.6")
+        if self.contexts is None:
+            return False
         return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
 
     @guild_only.setter

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,104 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Pycord Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+import warnings
+
+import pytest
+
+import discord
+from discord import SlashCommand, SlashCommandGroup
+from discord.enums import InteractionContextType
+
+
+async def _noop(ctx):
+    pass
+
+
+def _guild_only(command) -> bool:
+    # ``guild_only`` is deprecated in favour of ``contexts``; the warning is
+    # expected here and irrelevant to what we are asserting.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return command.guild_only
+
+
+def _slash_command(**kwargs) -> SlashCommand:
+    return SlashCommand(_noop, **kwargs)
+
+
+# Regression test for https://github.com/Pycord-Development/pycord/issues/3282:
+# reading ``guild_only`` raised ``TypeError`` when ``contexts`` was never set
+# (e.g. when only ``integration_types`` was passed), because the getter used the
+# ``in`` operator on ``None``.
+def test_guild_only_is_false_when_contexts_is_unset():
+    command = _slash_command(
+        integration_types={discord.IntegrationType.user_install}
+    )
+
+    assert command.contexts is None
+    assert _guild_only(command) is False
+
+
+def test_group_guild_only_is_false_when_contexts_is_unset():
+    group = SlashCommandGroup("group", "description")
+
+    assert group.contexts is None
+    assert _guild_only(group) is False
+
+
+def test_guild_only_is_true_for_guild_context_only():
+    command = _slash_command(contexts={InteractionContextType.guild})
+
+    assert _guild_only(command) is True
+
+
+def test_guild_only_is_false_for_multiple_contexts():
+    command = _slash_command(
+        contexts={
+            InteractionContextType.guild,
+            InteractionContextType.bot_dm,
+        }
+    )
+
+    assert _guild_only(command) is False
+
+
+def test_guild_only_setter_round_trips():
+    command = _slash_command(contexts={InteractionContextType.guild})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        command.guild_only = False
+        assert command.guild_only is False
+        command.guild_only = True
+        assert command.guild_only is True
+
+    assert command.contexts == {InteractionContextType.guild}
+
+
+def test_guild_only_emits_deprecation_warning():
+    command = _slash_command(contexts={InteractionContextType.guild})
+
+    with pytest.warns(DeprecationWarning):
+        command.guild_only

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -52,9 +52,7 @@ def _slash_command(**kwargs) -> SlashCommand:
 # (e.g. when only ``integration_types`` was passed), because the getter used the
 # ``in`` operator on ``None``.
 def test_guild_only_is_false_when_contexts_is_unset():
-    command = _slash_command(
-        integration_types={discord.IntegrationType.user_install}
-    )
+    command = _slash_command(integration_types={discord.IntegrationType.user_install})
 
     assert command.contexts is None
     assert _guild_only(command) is False


### PR DESCRIPTION
Reading guild_only on a SlashCommand or SlashCommandGroup raised TypeError: argument of type 'NoneType' is not iterable when contexts was never set (e.g. only integration_types was passed), because the getter used the in operator on None.

An unset contexts means no restriction, so guild_only now returns False in that case instead of raising. Adds regression tests covering the unset, guild-only, and multi-context paths plus the setter round-trip.

## Summary

Reading `guild_only` on a `SlashCommand` or `SlashCommandGroup` raised
`TypeError: argument of type 'NoneType' is not iterable` when `contexts`
was never set (e.g. only `integration_types` was passed), because the
getter used the `in` operator on `None`.

An unset `contexts` means no restriction, so `guild_only` now returns
`False` in that case instead of raising. Adds regression tests covering
the unset, guild-only, and multi-context paths plus the setter round-trip.

Closes #3282.

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

