### PR TITLE
fix(commands): prevent crash when syncing with delete_existing=False

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -409,6 +409,7 @@ class ApplicationCommandMixin(ABC):
                         "command": registered_commands_dict[cmd]["name"],
                         "id": int(value_["id"]),
                         "action": "delete",
+                        "raw": value_,
                     }
                 )
 
@@ -570,10 +571,11 @@ class ApplicationCommandMixin(ABC):
                 if cmd["action"] == "delete":
                     pending_actions.append(
                         {
-                            "action": "delete" if delete_existing else None,
+                            "action": "delete" if delete_existing else "keep",
                             "command": collections.namedtuple("Command", ["name"])(
                                 name=cmd["command"]
                             ),
+                            "raw": cmd.get("raw"),
                             "id": cmd["id"],
                         }
                     )
@@ -607,7 +609,10 @@ class ApplicationCommandMixin(ABC):
                 else:
                     raise ValueError(f"Unknown action: {cmd['action']}")
             filtered_no_action = list(
-                filter(lambda c: c["action"] is not None, pending_actions)
+                filter(
+                    lambda c: c["action"] is not None and c["action"] != "keep",
+                    pending_actions,
+                )
             )
             filtered_deleted = list(
                 filter(lambda a: a["action"] != "delete", pending_actions)
@@ -616,7 +621,11 @@ class ApplicationCommandMixin(ABC):
                 method == "auto" and len(filtered_deleted) == len(pending)
             ):
                 # Either the method is bulk or all the commands need to be modified, so we can just do a bulk upsert
-                data = [cmd["command"].to_dict() for cmd in filtered_deleted]
+                data = [
+                    cmd["raw"] if cmd["action"] == "keep" else cmd["command"].to_dict()
+                    for cmd in filtered_deleted
+                    if cmd["action"] != "keep" or cmd.get("raw") is not None
+                ]
                 # If there's nothing to update, don't bother
                 if len(filtered_no_action) == 0:
                     _log.debug("Skipping bulk command update: Commands are up to date")
@@ -677,6 +686,12 @@ class ApplicationCommandMixin(ABC):
             data = [cmd.to_dict() for cmd in pending]
             registered = await register("bulk", data, guild_id=guild_id)
 
+        kept_names = {
+            action["command"].name
+            for action in pending_actions
+            if action["action"] == "keep"
+        }
+
         for i in registered:
             cmd = get(
                 self.pending_application_commands,
@@ -684,6 +699,8 @@ class ApplicationCommandMixin(ABC):
                 type=i.get("type"),
             )
             if not cmd:
+                if i["name"] in kept_names:
+                    continue
                 raise ValueError(
                     f"Registered command {i['name']}, type {i.get('type')} not found in"
                     " pending commands"


### PR DESCRIPTION
## Summary

`sync_commands(delete_existing=False)` crashed with `AttributeError: 'Command' object has no attribute 'to_dict'` when Discord had a command that the bot didn't define locally. 
Now these commands are assigned the `keep` action and are forwarded unchanged, so Discord retains them instead of the sync crashing.
A wrapper class was suggested in the issue instead of the `namedtuple`. I passed the raw data directly, since Discord already provides the complete command.

Closes #3277

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [x] I have read the Contributing Guidelines.