### PR TITLE
fix: guard guild_only against unset contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fixed `TypeError` when accessing the deprecated `guild_only` property on an
+  application command or command group created without `contexts`.
+  ([#3319](https://github.com/Pycord-Development/pycord/pull/3319))
+
 ### Deprecated
 
 ### Removed

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -306,7 +306,11 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             "2.6",
             reference="https://docs.discord.com/developers/change-log#user-installable-apps-preview",
         )
-        return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
+        return (
+            self.contexts is not None
+            and InteractionContextType.guild in self.contexts
+            and len(self.contexts) == 1
+        )
 
     @guild_only.setter
     def guild_only(self, value: bool) -> None:
@@ -1341,7 +1345,11 @@ class SlashCommandGroup(ApplicationCommand):
     @property
     def guild_only(self) -> bool:
         warn_deprecated("guild_only", "contexts", "2.6")
-        return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
+        return (
+            self.contexts is not None
+            and InteractionContextType.guild in self.contexts
+            and len(self.contexts) == 1
+        )
 
     @guild_only.setter
     def guild_only(self, value: bool) -> None:

--- a/tests/test_application_commands.py
+++ b/tests/test_application_commands.py
@@ -1,0 +1,66 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Pycord Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+import warnings
+
+from discord import InteractionContextType
+from discord.commands import SlashCommand, SlashCommandGroup
+
+
+async def _callback(ctx):
+    pass
+
+
+def _guild_only(command):
+    # guild_only is deprecated, so silence the warning the getter emits.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return command.guild_only
+
+
+def test_guild_only_without_contexts():
+    command = SlashCommand(_callback, name="test", description="test")
+    group = SlashCommandGroup("test", "test")
+
+    assert command.contexts is None
+    assert group.contexts is None
+
+    assert _guild_only(command) is False
+    assert _guild_only(group) is False
+
+
+def test_guild_only_with_contexts():
+    command = SlashCommand(
+        _callback,
+        name="test",
+        description="test",
+        contexts={InteractionContextType.guild},
+    )
+    assert _guild_only(command) is True
+
+    command.contexts = {
+        InteractionContextType.guild,
+        InteractionContextType.bot_dm,
+    }
+    assert _guild_only(command) is False


### PR DESCRIPTION
## Summary

`ApplicationCommand.guild_only` and `SlashCommandGroup.guild_only` raise `TypeError: argument of type 'NoneType' is not iterable` when the command was created without `contexts`, because both getters run `in` against `self.contexts` while it is still `None`.

Reproducer on `master`:

```python
from discord.commands import SlashCommandGroup

group = SlashCommandGroup("g", "d")
print(group.contexts)     # None
print(group.guild_only)   # TypeError: argument of type 'NoneType' is not iterable
```

Both getters now guard `self.contexts is not None` first. An unset `contexts` means no restriction, so `guild_only` returns `False` instead of raising. This is the fix described by @vmphase in #3282.

Added `tests/test_application_commands.py` covering the unset case and the existing guild-only and multi-context cases. Reverting the change in `discord/commands/core.py` makes `test_guild_only_without_contexts` fail with the original `TypeError`, and restoring it passes.

Supersedes #3318, which was closed automatically for not following this template.

Fixes #3282

## Information

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, ...).

## Checklist

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, ...).
- [x] I have read the [Contributing Guidelines](https://github.com/Pycord-Development/pycord/blob/master/CONTRIBUTING.md)
- [x] AI Usage has been disclosed. This patch was written with AI assistance; the reproducer, the test, and the revert-to-fail check were run locally against this branch.
