### PR TITLE
fix: guard guild_only against unset contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fix `TypeError` when accessing the deprecated `guild_only` property on an
+  application command or command group created without `contexts`.
+  ([#3283](https://github.com/Pycord-Development/pycord/pull/3283))
+
 ### Deprecated
 
 ### Removed

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -306,7 +306,11 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             "2.6",
             reference="https://docs.discord.com/developers/change-log#user-installable-apps-preview",
         )
-        return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
+        return (
+            self.contexts is not None
+            and InteractionContextType.guild in self.contexts
+            and len(self.contexts) == 1
+        )
 
     @guild_only.setter
     def guild_only(self, value: bool) -> None:
@@ -1341,7 +1345,11 @@ class SlashCommandGroup(ApplicationCommand):
     @property
     def guild_only(self) -> bool:
         warn_deprecated("guild_only", "contexts", "2.6")
-        return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
+        return (
+            self.contexts is not None
+            and InteractionContextType.guild in self.contexts
+            and len(self.contexts) == 1
+        )
 
     @guild_only.setter
     def guild_only(self, value: bool) -> None:

--- a/tests/test_application_commands.py
+++ b/tests/test_application_commands.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`discord.commands.core`."""
+
+import pytest
+
+import discord
+
+
+def _make_group() -> discord.SlashCommandGroup:
+    return discord.SlashCommandGroup(
+        name="music",
+        description="Music commands",
+        integration_types={discord.IntegrationType.guild_install},
+    )
+
+
+def _make_command() -> discord.SlashCommand:
+    @discord.slash_command(
+        integration_types={discord.IntegrationType.guild_install},
+    )
+    async def music(ctx):
+        pass
+
+    return music
+
+
+@pytest.mark.parametrize("factory", [_make_group, _make_command])
+def test_guild_only_without_contexts(factory):
+    """`guild_only` must not raise when `contexts` was never supplied."""
+    command = factory()
+    assert command.contexts is None
+    with pytest.warns(DeprecationWarning):
+        assert command.guild_only is False
+
+
+@pytest.mark.parametrize("factory", [_make_group, _make_command])
+def test_guild_only_with_guild_context(factory):
+    command = factory()
+    command.contexts = {discord.InteractionContextType.guild}
+    with pytest.warns(DeprecationWarning):
+        assert command.guild_only is True


### PR DESCRIPTION
Closes #3282

`contexts` defaults to `None`, so accessing the deprecated `guild_only` property on a command or `SlashCommandGroup` created with `integration_types` but no `contexts` raised `TypeError: argument of type 'NoneType' is not a container or iterable`. Both properties now check `contexts is not None` first and return `False` instead of raising.

Added `tests/test_application_commands.py`, which fails on master with the reported `TypeError` and passes with this change.
