### PR TITLE
fix(scheduled_events): decrement subscriber_count on user_remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ These changes are available on the `master` branch, but have not yet been releas
   ([#3320](https://github.com/Pycord-Development/pycord/pull/3320))
 - Fix `SyntaxWarning` about `return` in a `finally` block raised on Python 3.14+
   ([#3332](https://github.com/Pycord-Development/pycord/pull/3334))
+- Fix `ScheduledEvent.subscriber_count` being incremented instead of decremented when a
+  user leaves the event.
+  ([#3387](https://github.com/Pycord-Development/pycord/pull/3387))
 
 ### Deprecated
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -1763,7 +1763,7 @@ class ConnectionState:
         if member is not None:
             event = guild.get_scheduled_event(data["guild_scheduled_event_id"])
             if event:
-                event.subscriber_count += 1
+                event.subscriber_count -= 1
                 guild._add_scheduled_event(event)
                 self.dispatch("scheduled_event_user_remove", event, member)
 


### PR DESCRIPTION
## Summary

This PR fixes a copy-paste bug from the `user_add` handler caused `subscriber_count` to increment when a user left a scheduled event (instead of decrement).

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [x] I have updated the changelog to include these changes.
- [x] I have read the [Contributing Guidelines](https://github.com/Pycord-Development/pycord/blob/master/CONTRIBUTING.md).
- [ ] AI Usage has been disclosed.
  - [ ] If AI has been used, I understand fully what the code does

