### PR TITLE
fix: correct 'option' to 'options' kwarg in Label.set_radio_group() and set_checkbox_group()

### DIFF
--- a/discord/ui/label.py
+++ b/discord/ui/label.py
@@ -432,7 +432,7 @@ class Label(ModalItem[M]):
 
         radio = RadioGroup(
             custom_id=custom_id,
-            option=options,
+            options=options,
             required=required,
             id=id,
         )
@@ -474,7 +474,7 @@ class Label(ModalItem[M]):
 
         checkboxes = CheckboxGroup(
             custom_id=custom_id,
-            option=options,
+            options=options,
             min_values=min_values,
             max_values=max_values,
             required=required,


### PR DESCRIPTION
## Summary
Fixed two typos in `discord/ui/label.py`:
- `Label.set_radio_group()`: `option=options` → `options=options`
- `Label.set_checkbox_group()`: `option=options` → `options=options`

Both `RadioGroup` and `CheckboxGroup` constructors expect `options` (plural) not `option` (singular). This fixes a `TypeError: RadioGroup.__init__() got an unexpected keyword argument 'option'` when calling either method.

## Fixes
Fixes #3331