### PR TITLE
fix(docs): resolve sphinx duplicate object description warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1834,7 +1834,7 @@ These changes are available on the `master` branch, but have not yet been releas
 [unreleased]: https://github.com/Pycord-Development/pycord/compare/v2.8.1...HEAD
 [2.8.1]: https://github.com/Pycord-Development/pycord/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Pycord-Development/pycord/compare/v2.7.2...v2.8.0
-[2.8.0rc1]: https://github.com/Pycord-Development/pycord/compare/v2.8.0rc1...v2.8.0rc2
+[2.8.0rc2]: https://github.com/Pycord-Development/pycord/compare/v2.8.0rc1...v2.8.0rc2
 [2.8.0rc1]: https://github.com/Pycord-Development/pycord/compare/v2.7.2...v2.8.0rc1
 [2.7.2]: https://github.com/Pycord-Development/pycord/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/Pycord-Development/pycord/compare/v2.7.0...v2.7.1

--- a/discord/ui/media_gallery.py
+++ b/discord/ui/media_gallery.py
@@ -55,11 +55,6 @@ class MediaGallery(ViewItem[V]):
         The initial items contained in this gallery, up to 10.
     id: Optional[:class:`int`]
         The gallery's ID.
-
-    Attributes
-    ----------
-    items: List[:class:`~discord.MediaGalleryItem`]
-        The list of media items in this gallery.
     """
 
     __item_repr_attributes__: tuple[str, ...] = (

--- a/discord/ui/radio_group.py
+++ b/discord/ui/radio_group.py
@@ -46,17 +46,6 @@ class RadioGroup(ModalItem):
     """Represents a UI Radio Group component.
 
     .. versionadded:: 2.8
-
-    Attributes
-    ----------
-    custom_id: Optional[:class:`str`]
-        The ID of the radio group that gets received during an interaction.
-    options: List[:class:`discord.RadioGroupOption`]
-        A list of options that can be selected from this group. Must provide between 2 and 10 options.
-    required: Optional[:class:`bool`]
-        Whether an option selection is required or not. Defaults to ``True``.
-    id: Optional[:class:`int`]
-        The radio group's ID.
     """
 
     __item_repr_attributes__: tuple[str, ...] = (

--- a/discord/voice/client.py
+++ b/discord/voice/client.py
@@ -85,12 +85,6 @@ class VoiceClient(VoiceProtocol):
 
     Attributes
     ----------
-    session_id: :class:`str`
-        The voice connection session ID.
-    token: :class:`str`
-        The voice connection token.
-    endpoint: :class:`str`
-        The endpoint we are connecting to.
     channel: Union[:class:`VoiceChannel`, :class:`StageChannel`]
         The channel we are connected to.
 


### PR DESCRIPTION
## Summary

This PR fixes warnings about duplicate object description (requested by @Lulalaby):
```bash
<unknown>:1: WARNING: duplicate object description of discord.ui.MediaGallery.items, other instance in api/ui_kit, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of discord.ui.RadioGroup.custom_id, other instance in api/ui_kit, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of discord.ui.RadioGroup.required, other instance in api/ui_kit, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of discord.ui.RadioGroup.options, other instance in api/ui_kit, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of discord.ui.RadioGroup.id, other instance in api/ui_kit, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of discord.voice.VoiceClient.session_id, other instance in api/voice, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of discord.voice.VoiceClient.token, other instance in api/voice, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of discord.voice.VoiceClient.endpoint, other instance in api/voice, use :no-index: for one of them
/home/runner/work/pycord/pycord/docs/changelog.md:1838: WARNING: Duplicate reference definition: 2.8.0RC1 [myst.duplicate_def]
```

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
- [x] I have read the [Contributing Guidelines](https://github.com/Pycord-Development/pycord/blob/master/CONTRIBUTING.md).
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

