### PR TITLE
fix(command/core): guard guild_only getters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These changes are available on the `master` branch, but have not yet been releas
 
 ### Fixed
 
+- Fix `TypeError` when accessing `ApplicationCommand.guild_only` or
+  `SlashCommandGroup.guild_only` when `contexts` is `None`.
+  ([#3320](https://github.com/Pycord-Development/pycord/pull/3320))
+
 ### Deprecated
 
 ### Removed

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -925,7 +925,9 @@ class SlashCommand(ApplicationCommand):
     def _is_typing_union(self, annotation):
         return getattr(annotation, "__origin__", None) is Union or type(
             annotation
-        ) is getattr(types, "UnionType", Union)  # type: ignore
+        ) is getattr(
+            types, "UnionType", Union
+        )  # type: ignore
 
     def _is_typing_optional(self, annotation):
         return self._is_typing_union(annotation) and type(None) in annotation.__args__  # type: ignore

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -306,7 +306,11 @@ class ApplicationCommand(_BaseCommand, Generic[CogT, P, T]):
             "2.6",
             reference="https://docs.discord.com/developers/change-log#user-installable-apps-preview",
         )
-        return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
+        return (
+            self.contexts is not None
+            and InteractionContextType.guild in self.contexts
+            and len(self.contexts) == 1
+        )
 
     @guild_only.setter
     def guild_only(self, value: bool) -> None:
@@ -921,9 +925,7 @@ class SlashCommand(ApplicationCommand):
     def _is_typing_union(self, annotation):
         return getattr(annotation, "__origin__", None) is Union or type(
             annotation
-        ) is getattr(
-            types, "UnionType", Union
-        )  # type: ignore
+        ) is getattr(types, "UnionType", Union)  # type: ignore
 
     def _is_typing_optional(self, annotation):
         return self._is_typing_union(annotation) and type(None) in annotation.__args__  # type: ignore
@@ -1341,7 +1343,11 @@ class SlashCommandGroup(ApplicationCommand):
     @property
     def guild_only(self) -> bool:
         warn_deprecated("guild_only", "contexts", "2.6")
-        return InteractionContextType.guild in self.contexts and len(self.contexts) == 1
+        return (
+            self.contexts is not None
+            and InteractionContextType.guild in self.contexts
+            and len(self.contexts) == 1
+        )
 
     @guild_only.setter
     def guild_only(self, value: bool) -> None:


### PR DESCRIPTION
## Summary

Fixes #3282.  
_P.S.: Opened proactively to prevent AI bots from being triggered by the issue into opening sloppy PRs._

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [x] I have read the [Contributing Guidelines](https://github.com/Pycord-Development/pycord/blob/master/CONTRIBUTING.md).
- [x] AI Usage has been disclosed.
  - [x] If AI has been used, I understand fully what the code does

