### PR TITLE
feat: add rotterdam to VoiceRegion (#3215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Added `RoleColours.HOLOGRAPHIC_PRIMARY`, `RoleColours.HOLOGRAPHIC_SECONDARY`, and
   `RoleColours.HOLOGRAPHIC_TERTIARY` class constants.
   ([#3268](https://github.com/Pycord-Development/pycord/pull/3268))
+- Added the `rotterdam` value to `VoiceRegion`.
+  ([#3215](https://github.com/Pycord-Development/pycord/issues/3215))
 
 ### Changed
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -299,6 +299,7 @@ class VoiceRegion(Enum):
     london = "london"
     sydney = "sydney"
     amsterdam = "amsterdam"
+    rotterdam = "rotterdam"
     frankfurt = "frankfurt"
     brazil = "brazil"
     hongkong = "hongkong"

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,36 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Pycord Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from discord.enums import VoiceRegion, try_enum
+
+
+# Regression test for https://github.com/Pycord-Development/pycord/issues/3215:
+# Discord now returns the "rotterdam" voice region, which was missing from the
+# enum, so resolving it fell back to an unknown value.
+def test_rotterdam_voice_region_resolves():
+    region = try_enum(VoiceRegion, "rotterdam")
+
+    assert region is VoiceRegion.rotterdam
+    assert region.value == "rotterdam"
+    assert str(region) == "rotterdam"


### PR DESCRIPTION
Discord's API now returns the rotterdam voice region, which was absent from the VoiceRegion enum, so it failed to resolve to a known member. Adds the missing value and a regression test. Deprecated regions are left in place to avoid breaking existing references.

## Summary

Discord's API now returns the `rotterdam` voice region, which was absent from
the `VoiceRegion` enum, so it failed to resolve to a known member. Adds the
missing value and a regression test. Deprecated regions are left in place to
avoid breaking existing references.

Closes #3215.

## Information

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

