### PR TITLE
fix(gateway; voice/reader): SyntaxWarning about return in a finally block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ These changes are available on the `master` branch, but have not yet been releas
 - Fix `TypeError` when accessing `ApplicationCommand.guild_only` or
   `SlashCommandGroup.guild_only` when `contexts` is `None`.
   ([#3320](https://github.com/Pycord-Development/pycord/pull/3320))
+- Fix `SyntaxWarning` about `return` in a `finally` block raised on Python 3.14+
+  ([#3332](https://github.com/Pycord-Development/pycord/pull/3332))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ These changes are available on the `master` branch, but have not yet been releas
   `SlashCommandGroup.guild_only` when `contexts` is `None`.
   ([#3320](https://github.com/Pycord-Development/pycord/pull/3320))
 - Fix `SyntaxWarning` about `return` in a `finally` block raised on Python 3.14+
-  ([#3332](https://github.com/Pycord-Development/pycord/pull/3332))
+  ([#3332](https://github.com/Pycord-Development/pycord/pull/3334))
 
 ### Deprecated
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -169,13 +169,13 @@ class KeepAliveHandler(threading.Thread):
 
                 try:
                     f.result()
-                except Exception:
+                except BaseException:
                     _log.exception(
                         "An error occurred while stopping the gateway. Ignoring."
                     )
                 finally:
                     self.stop()
-                    return
+                return
 
             data = self.get_payload()
             _log.debug(self.msg, self.shard_id, data["d"])

--- a/discord/voice/receive/reader.py
+++ b/discord/voice/receive/reader.py
@@ -172,8 +172,8 @@ class AudioReader:
         return len(data) == 74 and data[1] == 0x02
 
     def callback(self, packet_data: bytes) -> None:
-
         packet = rtp_packet = rtcp_packet = None
+        pending_exc: BaseException | None = None
 
         try:
             if not is_rtcp(packet_data):
@@ -181,7 +181,6 @@ class AudioReader:
                 packet.decrypted_data = self.decryptor.decrypt_rtp(packet)  # type: ignore
             else:
                 packet = rtcp_packet = decode(packet_data)
-
                 if not isinstance(packet, ReceiverReportPacket):
                     _log.info(
                         "Received unexpected rtcp packet type=%s, %s",
@@ -198,19 +197,24 @@ class AudioReader:
             _log.exception(
                 "An exception occurred while decoding voice packets", exc_info=exc
             )
-        finally:
-            if self.error:
-                _log.debug("Callback errored out, stopping: %s", self.error)
-                self.stop()
-                return
-            if not packet:
-                _log.debug("No packet found after callback")
-                return
+        except BaseException as exc:
+            pending_exc = exc
+
+        if self.error:
+            _log.debug("Callback errored out, stopping: %s", self.error)
+            self.stop()
+            return
+
+        if not packet:
+            _log.debug("No packet found after callback")
+            return
+
+        if pending_exc is not None:
+            raise pending_exc
 
         if rtcp_packet:
             self.packet_router.feed_rtcp(rtcp_packet)  # type: ignore
         elif rtp_packet:
-
             if not rtp_packet.decrypted_data:
                 _log.debug(
                     "No decrypted data for RTP packet, this should be safe to ignore."


### PR DESCRIPTION
## Summary

This PR fixes #3332:
`SyntaxWarning: 'return' in a 'finally' block` (introduced in Python 3.14) in two places (ruff `B012`)

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [x] I have read the [Contributing Guidelines](https://github.com/Pycord-Development/pycord/blob/master/CONTRIBUTING.md).
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

