### PR TITLE
fix(voice): strip RTP padding before DAVE decryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3320](https://github.com/Pycord-Development/pycord/pull/3320))
 - Fix `SyntaxWarning` about `return` in a `finally` block raised on Python 3.14+
   ([#3332](https://github.com/Pycord-Development/pycord/pull/3334))
+- Fix DAVE decryption failing for received RTP packets that carry tail padding,
+  which showed up as choppy incoming audio.
+  ([#3386](https://github.com/Pycord-Development/pycord/pull/3386))
 
 ### Deprecated
 

--- a/discord/voice/receive/reader.py
+++ b/discord/voice/receive/reader.py
@@ -68,6 +68,31 @@ def is_rtcp(data: bytes) -> bool:
     return 200 <= data[1] <= 204
 
 
+def _strip_rtp_padding(padding: bool, payload: bytes) -> bytes:
+    """Strip RTP tail padding (RFC 3550 5.1) from a decrypted payload.
+
+    When the P bit is set in the RTP header, the last octet of the payload
+    holds the padding length (including itself). Opus tolerates trailing
+    garbage, so this never mattered before DAVE: the E2EE layer looks for its
+    frame marker at the *tail* of the payload, and padding buries it, making
+    the whole frame fail to decrypt.
+
+    Only acts when the P bit is set, and only when the length is in range.
+    Deliberately does *not* guess based on "the tail is a run of equal bytes"
+    -- that would corrupt legitimate ciphertext that happens to look like
+    that, and a corrupted frame is indistinguishable from a dropped one in
+    the logs.
+    """
+    if not padding or not payload:
+        return payload
+    pad_len = payload[-1]
+    if pad_len < 1 or pad_len > len(payload):
+        # Out of range means the P bit can't be trusted; passing the payload
+        # through untouched is safer than truncating it.
+        return payload
+    return payload[:-pad_len]
+
+
 class AudioReader:
     def __init__(
         self,
@@ -295,7 +320,7 @@ class PacketDecryptor:
         state = self.client._connection
         dave = state.dave_session
 
-        raw_payload = self._decryptor_rtp(packet)
+        raw_payload = _strip_rtp_padding(packet.padding, self._decryptor_rtp(packet))
 
         if dave is not None and dave.ready:
             uid = state.ssrc_user_map.get(packet.ssrc)


### PR DESCRIPTION
## Summary

RTP packets from Discord may carry tail padding. When the `P` bit is set in the RTP header, the last octet of the payload holds the padding length, including itself ([RFC 3550 §5.1](https://datatracker.ietf.org/doc/html/rfc3550#section-5.1)). py-cord already parses that bit into `RTPPacket.padding` (`discord/voice/packets/rtp.py:100`) but never acts on it.

That was harmless as long as the payload went straight to the Opus decoder — Opus tolerates trailing garbage. It is **not** harmless with DAVE: the E2EE layer looks for its frame marker at the **tail** of the payload, so padding buries it and `DaveSession.decrypt` raises `DecryptionFailed(UnencryptedWhenPassthroughDisabled)`.

The failure mode is nasty because it is quiet. `PacketDecryptor.decrypt_rtp` catches the exception, logs at `debug`, and substitutes `OPUS_SILENCE`. So the symptom users report is not "decryption failed" — it is **choppy, stuttering incoming audio**, with a large share of frames silently replaced by silence.

## The fix

Strip the padding before the payload is handed to `dave.decrypt`, and only when the P bit is set and the declared length is in range. An out-of-range length means the P bit can't be trusted, so the payload is passed through untouched — truncating a valid frame is worse than leaving a bad one alone.

The helper deliberately does **not** try to detect padding heuristically (e.g. "the tail is a run of identical bytes"). That would corrupt legitimate ciphertext that happens to look that way, and a corrupted frame is indistinguishable from a dropped one in the logs.

## Prior art

discord.js hit exactly this bug and fixed it the same way in [discordjs/discord.js#11449](https://github.com/discordjs/discord.js/pull/11449) (merged 2026-03-13), which closed [#11419](https://github.com/discordjs/discord.js/issues/11419) and several linked issues. Their check is the same shape:

```js
const hasPadding = buffer[0] && Boolean(buffer[0] & 0b100000);
if (hasPadding) {
  const paddingAmount = packet[packet.length - 1]!;
  if (paddingAmount < packet.length) {
    packet = packet.subarray(0, packet.length - paddingAmount);
  }
}
```

The Python side has the same bug and never got the same fix. [snazzah/davey#15](https://github.com/snazzah/davey/issues/15) is a report of this symptom filed against `davey` while using py-cord ("Most DAVE-encrypted audio packets fail to decrypt (~95% failure rate)"). It was correctly closed with *"The `davey` package is not the issue here but the implementation of it in whatever library it is being used in."* — the reporter's own diagnostic dump has the fingerprint in it (`last4=05050505`, `last4=0f0f0f0f`: runs of identical bytes whose value equals the run length), it just wasn't recognised as padding at the time.

## Verification

Measured on a live voice channel with DAVE enabled, receiving from a desktop client, before and after this patch:

| | decrypted | failed | passthrough |
|---|---|---|---|
| before | 577 | 29 | 0 |
| after | 290 | 0 | 0 |

A later run on the same build logged 255 successful frames with 0 failures, of which 3 were packets that actually had the P bit set and went through this code path — those are the frames that would have failed before. Audio quality went from audibly stuttering to clean.

## Notes

- Single-purpose change; no behaviour difference for packets without the P bit, and none at all for the non-DAVE path (the helper is only called on the DAVE branch's input).
- No new dependencies, no public API change.
