### PR TITLE
feat: Deprecate d.py-style `is_x` getters

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -30,7 +30,6 @@ import os
 from typing import TYPE_CHECKING, Any, Literal
 
 import yarl
-from typing_extensions import deprecated
 
 from . import utils
 from .errors import DiscordException, InvalidArgument
@@ -150,17 +149,12 @@ class Asset(AssetMixin):
             Returns the asset's url's hash.
 
             This is equivalent to hash(:attr:`url`).
-
-    Attributes
-    ----------
-    animated: :class:`bool`
-        Whether the asset is animated.
     """
 
     __slots__: tuple[str, ...] = (
         "_state",
         "_url",
-        "animated",
+        "_animated",
         "_key",
     )
 
@@ -169,7 +163,7 @@ class Asset(AssetMixin):
     def __init__(self, state, *, url: str, key: str, animated: bool = False):
         self._state = state
         self._url = url
-        self.animated = animated
+        self._animated = animated
         self._key = key
 
     @classmethod
@@ -383,17 +377,9 @@ class Asset(AssetMixin):
         """Returns the identifying key of the asset."""
         return self._key
 
-    @deprecated(
-        "Asset.is_animated() is deprecated since version 2.9, consider using Asset.animated instead"
-    )
     def is_animated(self) -> bool:
-        """Returns whether the asset is animated.
-
-        .. deprecated:: 2.9
-
-            Use :attr:`animated` instead.
-        """
-        return self.animated
+        """Returns whether the asset is animated."""
+        return self._animated
 
     def replace(
         self,

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -30,6 +30,7 @@ import os
 from typing import TYPE_CHECKING, Any, Literal
 
 import yarl
+from typing_extensions import deprecated
 
 from . import utils
 from .errors import DiscordException, InvalidArgument
@@ -149,12 +150,17 @@ class Asset(AssetMixin):
             Returns the asset's url's hash.
 
             This is equivalent to hash(:attr:`url`).
+
+    Attributes
+    ----------
+    animated: :class:`bool`
+        Whether the asset is animated.
     """
 
     __slots__: tuple[str, ...] = (
         "_state",
         "_url",
-        "_animated",
+        "animated",
         "_key",
     )
 
@@ -163,7 +169,7 @@ class Asset(AssetMixin):
     def __init__(self, state, *, url: str, key: str, animated: bool = False):
         self._state = state
         self._url = url
-        self._animated = animated
+        self.animated = animated
         self._key = key
 
     @classmethod
@@ -377,9 +383,17 @@ class Asset(AssetMixin):
         """Returns the identifying key of the asset."""
         return self._key
 
+    @deprecated(
+        "Asset.is_animated() is deprecated since version 2.9, consider using Asset.animated instead"
+    )
     def is_animated(self) -> bool:
-        """Returns whether the asset is animated."""
-        return self._animated
+        """Returns whether the asset is animated.
+
+        .. deprecated:: 2.9
+
+            Use :attr:`animated` instead.
+        """
+        return self.animated
 
     def replace(
         self,

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -136,7 +136,7 @@ class ApplicationCommandMixin(ABC):
         command: :class:`.ApplicationCommand`
             The command to add.
         """
-        if isinstance(command, SlashCommand) and command.is_subcommand:
+        if isinstance(command, SlashCommand) and command.subcommand:
             raise TypeError("The provided command is a sub-command of group")
 
         if self._bot.debug_guilds and command.guild_ids is None:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -313,8 +313,15 @@ class _TextChannel(discord.abc.GuildChannel, Hashable):
             if thread.parent_id == self.id
         ]
 
+    @deprecated(
+        "Channel.is_nsfw() is deprecated since version 2.9, consider using Channel.nsfw instead"
+    )
     def is_nsfw(self) -> bool:
-        """Checks if the channel is NSFW."""
+        """Checks if the channel is NSFW.
+
+        .. deprecated:: 2.9
+            Use :attr:`nsfw` instead.
+        """
         return self.nsfw
 
     @property
@@ -751,10 +758,6 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
         :attr:`~Permissions.manage_messages` bypass slowmode.
     nsfw: :class:`bool`
         If the channel is marked as "not safe for work".
-
-        .. note::
-
-            To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
     default_auto_archive_duration: :class:`int`
         The default auto archive duration in minutes for threads created in this channel.
 
@@ -784,14 +787,21 @@ class TextChannel(discord.abc.Messageable, _TextChannel):
     async def _get_channel(self) -> TextChannel:
         return self
 
+    @deprecated(
+        "TextChannel.is_news() is deprecated since version 2.9, consider using TextChannel.news instead"
+    )
     def is_news(self) -> bool:
-        """Checks if the channel is a news/announcements channel."""
-        return self._type == ChannelType.news.value
+        """Checks if the channel is a news/announcements channel.
+
+        .. deprecated:: 2.9
+            Use :attr:`news` instead.
+        """
+        return self.news
 
     @property
     def news(self) -> bool:
-        """Equivalent to :meth:`is_news`."""
-        return self.is_news()
+        """Checks if the channel is a news/announcements channel."""
+        return self._type == ChannelType.news.value
 
     @overload
     async def edit(
@@ -1811,8 +1821,15 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
     async def _get_channel(self):
         return self
 
+    @deprecated(
+        "VoiceChannel.is_nsfw() is deprecated since version 2.9, consider using VoiceChannel.nsfw instead."
+    )
     def is_nsfw(self) -> bool:
-        """Checks if the channel is NSFW."""
+        """Checks if the channel is NSFW.
+
+        .. deprecated:: 2.9
+            Use :attr:`nsfw` instead.
+        """
         return self.nsfw
 
     @property
@@ -2399,8 +2416,15 @@ class StageChannel(discord.abc.Messageable, VocalGuildChannel):
     async def _get_channel(self):
         return self
 
+    @deprecated(
+        "StageChannel.is_nsfw() is deprecated since version 2.9, consider using StageChannel.nsfw instead"
+    )
     def is_nsfw(self) -> bool:
-        """Checks if the channel is NSFW."""
+        """Checks if the channel is NSFW.
+
+        .. deprecated:: 2.9
+            Use :attr:`nsfw` instead.
+        """
         return self.nsfw
 
     @property

--- a/discord/client.py
+++ b/discord/client.py
@@ -237,6 +237,8 @@ class Client:
         The WebSocket gateway the client is currently connected to. Could be ``None``.
     loop: :class:`asyncio.AbstractEventLoop`
         The event loop that the client uses for asynchronous operations.
+    closed: :class:`bool`
+        Indicates if the WebSocket connection is closed.
     """
 
     def __init__(
@@ -277,7 +279,7 @@ class Client:
         self._enable_debug_events: bool = options.pop("enable_debug_events", False)
         self._connection: ConnectionState = self._get_state(**options)
         self._connection.shard_count = self.shard_count
-        self._closed: bool = False
+        self.closed: bool = False
         self._ready: asyncio.Event = asyncio.Event()
         self._connection._get_websocket = self._get_websocket
         self._connection._get_client = lambda: self
@@ -337,6 +339,9 @@ class Client:
         ws = self.ws
         return float("nan") if not ws else ws.latency
 
+    @deprecated(
+        "Client.is_ws_ratelimited() is deprecated since version 2.9, consider using Client.ws_ratelimited instead."
+    )
     def is_ws_ratelimited(self) -> bool:
         """Whether the WebSocket is currently rate limited.
 
@@ -344,6 +349,18 @@ class Client:
         using HTTP or via the gateway.
 
         .. versionadded:: 1.6
+
+        .. deprecated:: 2.9
+            Use :attr:`ws_ratelimited` instead.
+        """
+        return self.ws_ratelimited
+
+    @property
+    def ws_ratelimited(self) -> bool:
+        """Whether the WebSocket is currently rate limited.
+
+        This can be useful to know when deciding whether you should query members
+        using HTTP or via the gateway.
         """
         if self.ws:
             return self.ws.is_ratelimited()
@@ -447,7 +464,19 @@ class Client:
         """
         return self._connection.application_flags  # type: ignore
 
+    @deprecated(
+        "Client.is_ready() is deprecated since version 2.9, consider using Client.ready instead"
+    )
     def is_ready(self) -> bool:
+        """Specifies if the client's internal cache is ready for use.
+
+        .. deprecated:: 2.9
+            Use :attr:`ready` instead.
+        """
+        return self.ready
+
+    @property
+    def ready(self) -> bool:
         """Specifies if the client's internal cache is ready for use."""
         return self._ready.is_set()
 
@@ -779,11 +808,11 @@ class Client:
 
         Closes the connection to Discord.
         """
-        if self._closed:
+        if self.closed:
             return
 
         await self.http.close()
-        self._closed = True
+        self.closed = True
 
         for voice in self.voice_clients:
             try:
@@ -804,7 +833,7 @@ class Client:
         and :meth:`is_ready` both return ``False`` along with the bot's internal
         cache cleared.
         """
-        self._closed = False
+        self.closed = False
         self._ready.clear()
         self._connection.clear()
         self.http.recreate()
@@ -884,9 +913,16 @@ class Client:
 
     # properties
 
+    @deprecated(
+        "Client.is_closed() is deprecated since version 2.9, consider using Client.closed instead."
+    )
     def is_closed(self) -> bool:
-        """Indicates if the WebSocket connection is closed."""
-        return self._closed
+        """Indicates if the WebSocket connection is closed.
+
+        .. deprecated:: 2.9
+            Use :attr:`closed` instead.
+        """
+        return self.closed
 
     @property
     def activity(self) -> ActivityTypes | None:

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -956,7 +956,7 @@ class SlashCommand(ApplicationCommand):
             self._validate_parameters()
 
     @property
-    def is_subcommand(self) -> bool:
+    def subcommand(self) -> bool:
         return self.parent is not None
 
     @property
@@ -973,7 +973,7 @@ class SlashCommand(ApplicationCommand):
             as_dict["name_localizations"] = self.name_localizations
         if self.description_localizations is not MISSING:
             as_dict["description_localizations"] = self.description_localizations
-        if self.is_subcommand:
+        if self.subcommand:
             as_dict["type"] = SlashCommandOptionType.sub_command.value
 
         if self.nsfw is not None:
@@ -984,7 +984,7 @@ class SlashCommand(ApplicationCommand):
                 self.default_member_permissions.value
             )
 
-        if not self.guild_ids and not self.is_subcommand:
+        if not self.guild_ids and not self.subcommand:
             as_dict["integration_types"] = [it.value for it in self.integration_types]
             as_dict["contexts"] = [ctx.value for ctx in self.contexts]
 

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Literal
 
+from typing_extensions import deprecated
+
 from .asset import Asset, AssetMixin
 from .partial_emoji import PartialEmoji, _EmojiTag
 from .user import User
@@ -211,11 +213,26 @@ class GuildEmoji(BaseEmoji):
         """The guild this emoji belongs to."""
         return self._state._get_guild(self.guild_id)
 
+    @deprecated(
+        "GuildEmoji.is_usable() is deprecated since version 2.9, consider using GuildEmoji.usable instead"
+    )
     def is_usable(self) -> bool:
         """Whether the bot can use this emoji.
 
         .. versionadded:: 1.3
+        .. deprecated:: 2.9
+            Use :attr:`usable` instead.
         """
+        if not self.available:
+            return False
+        if not self._roles:
+            return True
+        emoji_roles, my_roles = self._roles, self.guild.me._roles
+        return any(my_roles.has(role_id) for role_id in emoji_roles)
+
+    @property
+    def usable(self) -> bool:
+        """Whether the bot can use this emoji."""
         if not self.available:
             return False
         if not self._roles:
@@ -374,7 +391,19 @@ class AppEmoji(BaseEmoji):
         """A :class:`list` of roles that is allowed to use this emoji. This is always empty for :class:`AppEmoji`."""
         return []
 
+    @deprecated(
+        "AppEmoji.is_usable() is deprecated since version 2.9, consider using AppEmoji.usable instead"
+    )
     def is_usable(self) -> bool:
+        """Whether the bot can use this emoji.
+
+        .. deprecated:: 2.9
+            Use :attr:`usable` instead.
+        """
+        return self.application_id == self._state.application_id
+
+    @property
+    def usable(self) -> bool:
         """Whether the bot can use this emoji."""
         return self.application_id == self._state.application_id
 

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -223,12 +223,7 @@ class GuildEmoji(BaseEmoji):
         .. deprecated:: 2.9
             Use :attr:`usable` instead.
         """
-        if not self.available:
-            return False
-        if not self._roles:
-            return True
-        emoji_roles, my_roles = self._roles, self.guild.me._roles
-        return any(my_roles.has(role_id) for role_id in emoji_roles)
+        return self.usable
 
     @property
     def usable(self) -> bool:
@@ -400,7 +395,7 @@ class AppEmoji(BaseEmoji):
         .. deprecated:: 2.9
             Use :attr:`usable` instead.
         """
-        return self.application_id == self._state.application_id
+        return self.usable
 
     @property
     def usable(self) -> bool:

--- a/discord/message.py
+++ b/discord/message.py
@@ -40,6 +40,8 @@ from typing import (
 )
 from urllib.parse import parse_qs, urlparse
 
+from typing_extensions import deprecated
+
 from . import utils
 from .channel import PartialMessageable
 from .components import _component_factory
@@ -275,7 +277,19 @@ class Attachment(Hashable):
             return None
         return datetime.datetime.utcfromtimestamp(int(self._is, 16))
 
+    @deprecated(
+        "Attachment.is_spoiler() is deprecated since version 2.9, consider using Attachment.spoiler instead"
+    )
     def is_spoiler(self) -> bool:
+        """Whether this attachment contains a spoiler.
+
+        .. deprecated:: 2.9
+            Use :attr:`spoiler` instead.
+        """
+        return self.filename.startswith("SPOILER_")
+
+    @property
+    def spoiler(self) -> bool:
         """Whether this attachment contains a spoiler."""
         return self.filename.startswith("SPOILER_")
 
@@ -1505,6 +1519,9 @@ class Message(Hashable):
     def poll(self) -> Poll | None:
         return self._state._polls.get(self.id)
 
+    @deprecated(
+        "Message.is_system() is deprecated since version 2.9, consider using Message.system instead"
+    )
     def is_system(self) -> bool:
         """Whether the message is a system message.
 
@@ -1512,6 +1529,23 @@ class Message(Hashable):
         in response to something.
 
         .. versionadded:: 1.3
+
+        .. deprecated:: 2.9
+            Use :attr:`system` instead.
+        """
+        return self.type not in (
+            MessageType.default,
+            MessageType.reply,
+            MessageType.application_command,
+            MessageType.thread_starter_message,
+        )
+
+    @property
+    def system(self) -> bool:
+        """Whether the message is a system message.
+
+        A system message is a message that is constructed entirely by the Discord API
+        in response to something.
         """
         return self.type not in (
             MessageType.default,

--- a/discord/message.py
+++ b/discord/message.py
@@ -286,7 +286,7 @@ class Attachment(Hashable):
         .. deprecated:: 2.9
             Use :attr:`spoiler` instead.
         """
-        return self.filename.startswith("SPOILER_")
+        return self.spoiler
 
     @property
     def spoiler(self) -> bool:
@@ -1533,12 +1533,7 @@ class Message(Hashable):
         .. deprecated:: 2.9
             Use :attr:`system` instead.
         """
-        return self.type not in (
-            MessageType.default,
-            MessageType.reply,
-            MessageType.application_command,
-            MessageType.thread_starter_message,
-        )
+        return self.system
 
     @property
     def system(self) -> bool:

--- a/discord/player.py
+++ b/discord/player.py
@@ -41,6 +41,8 @@ from collections.abc import Callable
 from math import floor
 from typing import IO, TYPE_CHECKING, Any, Generic, TypeVar
 
+from typing_extensions import deprecated
+
 from .enums import SpeakingState
 from .errors import ClientException
 from .oggparse import OggStream
@@ -95,7 +97,7 @@ class AudioSource:
         If the audio is complete, then returning an empty
         :term:`py:bytes-like object` to signal this is the way to do so.
 
-        If :meth:`~AudioSource.is_opus` method returns ``True``, then it must return
+        If :attr:`opus` returns ``True``, then it must return
         20ms worth of Opus encoded audio. Otherwise, it must be 20ms
         worth of 16-bit 48KHz stereo PCM, which is about 3,840 bytes
         per frame (20ms worth of audio).
@@ -107,7 +109,19 @@ class AudioSource:
         """
         raise NotImplementedError
 
+    @deprecated(
+        "AudioSource.is_opus() is deprecated since version 2.9, consider using AudioSource.opus instead"
+    )
     def is_opus(self) -> bool:
+        """Checks if the audio source is already encoded in Opus.
+
+        .. deprecated:: 2.9
+            Use :attr:`opus` instead.
+        """
+        return self.opus
+
+    @property
+    def opus(self) -> bool:
         """Checks if the audio source is already encoded in Opus."""
         return False
 
@@ -739,6 +753,10 @@ class FFmpegOpusAudio(FFmpegAudio):
         return next(self._packet_iter, b"")
 
     def is_opus(self) -> bool:
+        return self.opus
+
+    @property
+    def opus(self) -> bool:
         return True
 
 
@@ -768,7 +786,7 @@ class PCMVolumeTransformer(AudioSource, Generic[AT]):
         if not isinstance(original, AudioSource):
             raise TypeError(f"expected AudioSource not {original.__class__.__name__}.")
 
-        if original.is_opus():
+        if original.opus:
             raise ClientException("AudioSource must not be Opus encoded.")
 
         self.original: AT = original
@@ -865,7 +883,7 @@ class AudioPlayer(threading.Thread):
                 self.loops = 0
                 self._start = time.perf_counter()
 
-            play_audio(data, encode=not self.source.is_opus())
+            play_audio(data, encode=not self.source.opus)
             self.loops += 1
             next_time = self._start + self.DELAY * self.loops
             delay = max(0, self.DELAY + (next_time - time.perf_counter()))
@@ -914,10 +932,12 @@ class AudioPlayer(threading.Thread):
         if update_speaking:
             self._speak(SpeakingState.voice)
 
-    def is_playing(self) -> bool:
+    @property
+    def playing(self) -> bool:
         return self._resumed.is_set() and not self._end.is_set()
 
-    def is_paused(self) -> bool:
+    @property
+    def paused(self) -> bool:
         return not self._end.is_set() and not self._resumed.is_set()
 
     def set_source(self, source: AudioSource) -> None:

--- a/discord/voice/client.py
+++ b/discord/voice/client.py
@@ -407,11 +407,11 @@ class VoiceClient(VoiceProtocol):
 
     def is_playing(self) -> bool:
         """INdicates if we're playing audio."""
-        return self._player is not None and self._player.is_playing()
+        return self._player is not None and self._player.playing
 
     def is_paused(self) -> bool:
         """Indicates if we're playing audio, but if we're paused."""
-        return self._player is not None and self._player.is_paused()
+        return self._player is not None and self._player.paused
 
     # audio related
 
@@ -573,7 +573,7 @@ class VoiceClient(VoiceProtocol):
             raise TypeError(
                 f"Source must be an AudioSource, not {source.__class__.__name__}",
             )
-        if not self.encoder and not source.is_opus():
+        if not self.encoder and not source.opus:
             self.encoder = opus.Encoder(
                 application=application,
                 bitrate=bitrate,

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1101,7 +1101,11 @@ class BaseWebhook(Hashable):
 
         self.source_guild: PartialWebhookGuild | None = source_guild
 
-    def is_partial(self) -> bool:
+    def is_partial(
+        self,
+    ) -> (
+        bool
+    ):  # TODO: Deprecate and replace with property when Webhook.partial is removed
         """Whether the webhook is a "partial" webhook.
 
         .. versionadded:: 2.0
@@ -1112,7 +1116,15 @@ class BaseWebhook(Hashable):
         """Whether the webhook is authenticated with a bot token.
 
         .. versionadded:: 2.0
+
+        .. deprecated:: 2.9
+            Use :attr:`authenticated` instead.
         """
+        return self.authenticated
+
+    @property
+    def authenticated(self) -> bool:
+        """Whether the webhook is authenticated with a bot token."""
         return self.auth_token is not None
 
     @property
@@ -1263,6 +1275,55 @@ class Webhook(BaseWebhook):
 
     @classmethod
     def partial(
+        cls,
+        id: int,
+        token: str,
+        *,
+        session: aiohttp.ClientSession,
+        proxy: str | None = None,
+        proxy_auth: aiohttp.BasicAuth | None = None,
+        bot_token: str | None = None,
+    ) -> Webhook:
+        """Creates a partial :class:`Webhook`.
+
+        .. deprecated:: 2.9
+            Use :meth:`as_partial` instead.
+
+        Parameters
+        ----------
+        id: :class:`int`
+            The ID of the webhook.
+        token: :class:`str`
+            The authentication token of the webhook.
+        session: :class:`aiohttp.ClientSession`
+            The session to use to send requests with. Note
+            that the library does not manage the session and
+            will not close it.
+
+            .. versionadded:: 2.0
+        bot_token: Optional[:class:`str`]
+            The bot authentication token for authenticated requests
+            involving the webhook.
+
+            .. versionadded:: 2.0
+
+        Returns
+        -------
+        :class:`Webhook`
+            A partial :class:`Webhook`.
+            A partial webhook is just a webhook object with an ID and a token.
+        """
+        warn_deprecated("partial()", "as_partial()", "2.9")
+        data: WebhookPayload = {
+            "id": id,
+            "type": 1,
+            "token": token,
+        }
+
+        return cls(data, session, proxy=proxy, proxy_auth=proxy_auth, token=bot_token)
+
+    @classmethod
+    def as_partial(
         cls,
         id: int,
         token: str,


### PR DESCRIPTION
## Summary
Fixes #3330, see that issue for more info 

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [x] I have read the [Contributing Guidelines](https://github.com/Pycord-Development/pycord/blob/master/CONTRIBUTING.md).
- [x] AI Usage has been disclosed.
  - [x] If AI has been used, I understand fully what the code does

