### PR TITLE
feat: Documents SlashCommandGroup.add_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Added `Member.vr_status` property.
   ([#3328](https://github.com/Pycord-Development/pycord/pull/3328))
+- Documented `SlashCommandGroup.add_command`.
+  ([#3346](https://github.com/Pycord-Development/pycord/pull/3346))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ These changes are available on the `master` branch, but have not yet been releas
 
 - Added `Member.vr_status` property.
   ([#3328](https://github.com/Pycord-Development/pycord/pull/3328))
-- Documented `SlashCommandGroup.add_command`.
+- Added `SlashCommandGroup.add_command`.
   ([#3346](https://github.com/Pycord-Development/pycord/pull/3346))
 
 ### Changed

--- a/discord/commands/core.py
+++ b/discord/commands/core.py
@@ -1392,9 +1392,22 @@ class SlashCommandGroup(ApplicationCommand):
         return as_dict
 
     def add_command(self, command: SlashCommand | SlashCommandGroup) -> None:
+        """Adds a :class:`.SlashCommand` or :class:`.SlashCommandGroup` as a subcommand.
+
+        This is usually not called, instead the :meth:`command` or
+        other shortcut decorators are used instead.
+
+        .. versionadded:: 2.9
+
+        Parameters
+        ----------
+        command: Union[:class:`.SlashCommand`, :class:`.SlashCommandGroup`]
+            The command to add.
+        """
         if command.cog is None and self.cog is not None:
             command.cog = self.cog
 
+        command.parent = self
         self.subcommands.append(command)
 
     def command(
@@ -1410,7 +1423,7 @@ class SlashCommandGroup(ApplicationCommand):
         """
 
         def wrap(func) -> T:
-            command = cls(func, parent=self, **kwargs)
+            command = cls(func, **kwargs)
             self.add_command(command)
             return command
 
@@ -1508,7 +1521,6 @@ class SlashCommandGroup(ApplicationCommand):
                     else "No description provided"
                 ),
                 guild_ids=guild_ids,
-                parent=self,
             )
             self.add_command(group)
             return group


### PR DESCRIPTION
## Summary
Documents the existing method `SlashCommandGroup.add_command` so that you do not need to use the decorator to create commands or subgroups. This also sets `ApplicationCommand.parent` in `add_command` instead of the various other methods.
<!-- What is this pull request for? Does it fix any issues? -->

<!-- If Generative AI (consisting of but not limited to LLMs and Agentic AI systems) 
has been used to partially or entirely produce this pull request (documentation included), 
disclose it here -->
No generative AI was used.

Side note: Is this how you are supposed to use `SlashCommandGroup.subgroup`?
```py
@my_group.subgroup(description="Say hello to a user")
class hello2sub(SlashCommandGroup):
    pass
  ```
## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [x] I have read the [Contributing Guidelines](https://github.com/Pycord-Development/pycord/blob/master/CONTRIBUTING.md).
- [x] AI Usage has been disclosed.
  - [x] If AI has been used, I understand fully what the code does

